### PR TITLE
docs: document zone-based data representation strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Where other clients test for correctness, Verity proves it. Every line of consen
 
 Learn more at [verityclient.com](https://verityclient.com).
 
+## Acknowledgments
+
+Verity does not start from zero. It builds on a young, fast-moving ecosystem of Lean Consensus implementations whose authors did the hard work of turning a moving specification into running clients — and Verity has learned from every one of them.
+
+- **[ethlambda](https://github.com/lambdaclass/ethlambda)** by LambdaClass is a study in disciplined minimalism: a clean-slate, consensus-only client that carries post-quantum, hash-based signatures into the production path from day one and refuses to accumulate the complexity Lean Ethereum was designed to shed. Keeping the surface that small is exactly the spirit a tractable proof needs.
+- **[ream](https://github.com/ReamLabs/ream)** by ReamLabs sets a high bar for engineering breadth — a Beacon/Lean dual stack, zkVM-friendly cryptography, serious networking, and a tooling and CI discipline worth imitating. Its habit of expressing collection bounds in the type, rather than checking them at runtime, is precisely the kind of invariant Verity wants inside its verified core.
+
+Verity makes a different bet — that the implementation should be *proven* to match the specification, not only tested against it — but that bet is worth making only because these clients have already shown what a good Lean Consensus client looks like. We are grateful to their authors and to the wider [Lean Ethereum](https://leanroadmap.org/) community.
+
 ## References
 
 - https://github.com/leanEthereum/leanSpec

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,3 +18,4 @@
 # Reference
 
 - [Architecture](./reference/architecture.md)
+- [Data Representation Across Zones](./reference/data-representation.md)

--- a/docs/src/reference/data-representation.md
+++ b/docs/src/reference/data-representation.md
@@ -1,0 +1,51 @@
+# Data Representation Across Zones
+
+How Verity represents a value in the host language is not a single decision made once for the whole codebase. It tracks the verification guarantee the value currently lives under. The same protocol quantity — a slot number, a validator index — is a precise, bounded type inside the proven core and a plain machine integer at the unproven edge, with an explicit conversion where the two meet. This page states that policy and the reason it follows from the [design philosophy](../design-philosophy.md).
+
+This is a consequence of beliefs Verity already holds, not a new rule. It is written down here because it decides the shape of every container and every arithmetic operation that follows.
+
+## The principle
+
+Representation precision follows the guarantee. A type that a proof reasons about carries its invariants in the type; a type that only shuttles bytes between the network and the parser does not need to. Because Verity's verification boundary is a first-class, *moving* part of the architecture rather than a fixed line, the right representation is decided per zone — and is expected to change for a given component when that component crosses the boundary.
+
+## In Verity Consensus (the proven core)
+
+Inside the proven core, protocol quantities are concrete, named types, not raw integers. A slot is a `Slot`, a validator index is a `ValidatorIndex`, and the two cannot be confused or transposed, because the type system forbids it. This is the same discipline the leanSpec reference applies in Python, where `Slot` is a distinct subtype of a bounded unsigned integer rather than an alias for it — and Verity holds the proven core to at least that standard.
+
+Two beliefs force this choice:
+
+- **Explicitness over cleverness.** The implementation must read like the Lean 4 model it corresponds to. The model distinguishes a slot from an index; so does the code. A raw `u64` standing for three unrelated quantities loosens exactly the correspondence the proof depends on.
+- **Arithmetic that mirrors proven invariants.** Overflow, underflow, and truncation are conditions the model rules out, not surprises caught downstream. Numeric operations in the core are fallible and explicit where the bound matters, so that the arithmetic corresponds one-to-one with the guarantees the proof discharges. A silently wrapping `u64` cannot make that correspondence.
+
+This is also why the core does not lean on macro-generated type machinery to conjure its containers: structure that a macro hides is structure a reviewer and a proof must recover by hand.
+
+## At the edges (Runtime Shell / I/O Edge)
+
+Outside the boundary — networking, storage, the RPC surface — none of this applies. Code there exists to feed the core clean, well-typed inputs and to carry its outputs to the network; no proof reasons about its internals. Plain machine integers and a conventional, derive-driven SSZ stack are entirely appropriate, and the edge is free to look like an ordinary high-quality Rust client. Precision here would buy nothing and cost ergonomics.
+
+## At the boundary
+
+Values do not drift across the boundary untyped. An input arriving from the edge is validated and converted — promoted — into the core's domain types at the point it enters; a value leaving the core is lowered back to its wire representation on the way out. The boundary is where range checks and well-formedness checks live, so that everything inside the core has already earned its type.
+
+This costs nothing in conformance, because **the wire format is independent of the host representation.** A `Slot` newtype and a raw `u64` serialize to byte-identical SSZ. leanSpec fixes the serialized shape — field order and encoding are consensus-critical, since they determine what gets hashed and signed — and Verity matches that shape exactly regardless of how richly it types the value in memory. Rich domain types in the core therefore buy proof alignment for free, without moving a single byte on the wire.
+
+## Because the boundary moves
+
+The boundary is designed to move: serialization may be pulled into the proven core once it is verified, and a component may be pushed back out if proving demands a different target. Moving a component across is meant to be a re-binding, not a redesign. Representing a boundary-adjacent value in the provable shape from the start is what makes that true — when the component is promoted, its types are already what the core requires, and nothing downstream has to be rewritten to absorb the change.
+
+## How the existing clients compare
+
+The Rust Lean clients make the trade-off concrete, and they consistently choose the edge style throughout — because they are uniformly unverified, and because pervasive newtypes in Rust carry real boilerplate. Verity differs only where it must: inside the proven core, where the guarantee changes the calculus.
+
+| Concern | leanSpec (Python) | ethlambda (Rust) | ream, Lean stack (Rust) |
+|---|---|---|---|
+| Slot / proposer index | distinct `Slot` / index newtypes, with domain methods | raw `u64` | raw `u64` |
+| Hash | dedicated `Bytes32` type | `H256` newtype (no bound checks) | `B256` (alloy) |
+| Collection length bound | bounded SSZ list | library-typed | type-level (`VariableList<_, N>`, `BitList`) |
+| Value range / type checking | enforced (bounded ints, strict models) | none beyond the type | none beyond the derive |
+| SSZ mechanism | bespoke SSZ type hierarchy | `libssz` derives | `ethereum_ssz` + `tree_hash` derives |
+| Domain newtypes for scalars | yes | no | no |
+
+References for the shapes above: ethlambda's `crates/common/types/src/block.rs` and `checkpoint.rs`; ream's `crates/common/consensus/lean/src/block.rs` and `state.rs`; leanSpec's `src/lean_spec/types/slot.py`, `uint.py`, and `checkpoint.py`.
+
+The reading is straightforward. The edge style is right for an unverified client and right for Verity's own unproven zones. It is the wrong default for Verity Consensus, where the proof is the product — and there, the leanSpec discipline, or stricter, is the one that pays off. ream's habit of putting collection capacities in the type is the part of the edge style worth carrying inward: a length bound expressed in the type is exactly the kind of invariant the core wants to state once and rely on everywhere.


### PR DESCRIPTION
## Summary

Adds a Reference page that states **how Verity represents protocol quantities across its verification zones**, and acknowledges the prior-art clients the policy draws on.

The policy is a consequence of the existing [design philosophy](docs/src/design-philosophy.md), not a new rule — representation precision tracks the verification guarantee a value currently lives under:

- **Proven core (Verity Consensus):** precise, named domain newtypes (`Slot`, `ValidatorIndex`, …) with fallible, explicit arithmetic — mirroring leanSpec and the invariants the Lean 4 proof discharges. Raw `u64` is rejected here because it breaks both *explicitness over cleverness* and *arithmetic that mirrors proven invariants*.
- **Unproven edges (Runtime Shell / I/O Edge):** plain machine integers and a conventional derive-driven SSZ stack are fine — the same style the Rust Lean clients use throughout.
- **At the boundary:** values are promoted into domain types on the way in and lowered to wire form on the way out. The **wire format is independent of the host representation** — a `Slot` newtype and a raw `u64` serialize to byte-identical SSZ — so rich core types cost nothing in conformance.
- **Because the boundary moves:** keeping boundary-adjacent types in the provable shape makes promotion a re-binding, not a redesign.

Includes a comparison table grounding the rationale in how leanSpec, ethlambda, and ream actually define their types.

### README

Adds an **Acknowledgments** section crediting **ethlambda** (LambdaClass) for its disciplined minimalism and production post-quantum signatures, and **ream** (ReamLabs) for its engineering breadth and its habit of expressing collection bounds in the type.

## Changes

- `docs/src/reference/data-representation.md` (new) — the Reference page
- `docs/src/SUMMARY.md` — register the page under Reference
- `README.md` — Acknowledgments section

## Verification

- `mdbook build` succeeds with the CI-pinned mdBook `0.4.40`
- New page renders, sidebar link resolves, no frontmatter leak (page opens at its H1)