### PR TITLE
docs: define the FFI error model and close two trust-base gaps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -230,6 +230,27 @@ bound — a wiring decision in the `verity` binary, constrained by what is actua
 proof obligation sits; and (c) whether that capability's functions appear in the `verity-consensus-sys`
 export set.
 
+**Error model.** Failure is part of the contract, in two strictly separated layers:
+
+- **Protocol rejection** (an invalid block) is a *value*. In the Lean model it is a pure
+  `Except`-style result; in the contract it is the `Err` arm of the shared `Result`. The error
+  type is a plain enum (`ProcessingError`), defined **in the contract crate** alongside the
+  traits, so the native-Rust and FFI-into-Lean implementations return the same type and a
+  migration leaves the error path untouched. At the C ABI the FFI implementation uses the
+  conventional shape — an `int32` status code plus an out-parameter for the result — with the
+  status codes in one-to-one correspondence with the Lean model's rejection reasons; that
+  correspondence table is kept next to the Lean definition it mirrors, and the code→enum
+  conversion is confined to `verity-consensus-sys`. Rejection reasons are a small closed set
+  (the Runtime Shell delivers already-verified inputs, so FFI-level rejection is rare by
+  design), which is why a code enum suffices and no structured error payload crosses the ABI.
+- **Runtime failure** (Lean runtime allocation failure) is *not* a value and is not modeled in
+  the contract. The Lean runtime can abort the process on allocation failure, and Verity
+  designs on the assumption that this cannot be hooked. Such an abort is classed with a
+  Rust-side OOM abort: an availability failure, not a safety failure. The panic-freedom claim
+  is precise on this point — it asserts that **no code path returns an incorrect consensus
+  value**, not that a linked runtime can never abort; the residual abort condition is listed in
+  the [trust base](docs/src/concepts/formal-verification.md).
+
 The contracts' "already-verified inputs" clause has concrete, named content: formal-leanSpec's
 theorems are proved relative to explicit well-formedness predicates — `Store.WellFormed` for the
 fork-choice store, `AnchorWF` (discharged by `Reachable`) for the state, and

--- a/docs/src/concepts/formal-verification.md
+++ b/docs/src/concepts/formal-verification.md
@@ -100,6 +100,20 @@ What must be trusted for the claim to hold — listed so no link stays implicit:
 - **The Lean 4 kernel** that checks the proofs.
 - **The transcription.** formal-leanSpec is a hand transcription of a Python spec; its
   fidelity is evidenced (per-file source tracing, review, shared vectors), not proven.
+- **The predicate mirrors.** The well-formedness predicates the theorems assume
+  (`Store.WellFormed`, `AnchorWF`, `ValidatorRegistry.WellFormed`) are Lean definitions;
+  for the Runtime Shell to maintain them — and for the boundary harnesses to target them —
+  they must be hand-transcribed into Rust. That is a **second transcription** of the same
+  kind as formal-leanSpec itself, and it is held to the same discipline: each Rust mirror
+  cites the Lean definition it mirrors, and shared vectors exercise both sides. A drifted
+  mirror silently voids the boundary checks, which is why this link is listed rather than
+  assumed.
+- **The Lean runtime's abort path.** The compiled artifact embeds the Lean runtime, which
+  can abort the process on allocation failure. This is an *availability* residue, classed
+  with a Rust-side OOM abort — the panic-freedom claim asserts that no path returns an
+  incorrect consensus value, not that a linked runtime can never abort (see the
+  [error model](../reference/architecture.md#capability-contracts)). Exported functions are
+  total, so no other runtime-panic path exists inside the export set.
 - **The artifact pipeline.** Lean's C backend, the generated C, the C compiler and linker,
   and the runtime the artifact embeds. No tool in the project checks that the static
   library computes the proven functions.

--- a/docs/src/reference/architecture.md
+++ b/docs/src/reference/architecture.md
@@ -246,6 +246,27 @@ bound — a wiring decision in the `verity` binary, constrained by what is actua
 proof obligation sits; and (c) whether that capability's functions appear in the `verity-consensus-sys`
 export set.
 
+**Error model.** Failure is part of the contract, in two strictly separated layers:
+
+- **Protocol rejection** (an invalid block) is a *value*. In the Lean model it is a pure
+  `Except`-style result; in the contract it is the `Err` arm of the shared `Result`. The error
+  type is a plain enum (`ProcessingError`), defined **in the contract crate** alongside the
+  traits, so the native-Rust and FFI-into-Lean implementations return the same type and a
+  migration leaves the error path untouched. At the C ABI the FFI implementation uses the
+  conventional shape — an `int32` status code plus an out-parameter for the result — with the
+  status codes in one-to-one correspondence with the Lean model's rejection reasons; that
+  correspondence table is kept next to the Lean definition it mirrors, and the code→enum
+  conversion is confined to `verity-consensus-sys`. Rejection reasons are a small closed set
+  (the Runtime Shell delivers already-verified inputs, so FFI-level rejection is rare by
+  design), which is why a code enum suffices and no structured error payload crosses the ABI.
+- **Runtime failure** (Lean runtime allocation failure) is *not* a value and is not modeled in
+  the contract. The Lean runtime can abort the process on allocation failure, and Verity
+  designs on the assumption that this cannot be hooked. Such an abort is classed with a
+  Rust-side OOM abort: an availability failure, not a safety failure. The panic-freedom claim
+  is precise on this point — it asserts that **no code path returns an incorrect consensus
+  value**, not that a linked runtime can never abort; the residual abort condition is listed in
+  the [trust base](../concepts/formal-verification.md#the-trust-base).
+
 The contracts' "already-verified inputs" clause has concrete, named content: formal-leanSpec's
 theorems are proved relative to explicit well-formedness predicates — `Store.WellFormed` for the
 fork-choice store, `AnchorWF` (discharged by `Reachable`) for the state, and


### PR DESCRIPTION
## Why

The capability contracts returned `Result<post_state>` but nothing specified how failure crosses the C ABI, and two trust links (the Rust mirrors of the WellFormed predicates; the Lean runtime's abort path) were implicit. Settled per design discussion: status-code error ABI (option A).

## Changes

**Error model** (new paragraph under Capability contracts, `ARCHITECTURE.md` + docs mirror), two strictly separated layers:

- **Protocol rejection is a value**: a shared `ProcessingError` enum living in the contract crate, so native-Rust and FFI-into-Lean implementations return the same type and a migration leaves the error path untouched. At the C ABI: `int32` status code + out-parameter, codes mapped one-to-one to the Lean model's rejection reasons (table kept next to the Lean definition), conversion confined to `verity-consensus-sys`.
- **Runtime failure is not a value**: Lean runtime allocation-failure abort is classed with a Rust OOM abort — an availability failure. The panic-freedom claim is made precise: no path returns an incorrect consensus value; it does not claim a linked runtime can never abort.

**Trust base** (`formal-verification.md`), two new entries:

- **Predicate mirrors**: the Rust transcriptions of `Store.WellFormed` / `AnchorWF` / `ValidatorRegistry.WellFormed` are a second hand transcription, held to the same discipline as formal-leanSpec (cited sources, shared vectors) — a drifted mirror silently voids the boundary checks.
- **Lean runtime abort path**: the availability residue above, with the note that exported functions are total so no other runtime-panic path exists inside the export set.

`mdbook build` passes locally.