### PR TITLE
docs: document FFI seam marshalling cost and verification policy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -254,6 +254,41 @@ architecturally is that the boundary is a contract, not a hardcoded call site.
 > **Open for discussion.** Whether duty scheduling, signing, and aggregation should be
 > separate crates rather than folded into `verity-validator` once the workspace split happens.
 
+### The FFI seam — marshalling cost and verification
+
+When a contract is bound FFI-into-Lean, every call marshals its inputs across the C ABI: the
+Rust value is **promoted** into the Lean object representation on the way in and the result
+**lowered** back on the way out. For `StateTransition` and `ForkChoiceDecision` that means the
+full state or fork-choice view crosses the seam per call. This layer deserves explicit
+attention, because it is the weakest trusted link in the whole chain: the Lean theorems stop
+at Lean values, so a conversion bug (a transposed field, an endianness slip, a truncated
+list) makes the proven function compute *correctly on the wrong input* — and no proof, on
+either side, can see it.
+
+Two obligations follow:
+
+- **Verification.** The promote/lower code is boundary code in the Runtime Shell and is the
+  primary target of the boundary harnesses (round-trip properties, no-panic-on-any-input,
+  range enforcement — see [MODEL_CHECK.md](MODEL_CHECK.md)). Cross-language behavioral
+  equivalence is additionally evidenced by shared leanSpec vectors run on both sides;
+  [verifiable-stf](https://github.com/NyxFoundation/verifiable-stf) demonstrates the
+  strongest form of that evidence — the compiled-Lean and compiled-Rust STF produce
+  **byte-identical outputs** on the same inputs.
+- **Measurement.** Adopting a Lean implementation behind a contract is gated on measured
+  cost, not assumed cost. Two data sets exist today:
+  - [leanSSZ](https://github.com/NyxFoundation/leanSSZ)'s C ABI PoC (Rust-caller round-trip
+    and `hash_tree_root` match): STF+HTR 27.5 ms at V=4096, within budget; per-op on a
+    ~526 KB state, serialize 33 ms / `hash_tree_root` 58 ms / deserialize 54 ms
+    (list-based codec, uncached merkleization).
+  - verifiable-stf's compiled-Lean vs compiled-Rust STF comparison (RISC-V zkVM cycles, a
+    proxy for relative native cost): 26.1 M vs 12.5 M cycles at N=10 and 35.3 M vs 14.4 M at
+    N=100 — the Lean runtime's one-time `Init` accounts for ~15 M of the Lean side, so the
+    steady-state Lean overhead is roughly **1.4× Rust** once initialization is amortized
+    across a long-lived process.
+
+  These numbers are inputs to the migration triggers below: a capability moves into the
+  Verified Core only when its measured seam cost fits the slot-time budget.
+
 ## Boundary migration
 
 Because a zone is a guarantee level and placement is a snapshot, components are expected to cross the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -289,6 +289,28 @@ Two obligations follow:
   These numbers are inputs to the migration triggers below: a capability moves into the
   Verified Core only when its measured seam cost fits the slot-time budget.
 
+**Interchange shape — a conditional design, not an adoption decision.** Nothing here decides
+*whether* any capability is bound to Lean — that remains gated per capability (stable, proved,
+measured-within-budget). What is fixed now is only the **shape** the seam takes *if* a binding
+happens, so that a future adoption is a re-binding rather than a redesign:
+
+- **Long-lived values stay resident.** The consensus state and fork-choice view do not round-trip
+  per call. The Rust side holds an opaque handle to a Lean-resident value
+  (`process_block(state_handle, block) -> new_state_handle`), which fits Lean's immutable,
+  reference-counted values and eliminates the per-call state marshalling cost entirely. The
+  single-writer discipline makes ownership simple: the store is the only holder. Persistence and
+  crash recovery are defined by SSZ export/import at the DB, not by the handle.
+- **Inputs cross as SSZ bytes, decoded by the callee.** Per-call inputs (blocks, votes) are
+  passed in their SSZ wire form and decoded on the Lean side. This deliberately avoids
+  constructing Lean objects field-by-field from Rust (`lean_alloc_ctor`-style), which would
+  couple the shell to the Lean object layout and concentrate `unsafe` exactly where a
+  conversion bug is least detectable. Bytes-as-interchange means the conversion is the
+  consensus-critical wire format itself — already fixture-tested on both sides — and, if the
+  Lean side ever ships a proven decoder, the Lean half of the seam becomes proven code.
+
+Field-by-field construction is not banned outright; it is the last resort, admitted only where
+measurement shows the byte path cannot fit the budget.
+
 ## Boundary migration
 
 Because a zone is a guarantee level and placement is a snapshot, components are expected to cross the

--- a/docs/src/reference/architecture.md
+++ b/docs/src/reference/architecture.md
@@ -270,6 +270,43 @@ architecturally is that the boundary is a contract, not a hardcoded call site.
 > **Open for discussion.** Whether duty scheduling, signing, and aggregation should be
 > separate crates rather than folded into `verity-validator` once the workspace split happens.
 
+### The FFI seam — marshalling cost and verification
+
+When a contract is bound FFI-into-Lean, every call marshals its inputs across the C ABI: the
+Rust value is **promoted** into the Lean object representation on the way in and the result
+**lowered** back on the way out. For `StateTransition` and `ForkChoiceDecision` that means the
+full state or fork-choice view crosses the seam per call. This layer deserves explicit
+attention, because it is the weakest trusted link in the whole chain: the Lean theorems stop
+at Lean values, so a conversion bug (a transposed field, an endianness slip, a truncated
+list) makes the proven function compute *correctly on the wrong input* — and no proof, on
+either side, can see it.
+
+Two obligations follow:
+
+- **Verification.** The promote/lower code is boundary code in the Runtime Shell and is the
+  primary target of the boundary harnesses (round-trip properties, no-panic-on-any-input,
+  range enforcement — see the
+  [Model-Checking Strategy](https://github.com/NyxFoundation/verity/blob/main/MODEL_CHECK.md)).
+  Cross-language behavioral equivalence is additionally evidenced by shared leanSpec vectors
+  run on both sides;
+  [verifiable-stf](https://github.com/NyxFoundation/verifiable-stf) demonstrates the
+  strongest form of that evidence — the compiled-Lean and compiled-Rust STF produce
+  **byte-identical outputs** on the same inputs.
+- **Measurement.** Adopting a Lean implementation behind a contract is gated on measured
+  cost, not assumed cost. Two data sets exist today:
+  - [leanSSZ](https://github.com/NyxFoundation/leanSSZ)'s C ABI PoC (Rust-caller round-trip
+    and `hash_tree_root` match): STF+HTR 27.5 ms at V=4096, within budget; per-op on a
+    ~526 KB state, serialize 33 ms / `hash_tree_root` 58 ms / deserialize 54 ms
+    (list-based codec, uncached merkleization).
+  - verifiable-stf's compiled-Lean vs compiled-Rust STF comparison (RISC-V zkVM cycles, a
+    proxy for relative native cost): 26.1 M vs 12.5 M cycles at N=10 and 35.3 M vs 14.4 M at
+    N=100 — the Lean runtime's one-time `Init` accounts for ~15 M of the Lean side, so the
+    steady-state Lean overhead is roughly **1.4× Rust** once initialization is amortized
+    across a long-lived process.
+
+  These numbers are inputs to the migration triggers below: a capability moves into the
+  Verified Core only when its measured seam cost fits the slot-time budget.
+
 ## Boundary migration
 
 Because a zone is a guarantee level and placement is a snapshot, components are expected to cross the

--- a/docs/src/reference/architecture.md
+++ b/docs/src/reference/architecture.md
@@ -307,6 +307,28 @@ Two obligations follow:
   These numbers are inputs to the migration triggers below: a capability moves into the
   Verified Core only when its measured seam cost fits the slot-time budget.
 
+**Interchange shape — a conditional design, not an adoption decision.** Nothing here decides
+*whether* any capability is bound to Lean — that remains gated per capability (stable, proved,
+measured-within-budget). What is fixed now is only the **shape** the seam takes *if* a binding
+happens, so that a future adoption is a re-binding rather than a redesign:
+
+- **Long-lived values stay resident.** The consensus state and fork-choice view do not round-trip
+  per call. The Rust side holds an opaque handle to a Lean-resident value
+  (`process_block(state_handle, block) -> new_state_handle`), which fits Lean's immutable,
+  reference-counted values and eliminates the per-call state marshalling cost entirely. The
+  single-writer discipline makes ownership simple: the store is the only holder. Persistence and
+  crash recovery are defined by SSZ export/import at the DB, not by the handle.
+- **Inputs cross as SSZ bytes, decoded by the callee.** Per-call inputs (blocks, votes) are
+  passed in their SSZ wire form and decoded on the Lean side. This deliberately avoids
+  constructing Lean objects field-by-field from Rust (`lean_alloc_ctor`-style), which would
+  couple the shell to the Lean object layout and concentrate `unsafe` exactly where a
+  conversion bug is least detectable. Bytes-as-interchange means the conversion is the
+  consensus-critical wire format itself — already fixture-tested on both sides — and, if the
+  Lean side ever ships a proven decoder, the Lean half of the seam becomes proven code.
+
+Field-by-field construction is not banned outright; it is the last resort, admitted only where
+measurement shows the byte path cannot fit the budget.
+
 ## Boundary migration
 
 Because a zone is a guarantee level and placement is a snapshot, components are expected to cross the


### PR DESCRIPTION
## Why

The promote/lower marshalling layer at the Verified Core ↔ Runtime Shell FFI seam is the weakest trusted link in the verification chain: Lean theorems stop at Lean values, so a conversion bug (transposed field, endianness slip, truncated list) makes a proven function compute correctly on the wrong input, invisibly to proofs on either side. The architecture docs were silent on both the cost and the verification of this layer.

## Changes

Adds "The FFI seam — marshalling cost and verification" under Capability contracts (`ARCHITECTURE.md` + docs mirror):

- **Verification obligation**: promote/lower code is the primary target of the boundary harnesses (round-trip, no-panic, range enforcement per `MODEL_CHECK.md`), with cross-language equivalence evidenced by shared leanSpec vectors — verifiable-stf's byte-identical compiled-Lean vs compiled-Rust STF outputs being the strongest existing instance.
- **Measurement obligation**: Lean adoption behind a contract is gated on measured seam cost. Records the two existing data sets:
  - leanSSZ C ABI PoC: STF+HTR 27.5 ms @ V=4096; serialize 33 ms / hash_tree_root 58 ms / deserialize 54 ms on a ~526 KB state.
  - verifiable-stf zkVM cycle comparison: 26.1 M (Lean) vs 12.5 M (Rust) cycles at N=10, 35.3 M vs 14.4 M at N=100; ~15 M of the Lean side is one-time runtime Init, leaving ~1.4× steady-state overhead.

`mdbook build` passes locally.

## Follow-up commit: interchange shape (conditional design)

Adds the seam's interchange shape **without deciding Lean adoption** (adoption stays gated per capability):

- Long-lived values (state, fork-choice view) stay Lean-resident behind an opaque handle — no per-call state round-trip.
- Per-call inputs (blocks, votes) cross as SSZ wire bytes, decoded by the callee — the conversion is the fixture-tested wire format, not a bespoke convention.
- Field-by-field Lean object construction from Rust is the measured-last-resort only.
