### PR TITLE
chore: add Claude Code skill definitions

### DIFF
--- a/.claude/skills/hive/SKILL.md
+++ b/.claude/skills/hive/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: hive
+description: |
+  Ground every "build / run the hive E2E test harness" question in hive — the Ethereum
+  end-to-end test harness that runs Dockerized clients against simulator test suites
+  (github.com/ethereum/hive), always read from the latest remote master. It is
+  operational tooling (Go core + Rust hivesim-rs), not a spec or library; the source of
+  truth for HOW to run it is the upstream README + docs/commandline.md + simulator READMEs
+  at master, which evolve. Especially relevant to Verity via the simulators/lean suite and
+  the lean clients in clients/. Use before building, running, or answering anything about
+  running hive (especially the lean simulator) for Verity.
+  Triggers: "hive", "ethereum/hive", "hivesim", "hive simulator", "hive sim", "--sim lean",
+  "simulators/lean", "lean simulator", "client interop", "E2E test", "結合テスト",
+  "互換性テスト", and any work building or running the hive test harness (especially the
+  lean simulator) for Verity.
+  Negative triggers: Do NOT activate for spinning up a local devnet to RUN it rather than
+  test it (use the leanQuickstart skill). Do NOT activate for consensus container shapes /
+  fork choice / state transition (use the leanSpec skill). Do NOT activate for aggregation
+  / zkVM / proof internals (use the leanMultisig skill). Do NOT activate for the metric
+  contract — names/types/buckets/labels — (use the leanMetrics skill). Do NOT activate for
+  pure docs-site (mdBook) work. Do NOT activate when working outside the Verity project.
+---
+
+# hive — operational runbook for the Ethereum E2E test harness
+
+hive (`github.com/ethereum/hive`) is the **Ethereum end-to-end test harness**: it builds
+each client as a Docker image, runs *simulator* test suites against them in isolated
+containers, and reports a pass/fail matrix. It is **tooling** (Go core + a Rust
+`hivesim-rs` framework), not a spec or a library. For Verity it matters because of the
+`simulators/lean` suite and the lean clients already wired up in `clients/` — this is
+where Verity would eventually be added as a client and tested for interop.
+
+## 0. Core principle
+
+- This skill grounds **how to build and run hive** — flags, simulator selection, client
+  selection, reading results — not protocol semantics. Chain behaviour is leanSpec's
+  domain; this is the harness that exercises clients.
+- The authoritative source for *how to run it* is the upstream `README.md`,
+  `docs/commandline.md`, and the target simulator's `README.md` at `master`. They change.
+  **Do not quote flags or paths from memory or a stale clone** — read `master` and cite
+  the SHA.
+- **The default branch is `master`** (not `main`). License is GPL-3.0.
+
+## 1. Always read hive from the remote `master` (no local path assumptions)
+
+The harness evolves (sims and flags are added often). Read the latest `master` of the
+canonical upstream directly from the remote.
+
+Repo: `github.com/ethereum/hive` (canonical; default branch `master`).
+
+```bash
+# Latest master commit — cite this SHA in your output:
+gh api repos/ethereum/hive/commits/master --jq '.sha'
+
+# Read the command-line docs (authoritative for flags) at master:
+gh api "repos/ethereum/hive/contents/docs/commandline.md?ref=master" --jq '.content' | base64 -d
+# raw fallback (no gh):
+curl -s https://raw.githubusercontent.com/ethereum/hive/master/docs/commandline.md
+
+# Lean simulator README:
+curl -s https://raw.githubusercontent.com/ethereum/hive/master/simulators/lean/README.md
+
+# Full tree at master:
+gh api "repos/ethereum/hive/git/trees/master?recursive=1" --jq '.tree[].path'
+```
+
+No `gh`/`curl`? Use WebFetch on `https://github.com/ethereum/hive/blob/master/<path>`.
+
+If you happen to have a local clone, `git fetch origin` first and read `origin/master`.
+Never assume a specific clone path.
+
+## 2. Install & run (the canonical commands)
+
+Prereqs (per `docs/commandline.md`): Linux, **Go ≥ 1.17**, and a working **Docker** setup
+on the **same host** (hive talks to local `dockerd`; remote Docker is unsupported). Add
+your user to the `docker` group to avoid `sudo`.
+
+```bash
+git clone https://github.com/ethereum/hive
+cd hive
+go build .
+
+# Run a simulation (always from the repo root):
+./hive --sim <simulation> --client <client[,client...]>
+```
+
+- `--sim <name>` — which simulator suite to run (e.g. `lean`, `ethereum`, `eth2`,
+  `devp2p`, `portal`, `smoke`).
+- `--client <list>` — comma-separated clients to test; pin a version with `_`
+  (e.g. `go-ethereum_v1.9.23`).
+- Results land in `workspace/logs/`; view them with the `hiveview` HTML viewer.
+
+## 3. Running the lean simulator (Verity-relevant)
+
+From `simulators/lean/README.md`:
+
+```bash
+./hive --sim lean --client-file simulators/lean/clients/devnet3.yaml --client ream
+# devnet4 profile:
+./hive --sim lean --client-file simulators/lean/clients/devnet4.yaml --client ream
+```
+
+- The active devnet is resolved from the **client name** (`ream_devnet4`,
+  `ethlambda_devnet3`, `gean_devnet3`, …) and validated against the support matrix in
+  `simulators/lean/config/lean-devnets.txt`.
+- The lean sim currently runs **RPC-compat, sync, and client-interop** suites. Client
+  interop runs each selected client against itself and against every other selected client
+  in three-node 2:1 topologies, asserting all three finalize past genesis at the same slot.
+- Post-genesis justification/finalization cases are driven by the `lean-spec-client`
+  helper (it caches a fixed set of validator keys at image-build time).
+
+## 4. Key flags (confirm the full set in `docs/commandline.md` at master)
+
+- `--sim.limit <regex>` — select suites/tests; split at the first `/` (suite before,
+  test after). E.g. `--sim.limit eth/Large`, or `--sim.limit /stBugs/` for any suite.
+- `--client-file <yaml>` — client list with per-client `dockerfile`, `build_args`
+  (`tag`, `baseimage`, `github`), and `nametag`.
+- `--docker.pull` / `--docker.nocache <regex>` / `--docker.output` — image rebuild &
+  output control (use `--docker.nocache` during simulator development).
+- `--sim.timelimit <dur>` — abort the simulator after this time (no default).
+- `--client.checktimelimit <dur>` — wait for the client RPC port (default 3m).
+- `--sim.loglevel <0-5>` — client log verbosity (default 3).
+
+## 5. Topic → authoritative location map
+
+Paths are relative to the hive repo root, read at `master`.
+
+| Topic | Path in ethereum/hive |
+|---|---|
+| Install / run / all flags | `docs/commandline.md`; `README.md` |
+| Overview & concepts | `docs/overview.md` |
+| Adding/configuring a client | `docs/clients.md`; `clients/<name>/` (Dockerfile, `hive.yaml`, `*.sh`, `mapper.jq`) |
+| Writing simulators | `docs/simulators.md`; `hivesim/` (Go), `hivesim-rs/` (Rust) |
+| Lean simulator | `simulators/lean/` (`README.md`, `src/scenarios/`, `clients/devnet*.yaml`, `config/lean-devnets.txt`) |
+| Lean sim scenarios | `simulators/lean/src/scenarios/` (`client_interop`, `gossip`, `reqresp`, `rpc_compat`, `spec_assets`, `sync`, `validation`) |
+| Other sims | `simulators/{ethereum,eth2,devp2p,portal,smoke}/` |
+| Lean clients | `clients/{ethlambda,gean,grandine_lean,lantern,lean-spec-client,nlean,qlean,ream,zeam}/` |
+| Hive core / CLI | `cmd/`, `internal/` |
+
+## 6. How to use (building / running / answering)
+
+1. Read `docs/commandline.md` and the target simulator's `README.md` at `master` first —
+   never quote flags from memory.
+2. Build with `go build .`; ensure Docker is running locally.
+3. Run with the right `--sim` / `--client` (or `--client-file`); for lean, use the
+   `simulators/lean/clients/devnet*.yaml` profiles.
+4. Inspect `workspace/logs/` (hiveview) for results.
+5. In your output, cite the **file/path + the `master` commit SHA** you checked.
+
+## 7. Relationship to the other skills & Verity
+
+- **leanQuickstart** (separate skill) = spin up and **run** a local lean devnet.
+- **leanSpec** / **leanMultisig** / **leanMetrics** (separate skills) = protocol &
+  container shapes / aggregation & zkVM / the metric contract.
+- **hive** (this skill) = the **test harness** that exercises clients (build + `--sim` +
+  `--client`), especially the `lean` simulator.
+- Verity is pre-implementation, so it is **not yet a client** in hive's `clients/`.

--- a/.claude/skills/leanMetrics/SKILL.md
+++ b/.claude/skills/leanMetrics/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: leanMetrics
+description: |
+  Ground every observability/metrics question in leanMetrics — the authoritative
+  standard for Prometheus-compatible metrics across Lean Ethereum consensus clients
+  (github.com/leanEthereum/leanMetrics), always read from the latest remote main.
+  leanMetrics fixes the metric name strings, Prometheus types, Histogram buckets, label
+  names/enum values, and collection events that every compliant client must match;
+  Verity's verity-metrics crate implements it. Use before implementing, reviewing, or
+  answering anything about exposing or monitoring consensus-client metrics.
+  Triggers: "leanMetrics", "lean_metrics", "leanMetricsを確認", "メトリクス", "metrics",
+  "prometheus", "grafana", "observability", "観測", "dashboard", "verity-metrics", any
+  "lean_*" metric name (e.g. "lean_head_slot", "lean_block_aggregated_payloads"), and
+  any work exposing or monitoring consensus-client metrics in Verity.
+  Negative triggers: Do NOT activate for consensus container shapes / fork choice /
+  state transition behavior (use the leanSpec skill). Do NOT activate for aggregation /
+  zkVM / proof internals (use the leanMultisig skill). Do NOT activate for pure docs-site
+  (mdBook) work. Do NOT activate when working outside the Verity project.
+---
+
+# leanMetrics — source of truth for observability metrics
+
+leanMetrics (`github.com/leanEthereum/leanMetrics`) is the authoritative **standard**
+for Prometheus-compatible metrics across all Lean Ethereum consensus clients. It is a
+*specification (`metrics.md`) + Grafana dashboards (`dashboards/`)* — **not a library**.
+It fixes what every compliant client must expose so that one dashboard serves all
+clients. Verity's `verity-metrics` crate implements it.
+
+## 0. Core principle
+
+- leanMetrics governs the **exposed contract**: the metric **name string** (`lean_*`),
+  the **Prometheus type** (Gauge/Counter/Histogram), the **Histogram bucket boundaries**,
+  the **label names + enum values**, and the **"Sample collection event"** (where the
+  client updates the metric). A compliant client matches these **exactly** — that match
+  is the entire point: it lets a single Grafana dashboard work across every client.
+- It is an **interop / observability standard, NOT consensus-critical** (unlike
+  leanSpec). A wrong metric breaks dashboards, not the chain.
+- **Internal code identifiers are free**; only the registered string + type + buckets +
+  labels are governed. (Proof: ethlambda names its variable `LEAN_HEAD_SLOT`, Ream names
+  its `HEAD_SLOT`, and both register the same string `"lean_head_slot"`.)
+- The repo holds `metrics.md` (the spec table) and `dashboards/` (Grafana JSON) — no
+  client instrumentation code. "Implementing leanMetrics" means writing matching
+  Prometheus instrumentation **in the client**; "using the dashboards" means pointing
+  Grafana at any compliant client.
+
+## 1. Always read leanMetrics from the remote `main` (no local path assumptions)
+
+leanMetrics evolves as clients add metrics. A stale local checkout is **not** the
+standard. Read the latest `main` of the canonical upstream directly from the remote —
+this works for every developer and in CI, with no dependency on anyone's local clone.
+
+Repo: `github.com/leanEthereum/leanMetrics` (canonical; do **not** use a personal fork).
+
+```bash
+# Latest main commit — cite this SHA in your output:
+gh api repos/leanEthereum/leanMetrics/commits/main --jq '.sha'
+
+# Read the spec table at main:
+gh api "repos/leanEthereum/leanMetrics/contents/metrics.md?ref=main" --jq '.content' | base64 -d
+# raw fallback (no gh):
+curl -s https://raw.githubusercontent.com/leanEthereum/leanMetrics/main/metrics.md
+
+# List the dashboards at main:
+gh api "repos/leanEthereum/leanMetrics/contents/dashboards?ref=main" --jq '.[].name'
+# Full tree:
+gh api "repos/leanEthereum/leanMetrics/git/trees/main?recursive=1" --jq '.tree[].path'
+```
+
+No `gh`/`curl`? Use WebFetch on `https://github.com/leanEthereum/leanMetrics/blob/main/<path>`.
+
+If you happen to have a local clone, you *may* use it for fast navigation/grep — but
+`git fetch origin` first and read `origin/main` (clones drift onto feature branches and
+forks). Never assume a specific clone path.
+
+## 2. What the spec defines per metric
+
+`metrics.md` is a set of tables, one per category. Each row defines a metric via these
+columns:
+
+- **Name** — the exact `lean_*` string to register.
+- **Type** — `Gauge` | `Counter` | `Histogram`.
+- **Usage** — what it measures (use as the metric HELP text).
+- **Sample collection event** — *when* the client updates it (e.g. "On state
+  transition", "On block production", "On scrape"). This tells you where to instrument.
+- **Labels** — label names and their allowed enum values (e.g. `result=success,error`).
+- **Buckets** — for Histograms, the exact bucket boundaries (seconds, bytes, or counts).
+- **Per-client status** — one column per tracked client.
+
+Status legend: ✅ implemented / 📝 in progress / □ not implemented.
+
+Tracked clients (status columns): **EthLambda, Grandine, Lantern, Lighthouse, Nlean,
+Peam, Qlean, Ream, Zeam**.
+
+What must match the spec vs what is free:
+
+| Aspect | Must match leanMetrics? |
+|---|---|
+| Registered metric name string (`lean_*`) | ✅ required |
+| Prometheus type (Gauge/Counter/Histogram) | ✅ required |
+| Histogram bucket boundaries | ✅ required (and the unit: seconds/bytes/count) |
+| Label names + enum values | ✅ required |
+| Internal code identifier (variable name) | ❌ free |
+
+## 3. Topic → authoritative location map
+
+Paths are relative to the leanMetrics repo root, read at `main`. The implementation
+column points at Rust references only (how clients have instrumented these) — it is not
+authoritative for the contract.
+
+| Topic (category) | leanMetrics (authoritative) | implementation reference |
+|---|---|---|
+| Node Info | `metrics.md#node-info-metrics` | ethlambda `crates/blockchain/src/metrics.rs`; Ream `crates/common/metrics/src/lib.rs` |
+| PQ Signature | `metrics.md#pq-signature-metrics` | ethlambda `crates/blockchain/src/metrics.rs`; Ream `crates/common/metrics/src/lib.rs` |
+| Block Production | `metrics.md#block-production-metrics` | (all clients □ — not yet implemented anywhere) |
+| Fork-Choice | `metrics.md#fork-choice-metrics` | ethlambda / Ream metrics crates (as above) |
+| State Transition | `metrics.md#state-transition-metrics` | ethlambda / Ream metrics crates (as above) |
+| Validator | `metrics.md#validator-metrics` | ethlambda / Ream metrics crates (as above) |
+| Network | `metrics.md#network-metrics` | ethlambda / Ream metrics crates (as above) |
+| Grafana dashboards | `dashboards/lean-ethereum-clients-dashboard.json` | Ream `metrics/` (compose + Grafana stack) |
+
+## 4. How to use (implementing / reviewing / answering)
+
+1. Read the authoritative `metrics.md` category section at `main` first.
+2. Match the name string, type, Histogram buckets (and their unit), and label
+   names + enum values **exactly**; internal variable names are free.
+3. For coverage/status questions, read the per-client status column (✅/📝/□).
+4. In your output, cite the **`metrics.md` section + the `main` commit SHA** you checked.
+
+## 5. Relationship to leanSpec & leanMultisig & Verity
+
+- **leanSpec** (separate skill) = consensus protocol & container shapes (Python).
+- **leanMultisig** (separate skill) = aggregation + zkVM (Rust).
+- **leanMetrics** (this skill) = the observability **metric contract** (Prometheus
+  names/types/buckets/labels) + Grafana dashboards.
+- Verity's `verity-metrics` crate implements leanMetrics; **ethlambda** and **Ream** are
+  Rust implementation references. The client is pre-implementation today.

--- a/.claude/skills/leanMultisig/SKILL.md
+++ b/.claude/skills/leanMultisig/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: leanMultisig
+description: |
+  Ground every question about post-quantum signature aggregation and the zkVM in
+  leanMultisig — the authoritative spec and Rust reference implementation
+  (github.com/leanEthereum/leanMultisig), always read from the latest remote main.
+  Verity's verity-crypto crate depends on it directly. Use before implementing,
+  reviewing, or answering anything about XMSS aggregation, Type-1/Type-2 proofs, the
+  prover/verifier, the zkVM, the zkDSL, or WHIR.
+  Triggers: "leanMultisig", "lean_multisig", "leanMultisigを確認", "署名集約", "aggregation",
+  "Type-1 proof", "Type-2 proof", "zkVM", "zkDSL", "WHIR", "prover", "verifier",
+  "verity-crypto", and any work touching signature aggregation or proof generation in Verity.
+  Negative triggers: Do NOT activate for consensus container shapes / fork choice / state
+  transition (use the leanSpec skill). Do NOT activate for pure docs-site work. Do NOT
+  activate when working outside the Verity project.
+---
+
+# leanMultisig — source of truth for aggregation & the zkVM
+
+leanMultisig (`github.com/leanEthereum/leanMultisig`) is a minimal zkVM targeting
+aggregation of hash-based (Generalized-XMSS) signatures. It is the **authoritative spec
+and Rust reference implementation** for everything aggregation/zkVM-related in Verity.
+Verity's `verity-crypto` crate depends on it directly (as a pinned git dependency).
+
+## 0. Core principle
+
+- The behavior of signature aggregation, Type-1/Type-2 proofs, the prover/verifier, the
+  zkVM and its zkDSL is defined by **leanMultisig** (its Rust crates + design docs). When
+  in doubt, read the source.
+- Division of authority with the leanSpec skill: **leanSpec** defines the *consensus
+  containers* that carry proofs (`TypeOneMultiSignature`, `SignedBlock.proof` =
+  `ByteList512KiB`, the verify entry points). **leanMultisig** defines how those proofs
+  are *produced and verified*. For container shapes → leanSpec; for proof internals →
+  here.
+
+## 1. Always read leanMultisig from the remote `main` (no local path assumptions)
+
+leanMultisig moves fast. Read the latest `main` of the canonical upstream directly from
+the remote — this works for every developer and in CI, with no dependency on anyone's
+local clone path.
+
+Repo: `github.com/leanEthereum/leanMultisig` (canonical; do **not** use a personal fork).
+
+```bash
+# Latest main commit — cite this SHA in your output:
+gh api repos/leanEthereum/leanMultisig/commits/main --jq '.sha'
+
+# Read a file at main:
+gh api "repos/leanEthereum/leanMultisig/contents/crates/xmss/xmss.md?ref=main" --jq '.content' | base64 -d
+# raw fallback (no gh):
+curl -s https://raw.githubusercontent.com/leanEthereum/leanMultisig/main/crates/xmss/xmss.md
+
+# List a directory at main:
+gh api "repos/leanEthereum/leanMultisig/contents/crates?ref=main" --jq '.[].name'
+# Full tree:
+gh api "repos/leanEthereum/leanMultisig/git/trees/main?recursive=1" --jq '.tree[].path'
+```
+
+No `gh`/`curl`? Use WebFetch on `https://github.com/leanEthereum/leanMultisig/blob/main/<path>`.
+
+If you happen to have a local clone, you *may* use it for fast navigation/grep — but
+`git fetch origin` first and read `origin/main` (clones drift onto feature branches and
+forks). Never assume a specific clone path.
+
+## 2. How Verity consumes it
+
+- `verity-crypto` depends on leanMultisig as a **pinned git dependency** in `Cargo.toml`.
+  The pinned commit is what Verity builds against; the latest `main` is the source of
+  truth for understanding/spec questions. When bumping the pin, re-read `main`.
+- The proving stack is expensive; the prover context is set up once at startup. Verity
+  produces Type-1 proofs only when acting as an aggregator; every node verifies.
+
+## 3. Topic → authoritative location map
+
+Paths are relative to the leanMultisig repo root, read at `main`.
+
+| Topic | leanMultisig (authoritative) |
+|---|---|
+| XMSS signature scheme | `crates/xmss/` (+ `crates/xmss/xmss.md`) |
+| Aggregation: Type-1 / Type-2 proofs | `crates/rec_aggregation/` (+ `crates/rec_aggregation/TYPE1_TYPE2_LAYOUT.md`) |
+| Prover | `crates/lean_prover/` |
+| zkVM | `crates/lean_vm/` |
+| zkDSL compiler | `crates/lean_compiler/` (+ `crates/lean_compiler/zkDSL.md`) |
+| WHIR (polynomial commitment) | `crates/whir/` |
+| Proof backend (AIR, sumcheck, Fiat-Shamir, field, KoalaBear, poly, symmetric) | `crates/backend/` (`air`, `sumcheck`, `fiat-shamir`, `field`, `koala-bear`, `poly`, `symetric`, …) |
+| Sub-protocols | `crates/sub_protocols/` |
+| Top-level crate / public API | `src/lib.rs`, `Cargo.toml` |
+| Tests | `tests/` |
+| Overview / design | `README.md`, `minimal_zkVM.pdf`, `TODO.md` |
+
+## 4. How to use (implementing / reviewing / answering)
+
+1. Read the **authoritative leanMultisig path at `main`** for the topic first.
+2. For the consensus containers carrying proofs, defer to the **leanSpec** skill.
+3. In your output, cite the **leanMultisig path + the `main` commit SHA** you checked.
+
+## 5. Relationship to leanSpec & Verity
+
+- **leanSpec** (separate skill) = consensus protocol spec & container shapes (Python).
+- **leanMultisig** (this skill) = aggregation + zkVM (Rust); produces/verifies the proofs
+  that fill leanSpec's containers.
+- Verity (Rust) wires both together: `verity-types` (leanSpec shapes) +
+  `verity-crypto` (leanMultisig + Generalized-XMSS). The client is pre-implementation today.

--- a/.claude/skills/leanQuickstart/SKILL.md
+++ b/.claude/skills/leanQuickstart/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: leanQuickstart
+description: |
+  Ground every "spin up / run a local lean multi-client devnet" question in
+  lean-quickstart — the utility for bootstrapping a localnet of Lean Ethereum
+  multi-client nodes (github.com/blockblaz/lean-quickstart), always read from the
+  latest remote main. It is operational tooling (Shell + Python + Ansible + Docker),
+  not a spec or library; the source of truth for HOW to run it is the upstream
+  README + scripts at main, which evolve. Use before running, configuring, or
+  answering anything about starting a local Lean devnet for Verity.
+  Triggers: "leanQuickstart", "lean-quickstart", "lean_quickstart", "localnet",
+  "devnet", "ローカルネット", "デブネット", "spin-node", "spin-node.sh",
+  "validator-config.yaml", "generate-genesis", "multi-client devnet", "マルチクライアント",
+  and any work spinning up or running a local lean multi-client devnet for Verity.
+  Negative triggers: Do NOT activate for consensus container shapes / fork choice /
+  state transition (use the leanSpec skill). Do NOT activate for aggregation / zkVM /
+  proof internals (use the leanMultisig skill). Do NOT activate for the metric
+  contract — names/types/buckets/labels — (use the leanMetrics skill); this skill
+  only covers RUNNING the bundled Prometheus/Grafana stack. Do NOT activate for pure
+  docs-site (mdBook) work. Do NOT activate when working outside the Verity project.
+---
+
+# leanQuickstart — operational runbook for the local multi-client devnet
+
+lean-quickstart (`github.com/blockblaz/lean-quickstart`) is "a utility to quickly spin up
+a localnet of lean (multi-client) nodes". It is **tooling**, not a spec or a library:
+Shell scripts orchestrate genesis generation, per-client launch commands, and an optional
+Prometheus/Grafana metrics stack, driven by a single `validator-config.yaml`. Multiple
+*different client implementations* (Zeam, Ream, Lighthouse, …) run against one shared
+genesis so you can test interop on a single local chain.
+
+## 0. Core principle
+
+- This skill grounds **how to run the devnet** — flags, config, genesis, metrics — not
+  protocol semantics. The chain behaviour is leanSpec's domain; this is the harness that
+  starts nodes.
+- The authoritative source for *how to run it* is the upstream `README.md` + the scripts
+  at `main`. They change (the repo is actively developed). **Do not quote flags or
+  filenames from memory or from a stale local clone** — read `main` and cite the SHA.
+- "Run the devnet" = edit `validator-config.yaml`, then invoke `spin-node.sh`. Everything
+  else (genesis, per-client commands, metrics) is wired from that config.
+
+## 1. Always read lean-quickstart from the remote `main` (no local path assumptions)
+
+The tooling evolves. Read the latest `main` of the canonical upstream directly from the
+remote — this works for every developer and in CI, with no dependency on a local clone.
+
+Repo: `github.com/blockblaz/lean-quickstart` (canonical; default branch `main`. Do **not**
+use a personal fork.).
+
+```bash
+# Latest main commit — cite this SHA in your output:
+gh api repos/blockblaz/lean-quickstart/commits/main --jq '.sha'
+
+# Read the README (the authoritative quick-start) at main:
+gh api "repos/blockblaz/lean-quickstart/contents/README.md?ref=main" --jq '.content' | base64 -d
+# raw fallback (no gh):
+curl -s https://raw.githubusercontent.com/blockblaz/lean-quickstart/main/README.md
+
+# Read a specific script (e.g. the entry point) at main:
+curl -s https://raw.githubusercontent.com/blockblaz/lean-quickstart/main/spin-node.sh
+
+# Full tree at main:
+gh api "repos/blockblaz/lean-quickstart/git/trees/main?recursive=1" --jq '.tree[].path'
+```
+
+No `gh`/`curl`? Use WebFetch on `https://github.com/blockblaz/lean-quickstart/blob/main/<path>`.
+
+If you happen to have a local clone, you *may* use it for fast navigation/grep — but
+`git fetch origin` first and read `origin/main` (clones drift onto feature branches and
+forks). Never assume a specific clone path.
+
+## 2. Quick start (the canonical command)
+
+```bash
+NETWORK_DIR=local-devnet ./spin-node.sh --node all --generateGenesis --popupTerminal
+```
+
+- `--node all` — launch **every node** defined in the config; `--node <name>` launches a
+  single node by name.
+- `--generateGenesis` — (re)generate genesis state, validator keys, and config from
+  `validator-config.yaml` before starting (PQ hash-sig keys via `ethpandaops/eth-beacon-genesis`).
+- `--popupTerminal` — open each node's logs in its own terminal window.
+- `NETWORK_DIR` selects the network directory (`local-devnet` for local; `ansible-devnet`
+  for the remote/Ansible flow).
+
+The **authoritative, current flag set** lives in `spin-node.sh --help` and the README at
+`main` — confirm there before relying on any flag, as options change.
+
+## 3. Topic → authoritative location map
+
+Paths are relative to the lean-quickstart repo root, read at `main`.
+
+| Topic | Path in lean-quickstart |
+|---|---|
+| Main entry point / flags | `spin-node.sh`; README "Quick Start" |
+| Initial host setup | `set-up.sh` |
+| Genesis generation | `generate-genesis.sh` (PQ hash-sig keys via eth-beacon-genesis) |
+| Network/node config (local) | `local-devnet/genesis/validator-config.yaml` |
+| Network/node config (remote) | `ansible-devnet/genesis/validator-config.yaml` |
+| Config expansion (subnets) | `convert-validator-config.py`, `generate-subnet-config.py` |
+| Per-client launch commands | `client-cmds/<client>-cmd.sh` (zeam, ream, qlean, lantern, lighthouse, grandine, ethlambda, gean, nlean, peam) |
+| Remote (Ansible) deploy | `ansible-deploy.sh`, `run-ansible.sh`, `ansible/` |
+| Metrics stack (run it) | `generate-prometheus-config.sh`, `metrics/docker-compose-metrics.yaml`, `metrics/grafana/` |
+| Devnet test notes / retros | `TESTING_DEVNET3.md`, `docs/devnets/` |
+
+## 4. How to use (running / configuring / answering)
+
+1. Read the README and `spin-node.sh --help` at `main` first — never quote flags from
+   memory.
+2. Edit `validator-config.yaml` (the single source of truth) to define which nodes, which
+   client implementations, and how many validators each.
+3. Run `spin-node.sh` with the appropriate `--node` / `--generateGenesis` flags; bring up
+   `metrics/docker-compose-metrics.yaml` if you want the Prometheus/Grafana stack.
+4. In your output, cite the **file/script + the `main` commit SHA** you checked.
+
+## 5. Relationship to leanSpec, leanMultisig, leanMetrics & Verity
+
+- **leanSpec** (separate skill) = consensus protocol & container shapes (the chain rules).
+- **leanMultisig** (separate skill) = aggregation + zkVM proof internals.
+- **leanMetrics** (separate skill) = the observability **metric contract** (names/types/
+  buckets/labels). This skill only covers **running** the bundled Prometheus/Grafana
+  stack, not what the metrics are.
+- **leanQuickstart** (this skill) = the harness that **boots and runs** a local
+  multi-client devnet.
+- Verity is pre-implementation, so it is **not yet a node** in `validator-config.yaml`.

--- a/.claude/skills/leanSpec/SKILL.md
+++ b/.claude/skills/leanSpec/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: leanSpec
+description: |
+  Ground every Verity spec question in leanSpec — the single authoritative specification
+  (Python reference implementation), always read from the latest origin/main (lstar HEAD).
+  Use before implementing, reviewing, or answering anything about Verity's protocol
+  behavior, container shapes, constants, fork choice, state transition, signatures, or
+  test vectors. Maps a topic to the authoritative leanSpec path for any protocol element.
+  Triggers: "leanSpec", "leanSpecを確認", "仕様を確認", "Verityの仕様", "prime", "verity context",
+  "where is the spec for", "container shape", "コンテナの形", "3SF", "fork choice",
+  "state transition", "XMSS", "leanMultisig", "devnet spec", and starting any Verity
+  implementation or review work.
+  Negative triggers: Do NOT activate for pure docs-site work (mdBook page authoring or
+  build/serve). Do NOT activate when working outside the Verity project.
+---
+
+# leanSpec — single source of truth for Verity
+
+Verity is a Rust Lean Consensus client. **leanSpec** (the Python reference implementation)
+is the *only* authoritative specification. This skill tells you where the authoritative
+definition of any protocol element lives, and how to read it correctly.
+
+## 0. Core principle
+
+- Container shapes, field order, constants, protocol behavior, and conformance test
+  vectors are defined by **leanSpec** (`lstar` fork). Verity (Rust) must match it exactly.
+- The user-facing `docs/` mdBook provides framing but **does not override leanSpec.**
+  When they conflict, leanSpec wins — treat other docs as possibly lagging.
+- Field order is consensus-critical (it determines `hash_tree_root`). Never reorder.
+
+## 1. Always read leanSpec from the remote `main` (no local path assumptions)
+
+Verity targets `lstar` HEAD (devnet-4/5 are in flight on `main`), so the spec moves.
+A pinned commit or a stale local checkout is **not** the spec. Read the latest `main`
+of the canonical upstream **`leanEthereum/leanSpec`** directly from the remote — this
+works for every developer and in CI, with no dependency on anyone's local clone path.
+
+Repo: `github.com/leanEthereum/leanSpec` (canonical; do **not** use a personal fork).
+
+```bash
+# Latest main commit — cite this SHA in your output:
+gh api repos/leanEthereum/leanSpec/commits/main --jq '.sha'
+
+# Read a file at main:
+gh api "repos/leanEthereum/leanSpec/contents/src/lean_spec/forks/lstar/spec.py?ref=main" --jq '.content' | base64 -d
+# raw fallback (no gh):
+curl -s https://raw.githubusercontent.com/leanEthereum/leanSpec/main/src/lean_spec/forks/lstar/spec.py
+
+# List a directory at main:
+gh api "repos/leanEthereum/leanSpec/contents/src/lean_spec/subspecs?ref=main" --jq '.[].name'
+# Full tree:
+gh api "repos/leanEthereum/leanSpec/git/trees/main?recursive=1" --jq '.tree[].path'
+```
+
+No `gh`/`curl`? Use WebFetch on `https://github.com/leanEthereum/leanSpec/blob/main/<path>`.
+
+If you happen to have a local clone, you *may* use it for fast navigation/grep — but
+`git fetch origin` first and read `origin/main` (clones drift onto feature branches and
+forks). Never assume a specific clone path.
+
+## 2. Devnet pin awareness
+
+- `origin/main` is the spec source of truth. `VERSIONS.md` records devnet commit pins
+  (Devnet 3 = `be853180d21aa36d6401b8c1541aa6fcaad5008d`; devnet-4/5 not yet pinned —
+  they live on `main`).
+- Only consult a pin when checking interop against an already-shipped network (e.g. a
+  devnet-3 build target). The final container shapes are governed by `main`.
+
+## 3. Topic → authoritative location map
+
+Paths are relative to the leanSpec repo root, read at `origin/main`.
+
+| Topic | leanSpec (authoritative) |
+|---|---|
+| Container types / shapes | `src/lean_spec/forks/lstar/containers/` (`attestation/`, `block/`, `state/`, `validator.py`, `config.py`) |
+| State transition | `src/lean_spec/forks/lstar/spec.py` |
+| Fork choice | `src/lean_spec/forks/lstar/store.py`, `src/lean_spec/subspecs/forkchoice/` |
+| XMSS signatures | `src/lean_spec/subspecs/xmss/` |
+| Poseidon / KoalaBear (XMSS internals) | `src/lean_spec/subspecs/poseidon1/`, `poseidon2/`, `koalabear/` |
+| SSZ / merkleization | `src/lean_spec/subspecs/ssz/` |
+| Networking (gossipsub / req-resp) | `src/lean_spec/subspecs/networking/` |
+| Storage | `src/lean_spec/subspecs/storage/` |
+| Sync | `src/lean_spec/subspecs/sync/` |
+| Genesis / validator / chain config | `src/lean_spec/subspecs/{genesis,validator,chain}/`, `forks/lstar/containers/config.py` |
+| API | `src/lean_spec/subspecs/api/` |
+| Conformance test vectors | `tests/consensus/devnet/{state_transition,fc,ssz,networking,sync,verify_signatures}/` |
+| leanMultisig (aggregation / zkVM) | **not** in leanSpec — use the dedicated `leanMultisig` skill (`github.com/leanEthereum/leanMultisig`) |
+| ethlambda (Rust *design* reference, not spec) | external `github.com/lambdaclass/ethlambda` |
+
+## 4. How to use (implementing / reviewing / answering)
+
+1. Read the **authoritative leanSpec path at `origin/main`** for the topic first.
+2. Never let the user-facing `docs/` override leanSpec.
+3. In your output, cite the **leanSpec path + the `origin/main` commit** you checked.
+
+## 5. Verity layout reminder
+
+- `docs/` — user-facing mdBook documentation (deployed to docs.verityclient.com).
+- Verity's Rust crates mirror ethlambda's components (`verity-types`, `verity-fork-choice`,
+  `verity-state-transition`, `verity-crypto`, `verity-p2p`, `verity-rpc`, `verity-storage`,
+  `verity-metrics`, `verity-cli`). The client is pre-implementation today.


### PR DESCRIPTION
## What

Adds agent background-knowledge skills under `.claude/skills/`:

- `hive/SKILL.md`
- `leanMetrics/SKILL.md`
- `leanMultisig/SKILL.md`
- `leanQuickstart/SKILL.md`
- `leanSpec/SKILL.md`

## Why

These give contributors a shared project context when working with Claude Code, mirroring the existing reference material the team relies on (leanSpec, hive simulator, etc.).

## Notes

- No code or build changes; documentation/skill content only.
- Scanned for local filesystem paths and secrets before committing — none present.