### PR TITLE
docs: settle XMSS validator key-state management

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,9 +47,11 @@ verification frontier moves; see [boundary migration](#boundary-migration).
 
 - **I/O Edge — Rust, concurrent.** The only place where concurrency and the outside world
   live: networking, the slot clock, validator duties, RPC, metrics, and node orchestration. Bounded
-  queues provide backpressure. The choice of concurrency primitive (actor model vs. async tasks) is a
-  later, I/O-Edge-internal decision — it is **not** an architectural concern, because the consensus
-  state has a single owner in Runtime Shell and Verity Consensus is invoked sequentially regardless.
+  queues provide backpressure. The concurrency primitive is settled (2026-08-15, see the
+  [Concurrency Model](CONCURRENCY.md)): the single writer is a dedicated task fed by bounded
+  channels, with signature/proof verification staged in front of it. It remains an I/O-Edge-internal
+  concern — the consensus state has a single owner in Runtime Shell and Verity Consensus is invoked
+  sequentially regardless.
 
 ## Component diagram
 

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -69,6 +69,17 @@ reads leave as immutable snapshots — after each mutation the task publishes an
 `Arc<ChainView>` over a `watch` channel, and every consumer (validator duties, RPC, metrics,
 the verification stage) reads the snapshot current at its own read time.
 
+`ChainView` is an immutable value — a snapshot, not a live reference — so a reader can never
+observe a half-applied mutation and has no way to mutate shared state. What is fixed here is
+its **contract**, not its field list: it must carry (a) the current head and the latest
+justified / finalized checkpoints, and (b) enough of the block tree and post-states to resolve
+a validator registry by block root. Those two clauses serve its two consumer groups — the read
+APIs [memo.md](memo.md) assigns to `verity-chain` (head, finalized checkpoint, state views)
+and the verification stage's key resolution. **The `watch`-published snapshot is the entire
+read path**: there is no query channel into the chain task; RPC, metrics, and validator duties
+answer reads from the snapshot they hold. The exact field layout is an implementation
+decision.
+
 Why this form, against the two alternatives:
 
 - **Ownership deletes the property.** With the store owned by one task, single-writer stops
@@ -114,14 +125,24 @@ flowchart LR
   `VerifiedBlock` / `VerifiedAttestation` values whose constructors are private to the
   verification stage. An unverified value cannot reach the chain task, and therefore cannot
   reach the FFI: the spec's verify-before-STF ordering holds by construction, and the boundary
-  harnesses (Kani / bolero, per MODEL_CHECK.md) cut exactly at these constructors.
+  harnesses (Kani / bolero, per MODEL_CHECK.md) cut exactly at these constructors. A
+  `Verified*` value wraps the decoded, typed container together with the roots computed during
+  verification — ARCHITECTURE.md's "verified, typed block (+ roots)" — so the chain task
+  re-computes nothing; the exact fields are an implementation decision.
 - **State supply.** The stage resolves validator registries (parent / target post-state) from
   the `watch`-published `Arc<ChainView>` snapshot — the read side of Decision 1 is the supply
   line.
 - **Pending lives in the stage.** A block whose parent post-state is not yet in view cannot be
-  verified; it waits in a bounded buffer inside the stage, keyed by parent root, retried when
-  the `ChainView` updates, oldest-evicted on overflow. The chain task never holds unverified
-  values — the invariant admits no exceptions.
+  verified; it waits in a bounded buffer inside the stage, keyed by parent root. The stage's
+  loop selects over its input channel *and* the snapshot's `watch::changed()`; on an update it
+  retries exactly the entries whose parent root became resolvable in the new snapshot. The
+  buffer is parked storage, not a send path: it never blocks, and it holds only items that
+  *cannot be verified yet* — an item that fails verification is dropped on the spot (peer
+  scoring for invalid input is deferred to the sync / peer-management design). Overflow evicts
+  in FIFO arrival order, and eviction is silent: nothing re-requests an evicted block — like a
+  gossip drop at the network edge it is peer-recoverable, and range sync closes the gap when
+  the chain notices the missing ancestry. The chain task never holds unverified values — the
+  invariant admits no exceptions.
 - **Propagation is not gated.** Matching the spec reference and all four surveyed clients,
   gossipsub is configured without message validation gating (`validate_messages()` is not
   enabled); forwarding proceeds independently of verification.
@@ -142,11 +163,18 @@ The chain task's inbox is three independent channels, not one. The unit of separ
 | ② local | own proposed `SignedBlock`, own `SignedAttestation`, completed `SignedAggregatedAttestation` from the aggregation worker | small bounded `mpsc` | sender awaits — **never dropped** |
 | ③ network | `VerifiedBlock` / `VerifiedAttestation` / verified aggregates, from gossip and range-sync responses | bounded `mpsc` | sender (verification stage) awaits; backpressure propagates to the network edge, where raw gossip is dropped by `try_send` |
 
-The chain task reads all three in a `tokio::select!` with `biased` ordering ① → ② → ③.
+The chain task reads all three in a `tokio::select!` with `biased` ordering ① → ② → ③. The
+loop takes **one event per iteration** and re-enters the `select!`, so the priority order is
+re-evaluated after every event and no channel is ever drained in bulk. No fairness window is
+needed: every step is short by construction — the heavy work already happened upstream in the
+verification stage.
 
 - **① is sound as latest-only** because of the spec's own catch-up semantics: `on_tick` steps
   to the target one interval at a time and skips no interval's action, so delivering only the
-  newest target loses nothing. The tick is not a timer callback — it drives genuine store
+  newest target loses nothing. The corresponding **requirement on the chain task**: on reading
+  a new target it advances interval-by-interval to that target, executing every intermediate
+  interval's action — it must never process only the latest interval. The tick is not a timer
+  callback — it drives genuine store
   mutations (ingest pending attestations at intervals 0 and 4, trigger aggregation at 2,
   advance the safe target at 3), which is why it enters the single writer's inbox at all.
 - **② is never dropped** because its contents are the node's own duty products: no other peer
@@ -166,6 +194,31 @@ The chain task reads all three in a `tokio::select!` with `biased` ordering ① 
   clock, not the network — and the bias is the desired property stated directly: time and the
   node's own duties are processed ahead of any volume of gossip.
 
+## Lifecycle
+
+Startup runs the dependency arrows backwards. Open the database and validate its identity
+values ([STORAGE.md](STORAGE.md)); the chain task loads the finalized anchor, reconstructs
+`Store` and `State`, and publishes the **first `ChainView`** — that publication is the
+readiness signal every other component waits on; only then do the verification stage, network,
+validator-duty, and RPC tasks start. Shutdown inverts it: stop network intake first; discard
+the verification stage's in-flight and pending items (peer-recoverable, like any network-edge
+drop); drain ② completely (duty products are never dropped, in shutdown included); process
+what ③ already holds; persist; stop the chain task. Process-level orchestration — signal
+handling, restart policy — belongs to the `verity` binary and is out of scope here.
+
+## Deliberately deferred to implementation
+
+Listed so they are not mistaken for omissions:
+
+- **Channel capacities** for ② and ③ and the **pending-buffer size** are configuration
+  constants chosen and tuned at implementation time. The architectural commitments are only
+  that every buffer is bounded and that each channel's full-queue *policy* is exactly as
+  specified above.
+- **Exact field layouts** of `ChainView` and the `Verified*` types — their contracts are fixed
+  above, their struct definitions are not.
+- **Peer scoring** in response to invalid (verification-failing) input — deferred to the sync
+  / peer-management design, the next design area in sequence.
+
 ## Verification obligations introduced by this model
 
 What this document adds to the [MODEL_CHECK.md](MODEL_CHECK.md) map, concretely:
@@ -176,3 +229,7 @@ What this document adds to the [MODEL_CHECK.md](MODEL_CHECK.md) map, concretely:
   inbound event order, exercised end-to-end by the leanSpec fixture suite in CI.
 - **Kani / bolero targets:** the `Verified*` constructor boundary in the verification stage —
   no-panic-on-any-input for decode and proof verification, and rejection ⇒ no store effect.
+
+A panic that escapes despite these checks is not caught and continued: consistent with
+ARCHITECTURE.md's error model, it is classed as an availability failure and aborts the
+process — never a silently degraded consensus path.

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -197,7 +197,10 @@ verification stage.
   authoritative per-interval action map is leanSpec's `tick_interval`
   (`src/lean_spec/spec/forks/lstar/timeline.py`); the actions named here — ingest pending
   attestations at intervals 0 and 4, trigger aggregation at 2, advance the safe target at 3 —
-  are that map's content at `cce7955`, cited for orientation, not restated normatively.
+  are that map's content at `cce7955`, cited for orientation. The map is **normative by
+  reference to leanSpec `main`**, deliberately not restated here: Verity tracks the moving
+  spec (repo policy), so the commit records what was read, not a frozen contract — the chain
+  task implements whatever `tick_interval` says at the tracked revision.
   Catch-up cost is not a liveness concern: interval actions are pool ingestion and pointer
   updates, not STF work, so even a long stall replays cheaply. The tick is not a timer
   callback — it drives genuine store mutations, which is why it enters the single writer's
@@ -205,11 +208,16 @@ verification stage.
 - **② is never dropped** because its contents are the node's own duty products: no other peer
   holds them, range sync cannot recover them, and losing one is a missed duty. Its flow rate is
   structurally tiny (a handful of events per slot), so a small buffer with an awaiting sender
-  costs nothing. Aggregate-proof *production* — seconds of zk proving — follows the ethlambda
-  pattern with the wiring explicit: the interval-2 tick action in the chain task determines
-  that aggregation is due and hands the signature-pool snapshot to `verity-validator`'s
-  aggregation worker; the worker runs on `spawn_blocking`, and the chain task never awaits it
-  — the finished
+  costs nothing. The production side of ② is fixed too: the validator-duty tasks are driven
+  by the **same slot clock** that feeds ① — one clock in the `verity` binary, two consumers —
+  and never by callbacks from the chain task. At its duty interval a validator task reads the
+  current `ChainView` snapshot (proposal head, attestation target), produces and signs, and
+  sends the product into ②; the chain task's sole involvement in production is the interval-2
+  aggregation handoff below. Aggregate-proof *production* — seconds of zk proving — follows
+  the ethlambda pattern with the wiring explicit: the interval-2 tick action in the chain task
+  determines that aggregation is due and hands the signature-pool snapshot to
+  `verity-validator`'s aggregation worker; the worker runs on `spawn_blocking`, and the chain
+  task never awaits it — the finished
   aggregate re-enters through ②.
 - **③ is the only place load is shed, and only pre-verification.** Backpressure runs backwards
   through the pipeline so that when the node falls behind, what gets dropped is raw bytes at
@@ -234,8 +242,10 @@ tasks start. Shutdown inverts it, and **channel closure is the only
 signal** — there is no shutdown broadcast. The binary stops the producers at the edge; each
 stopped producer drops its sender; every downstream task exits when its inputs return `None`
 (a closed-and-empty channel), with no side-channel bookkeeping. Concretely: the network task
-stops and drops its sender; the verification stage, on `None` from its input, discards its
-in-flight and pending items (peer-recoverable, like any network-edge drop) and drops its own
+stops and drops its sender; the verification stage, on `None` from its input, stops accepting
+work, lets verifications already running on `spawn_blocking` finish and **discards their
+results** (blocking work is uncancellable by nature — nothing waits on it), drops its pending
+buffer (peer-recoverable, like any network-edge drop), and drops its own
 sender, closing ③; the validator tasks stop, closing ②; the chain task consumes ② and ③ to
 `None` — duty products are never dropped, in shutdown included — then persists and stops. Process-level
 orchestration — signal handling, restart policy — belongs to the `verity` binary and is out of

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -241,7 +241,10 @@ component waits on; only then do the verification stage, network, validator-duty
 tasks **begin serving**. What the first `ChainView` gates is serving, not construction:
 initialization that needs no consensus state — validator key preparation above all
 ([KEY_MANAGEMENT.md](KEY_MANAGEMENT.md)) — is spawned by the binary at process start and runs
-in parallel with this sequence. Shutdown inverts it, and **channel closure is the only
+in parallel with this sequence. The first `ChainView` is a *necessary* serving gate for every
+component, not always a *sufficient* one: a component may add its own readiness condition, and
+the validator-duty loop does — it serves only once its keys are also prepared
+(KEY_MANAGEMENT.md's join of two gates). Shutdown inverts it, and **channel closure is the only
 signal** — there is no shutdown broadcast. The binary stops the producers at the edge; each
 stopped producer drops its sender; every downstream task exits when its inputs return `None`
 (a closed-and-empty channel), with no side-channel bookkeeping. Concretely: the network task

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -78,7 +78,19 @@ APIs [memo.md](memo.md) assigns to `verity-chain` (head, finalized checkpoint, s
 and the verification stage's key resolution. **The `watch`-published snapshot is the entire
 read path**: there is no query channel into the chain task; RPC, metrics, and validator duties
 answer reads from the snapshot they hold. The exact field layout is an implementation
-decision.
+decision. Three consequences are fixed alongside the contract:
+
+- **Retention bound.** The snapshot covers the *unfinalized* block tree plus the finalized
+  anchor — exactly what fork choice operates on, and the only states verification's registry
+  resolution can name. Anything older is `verity-db`'s job ([STORAGE.md](STORAGE.md) state
+  snapshots + diffs): an RPC query for a historical state is a database read, not a snapshot
+  miss.
+- **Publication cadence.** At most once per chain-task loop iteration, after an event's import
+  has fully completed — never mid-import, so no reader can observe a half-applied mutation.
+- **Distribution.** Every consumer receives its `watch::Receiver<Arc<ChainView>>` at
+  construction, before its task starts; the same receiver doubles as the startup readiness
+  signal ([Lifecycle](#lifecycle)). There is no separate registration or notification
+  mechanism.
 
 Why this form, against the two alternatives:
 
@@ -116,7 +128,9 @@ flowchart LR
 - **Placement.** Between the network task and the chain task, as its own stage — the
   `Codec + Crypto` participant in ARCHITECTURE.md's inbound-block sequence, made an execution
   unit. The network task performs topic validation and deduplication only: no decode, no
-  crypto, so network liveness (mesh maintenance, keep-alives) never waits on a proof.
+  crypto, so network liveness (mesh maintenance, keep-alives) never waits on a proof. It hands
+  raw bytes to the stage with `try_send` on the stage's bounded input channel — the single
+  drop point of the entire pipeline.
 - **Execution.** The stage runs decode, `hash_tree_root`, and XMSS / aggregate-proof
   verification on `tokio::task::spawn_blocking`. **No rayon pool, and no promotion path to
   one** — settled 2026-08-15 for design simplicity. (zeam demonstrates the rayon endpoint
@@ -136,13 +150,15 @@ flowchart LR
   verified; it waits in a bounded buffer inside the stage, keyed by parent root. The stage's
   loop selects over its input channel *and* the snapshot's `watch::changed()`; on an update it
   retries exactly the entries whose parent root became resolvable in the new snapshot. The
-  buffer is parked storage, not a send path: it never blocks, and it holds only items that
-  *cannot be verified yet* — an item that fails verification is dropped on the spot (peer
-  scoring for invalid input is deferred to the sync / peer-management design). Overflow evicts
-  in FIFO arrival order, and eviction is silent: nothing re-requests an evicted block — like a
-  gossip drop at the network edge it is peer-recoverable, and range sync closes the gap when
-  the chain notices the missing ancestry. The chain task never holds unverified values — the
-  invariant admits no exceptions.
+  buffer is parked storage, not a send path: it never blocks, and it holds only the one
+  *recoverable* failure — parent post-state not yet in view. Every definitive failure —
+  malformed SSZ, a root mismatch, an invalid signature or proof — drops the item on the spot,
+  counted in metrics (peer scoring for invalid input is deferred to the sync /
+  peer-management design). Overflow evicts count-bounded, in FIFO order of arrival into the
+  buffer, and eviction is silent: nothing re-requests an evicted block — like a gossip drop at
+  the network edge it is peer-recoverable, and range sync closes the gap when the chain
+  notices the missing ancestry. The chain task never holds unverified values — the invariant
+  admits no exceptions.
 - **Propagation is not gated.** Matching the spec reference and all four surveyed clients,
   gossipsub is configured without message validation gating (`validate_messages()` is not
   enabled); forwarding proceeds independently of verification.
@@ -173,15 +189,25 @@ verification stage.
   to the target one interval at a time and skips no interval's action, so delivering only the
   newest target loses nothing. The corresponding **requirement on the chain task**: on reading
   a new target it advances interval-by-interval to that target, executing every intermediate
-  interval's action — it must never process only the latest interval. The tick is not a timer
-  callback — it drives genuine store
-  mutations (ingest pending attestations at intervals 0 and 4, trigger aggregation at 2,
-  advance the safe target at 3), which is why it enters the single writer's inbox at all.
+  interval's action — it must never process only the latest interval. No new bookkeeping is
+  required for this: the node's current interval **is** `Store.time`, and the handler is the
+  spec's own `on_tick(store, target)` loop — advance while `store.time < target`. The
+  authoritative per-interval action map is leanSpec's `tick_interval`
+  (`src/lean_spec/spec/forks/lstar/timeline.py`); the actions named here — ingest pending
+  attestations at intervals 0 and 4, trigger aggregation at 2, advance the safe target at 3 —
+  are that map's content at `cce7955`, cited for orientation, not restated normatively.
+  Catch-up cost is not a liveness concern: interval actions are pool ingestion and pointer
+  updates, not STF work, so even a long stall replays cheaply. The tick is not a timer
+  callback — it drives genuine store mutations, which is why it enters the single writer's
+  inbox at all.
 - **② is never dropped** because its contents are the node's own duty products: no other peer
   holds them, range sync cannot recover them, and losing one is a missed duty. Its flow rate is
   structurally tiny (a handful of events per slot), so a small buffer with an awaiting sender
   costs nothing. Aggregate-proof *production* — seconds of zk proving — follows the ethlambda
-  pattern: the tick triggers it, a `spawn_blocking` worker computes it, and the finished
+  pattern with the wiring explicit: the interval-2 tick action in the chain task determines
+  that aggregation is due and hands the signature-pool snapshot to `verity-validator`'s
+  aggregation worker; the worker runs on `spawn_blocking`, and the chain task never awaits it
+  — the finished
   aggregate re-enters through ②.
 - **③ is the only place load is shed, and only pre-verification.** Backpressure runs backwards
   through the pipeline so that when the node falls behind, what gets dropped is raw bytes at
@@ -200,11 +226,14 @@ Startup runs the dependency arrows backwards. Open the database and validate its
 values ([STORAGE.md](STORAGE.md)); the chain task loads the finalized anchor, reconstructs
 `Store` and `State`, and publishes the **first `ChainView`** — that publication is the
 readiness signal every other component waits on; only then do the verification stage, network,
-validator-duty, and RPC tasks start. Shutdown inverts it: stop network intake first; discard
-the verification stage's in-flight and pending items (peer-recoverable, like any network-edge
-drop); drain ② completely (duty products are never dropped, in shutdown included); process
-what ③ already holds; persist; stop the chain task. Process-level orchestration — signal
-handling, restart policy — belongs to the `verity` binary and is out of scope here.
+validator-duty, and RPC tasks start. Shutdown inverts it, and "drained" has a concrete signal:
+each producer drops its sender when it stops, and a closed-and-empty channel returns `None` to
+the receiver — no side-channel bookkeeping. Stop network intake first; the verification stage
+discards its in-flight and pending items (peer-recoverable, like any network-edge drop) and
+drops its sender; ② is drained completely (duty products are never dropped, in shutdown
+included); the chain task consumes ② and ③ to `None`, persists, and stops. Process-level
+orchestration — signal handling, restart policy — belongs to the `verity` binary and is out of
+scope here.
 
 ## Deliberately deferred to implementation
 
@@ -213,9 +242,12 @@ Listed so they are not mistaken for omissions:
 - **Channel capacities** for ② and ③ and the **pending-buffer size** are configuration
   constants chosen and tuned at implementation time. The architectural commitments are only
   that every buffer is bounded and that each channel's full-queue *policy* is exactly as
-  specified above.
+  specified above. The sizing anchors are structural, not free: ② carries a handful of events
+  per slot (tens suffice); ③ and the pending buffer are sized against per-slot gossip volume
+  (order hundreds).
 - **Exact field layouts** of `ChainView` and the `Verified*` types — their contracts are fixed
-  above, their struct definitions are not.
+  above, their struct definitions are not — and internal data structures such as the pending
+  buffer's index.
 - **Peer scoring** in response to invalid (verification-failing) input — deferred to the sync
   / peer-management design, the next design area in sequence.
 

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -146,19 +146,21 @@ flowchart LR
 - **State supply.** The stage resolves validator registries (parent / target post-state) from
   the `watch`-published `Arc<ChainView>` snapshot — the read side of Decision 1 is the supply
   line.
-- **Pending lives in the stage.** A block whose parent post-state is not yet in view cannot be
-  verified; it waits in a bounded buffer inside the stage, keyed by parent root. The stage's
-  loop selects over its input channel *and* the snapshot's `watch::changed()`; on an update it
-  retries exactly the entries whose parent root became resolvable in the new snapshot. The
+- **Pending lives in the stage.** An item whose required post-state is not yet in view — a
+  block's *parent*, an attestation's *target* — cannot be verified; both kinds wait in the
+  same bounded buffer inside the stage, keyed by the awaited block root, under the same
+  policy. The stage's loop selects over its input channel *and* the snapshot's
+  `watch::changed()`; on an update it retries exactly the entries whose awaited root became
+  resolvable in the new snapshot. The
   buffer is parked storage, not a send path: it never blocks, and it holds only the one
   *recoverable* failure — parent post-state not yet in view. Every definitive failure —
   malformed SSZ, a root mismatch, an invalid signature or proof — drops the item on the spot,
   counted in metrics (peer scoring for invalid input is deferred to the sync /
   peer-management design). Overflow evicts count-bounded, in FIFO order of arrival into the
-  buffer, and eviction is silent: nothing re-requests an evicted block — like a gossip drop at
-  the network edge it is peer-recoverable, and range sync closes the gap when the chain
-  notices the missing ancestry. The chain task never holds unverified values — the invariant
-  admits no exceptions.
+  buffer, and eviction is silent: nothing re-requests an evicted item. An evicted block is
+  peer-recoverable — range sync closes the gap when the chain notices the missing ancestry —
+  and an evicted attestation's vote re-arrives embedded in an aggregate or a block body. The
+  chain task never holds unverified values — the invariant admits no exceptions.
 - **Propagation is not gated.** Matching the spec reference and all four surveyed clients,
   gossipsub is configured without message validation gating (`validate_messages()` is not
   enabled); forwarding proceeds independently of verification.
@@ -222,16 +224,20 @@ verification stage.
 
 ## Lifecycle
 
-Startup runs the dependency arrows backwards. Open the database and validate its identity
-values ([STORAGE.md](STORAGE.md)); the chain task loads the finalized anchor, reconstructs
-`Store` and `State`, and publishes the **first `ChainView`** — that publication is the
-readiness signal every other component waits on; only then do the verification stage, network,
-validator-duty, and RPC tasks start. Shutdown inverts it, and "drained" has a concrete signal:
-each producer drops its sender when it stops, and a closed-and-empty channel returns `None` to
-the receiver — no side-channel bookkeeping. Stop network intake first; the verification stage
-discards its in-flight and pending items (peer-recoverable, like any network-edge drop) and
-drops its sender; ② is drained completely (duty products are never dropped, in shutdown
-included); the chain task consumes ② and ③ to `None`, persists, and stops. Process-level
+Startup runs the dependency arrows backwards. The `verity` binary — the owner of all wiring —
+opens the database, validates its identity values ([STORAGE.md](STORAGE.md)), and hands the
+chain task its handle; the chain task loads the finalized anchor and reconstructs `Store` and
+`State` (initial values, `Store.time` included, per leanSpec's store initialization), then
+publishes the **first `ChainView`** — that publication is the readiness signal every other
+component waits on; only then do the verification stage, network, validator-duty, and RPC
+tasks start. Shutdown inverts it, and **channel closure is the only
+signal** — there is no shutdown broadcast. The binary stops the producers at the edge; each
+stopped producer drops its sender; every downstream task exits when its inputs return `None`
+(a closed-and-empty channel), with no side-channel bookkeeping. Concretely: the network task
+stops and drops its sender; the verification stage, on `None` from its input, discards its
+in-flight and pending items (peer-recoverable, like any network-edge drop) and drops its own
+sender, closing ③; the validator tasks stop, closing ②; the chain task consumes ② and ③ to
+`None` — duty products are never dropped, in shutdown included — then persists and stops. Process-level
 orchestration — signal handling, restart policy — belongs to the `verity` binary and is out of
 scope here.
 

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -238,7 +238,10 @@ chain task its handle; the chain task loads the finalized anchor and reconstruct
 `State` (initial values, `Store.time` included, per leanSpec's store initialization), then
 publishes the **first `ChainView`** — that publication is the readiness signal every other
 component waits on; only then do the verification stage, network, validator-duty, and RPC
-tasks start. Shutdown inverts it, and **channel closure is the only
+tasks **begin serving**. What the first `ChainView` gates is serving, not construction:
+initialization that needs no consensus state — validator key preparation above all
+([KEY_MANAGEMENT.md](KEY_MANAGEMENT.md)) — is spawned by the binary at process start and runs
+in parallel with this sequence. Shutdown inverts it, and **channel closure is the only
 signal** — there is no shutdown broadcast. The binary stops the producers at the edge; each
 stopped producer drops its sender; every downstream task exits when its inputs return `None`
 (a closed-and-empty channel), with no side-channel bookkeeping. Concretely: the network task

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -1,0 +1,178 @@
+# Verity Concurrency Model
+
+> Status: pre-implementation. Decisions ratified 2026-08-15. This document settles the question
+> [ARCHITECTURE.md](ARCHITECTURE.md) left open at the I/O Edge — which concurrency primitive
+> enforces the single-writer discipline, where signature and proof verification execute, and how
+> inbound work reaches the consensus state — and records the evidence the decisions rest on.
+
+The selection criterion throughout is **verifiability, not throughput**. The deductive proof
+stops at the FFI seam and structurally cannot reach concurrency (see
+[MODEL_CHECK.md](MODEL_CHECK.md)); the strongest tool available in this zone is exhaustive
+concurrency model checking (Loom), and Loom is only tractable on small interleaving spaces. Every
+choice below either eliminates a concurrency property outright (by making it a type-system fact)
+or confines the surviving interleavings to channel endpoints, where Loom can reach them.
+
+## What the spec constrains, and what it leaves free
+
+Read from [leanSpec](https://github.com/leanEthereum/leanSpec) `main` at
+`cce7955660b0d1983d4d104ef2f1cf7a839f4149`.
+
+**Constrained — ordering only:**
+
+- `on_block` calls `verify_signatures(signed_block, parent_state.validators)` *before*
+  `state_transition`, and a verification failure aborts the import with no store mutation
+  (`src/lean_spec/spec/forks/lstar/fork_choice.py`).
+- `on_gossip_attestation` fixes the order: validate the attestation data → verify the XMSS
+  signature → record it into the signature pool (aggregators only).
+- `on_tick(store, target_interval)` advances time one interval at a time — "runs every
+  interval's action without skipping any" (`src/lean_spec/spec/forks/lstar/timeline.py`).
+
+**Free — execution placement:**
+
+- The reference implementation is sequential Python; no thread, task, or pool placement is
+  specified for any of the above.
+- The reference gossipsub behavior forwards a received message to mesh peers *before* any
+  application-level verification runs (`src/lean_spec/node/networking/gossipsub/behavior.py`,
+  `_handle_message`). There is no eth2-style validate-before-propagate gate in the protocol, so
+  verification sits off the propagation latency path entirely — it has a throughput requirement
+  (keep up with slot cadence), not a latency one.
+
+**A structural fact that shapes the design:** verification is not self-contained. Verifying a
+block's aggregate proof requires the validator registry from the **parent block's post-state**;
+verifying an attestation signature requires the **target block's post-state**. Whatever component
+verifies must be able to read consensus state.
+
+## Survey — where other clients run verification
+
+All four public Lean clients were read at the revisions below. None gates gossip propagation on
+verification (consistent with the spec reference).
+
+| Client | Revision | Verification placement | Offload |
+|---|---|---|---|
+| [ethlambda](https://github.com/lambdaclass/ethlambda) | `e16f477` | inline in the store-owning chain actor | none for inbound; `spawn_blocking` only for the aggregator's own proof *production* |
+| [ream](https://github.com/ReamLabs/ream) | `842a709` | inline in the lean chain-service task | block proof verification moved to `spawn_blocking`, gated behind the `devnet5` feature |
+| [zeam](https://github.com/blockblaz/zeam) | `6495beb` | dedicated chain-worker thread | FFI verifier internally rayon-parallel, thread count configurable; FFI wrapper comments mandate "must not be called from the libxev thread" |
+| [qlean-mini](https://github.com/qdrvm/qlean-mini) | `55b6eb3` | inline on the single Boost.Asio io thread that also runs all network I/O | none |
+
+The trend line matters more than any single row: the clients that have started exercising the
+production signature scheme are the ones moving verification *off* their event-processing
+threads (ream's `devnet5`-gated `spawn_blocking`, zeam's explicit placement rule). The inline
+holdouts have not yet been exercised against production-scheme proofs, whose verification cost
+is what makes inline placement untenable — a 190 KB aggregate proof verified inline on
+qlean-mini's single io thread stalls all network I/O for the duration.
+
+## Decision 1 — the single writer is a task
+
+`verity-chain` runs as **one dedicated tokio task that owns `Store` and `State` outright**. No
+locks, no actor framework. Inbound work arrives over bounded channels ([Decision 3](#decision-3--three-inbound-channels-biased-select));
+reads leave as immutable snapshots — after each mutation the task publishes an
+`Arc<ChainView>` over a `watch` channel, and every consumer (validator duties, RPC, metrics,
+the verification stage) reads the snapshot current at its own read time.
+
+Why this form, against the two alternatives:
+
+- **Ownership deletes the property.** With the store owned by one task, single-writer stops
+  being a checked property and becomes an aliasing-xor-mutability fact — there is nothing left
+  for Loom to explore at the store itself. `Arc<RwLock<Store>>` keeps single-writer as a
+  convention, puts every read-modify-write interleaving into the model-checking space, and that
+  space exceeds what Loom can exhaust — assurance would degrade to randomized exploration
+  (Shuttle, unsound).
+- **Sequential FFI by construction.** The Lean theorems are about pure, sequential functions.
+  With one owning task, every call into Verity Consensus is serialized structurally, so the
+  proofs' premises hold by construction rather than by lock discipline.
+- **A total event order exists.** The inbound channels give the chain task a single linear
+  sequence of events, which supports the refinement claim this architecture aims at: *the
+  node's observable consensus state is the fold of the transition functions over the inbound
+  event sequence* — the same shape as the leanSpec/formal-leanSpec model, checked continuously
+  by the leanSpec fixture suite. Under a shared-lock design no canonical event order exists,
+  and linearizability itself becomes a proof obligation.
+- **No framework in the trust base.** An actor framework would add third-party concurrent
+  internals (mailboxes, supervision) that Loom cannot instrument, to solve a problem
+  `tokio::sync::mpsc`/`watch` already solve.
+
+## Decision 2 — verification is a stage in front of the chain task
+
+```mermaid
+flowchart LR
+    NET["network task<br/>topic check · dedup only"]
+    VER["verification stage<br/>SSZ decode · hash_tree_root<br/>XMSS / aggregate-proof verify<br/>(spawn_blocking)"]
+    CHAIN["chain task<br/>single writer<br/>STF · fork choice · persist"]
+    NET -->|"raw bytes, bounded mpsc<br/>(drops happen here, and only here)"| VER
+    VER -->|"Verified* types, bounded mpsc"| CHAIN
+    CHAIN -.->|"watch: Arc&lt;ChainView&gt;"| VER
+```
+
+- **Placement.** Between the network task and the chain task, as its own stage — the
+  `Codec + Crypto` participant in ARCHITECTURE.md's inbound-block sequence, made an execution
+  unit. The network task performs topic validation and deduplication only: no decode, no
+  crypto, so network liveness (mesh maintenance, keep-alives) never waits on a proof.
+- **Execution.** The stage runs decode, `hash_tree_root`, and XMSS / aggregate-proof
+  verification on `tokio::task::spawn_blocking`. **No rayon pool, and no promotion path to
+  one** — settled 2026-08-15 for design simplicity. (zeam demonstrates the rayon endpoint
+  works, but Verity does not carry the option.)
+- **The type boundary is the enforcement.** The channel into the chain task carries
+  `VerifiedBlock` / `VerifiedAttestation` values whose constructors are private to the
+  verification stage. An unverified value cannot reach the chain task, and therefore cannot
+  reach the FFI: the spec's verify-before-STF ordering holds by construction, and the boundary
+  harnesses (Kani / bolero, per MODEL_CHECK.md) cut exactly at these constructors.
+- **State supply.** The stage resolves validator registries (parent / target post-state) from
+  the `watch`-published `Arc<ChainView>` snapshot — the read side of Decision 1 is the supply
+  line.
+- **Pending lives in the stage.** A block whose parent post-state is not yet in view cannot be
+  verified; it waits in a bounded buffer inside the stage, keyed by parent root, retried when
+  the `ChainView` updates, oldest-evicted on overflow. The chain task never holds unverified
+  values — the invariant admits no exceptions.
+- **Propagation is not gated.** Matching the spec reference and all four surveyed clients,
+  gossipsub is configured without message validation gating (`validate_messages()` is not
+  enabled); forwarding proceeds independently of verification.
+
+**Deliberate deviation.** ream and zeam offload verification *inside* the import path; Verity
+hoists it into a stage *before* the importer. The motivation is not performance but Decision
+1's verification story: the chain task stays a loop of short sequential steps with no re-entry,
+which is what keeps its interleaving space Loom-sized and the fold-refinement claim clean.
+
+## Decision 3 — three inbound channels, biased select
+
+The chain task's inbox is three independent channels, not one. The unit of separation is
+**what full-queue behavior is correct**, which differs irreconcilably per source:
+
+| Channel | Carries | Primitive | Full-queue behavior |
+|---|---|---|---|
+| ① clock | "the clock reached interval N" | `watch` (capacity 1, latest wins) | coalesce — never lost, never stale |
+| ② local | own proposed `SignedBlock`, own `SignedAttestation`, completed `SignedAggregatedAttestation` from the aggregation worker | small bounded `mpsc` | sender awaits — **never dropped** |
+| ③ network | `VerifiedBlock` / `VerifiedAttestation` / verified aggregates, from gossip and range-sync responses | bounded `mpsc` | sender (verification stage) awaits; backpressure propagates to the network edge, where raw gossip is dropped by `try_send` |
+
+The chain task reads all three in a `tokio::select!` with `biased` ordering ① → ② → ③.
+
+- **① is sound as latest-only** because of the spec's own catch-up semantics: `on_tick` steps
+  to the target one interval at a time and skips no interval's action, so delivering only the
+  newest target loses nothing. The tick is not a timer callback — it drives genuine store
+  mutations (ingest pending attestations at intervals 0 and 4, trigger aggregation at 2,
+  advance the safe target at 3), which is why it enters the single writer's inbox at all.
+- **② is never dropped** because its contents are the node's own duty products: no other peer
+  holds them, range sync cannot recover them, and losing one is a missed duty. Its flow rate is
+  structurally tiny (a handful of events per slot), so a small buffer with an awaiting sender
+  costs nothing. Aggregate-proof *production* — seconds of zk proving — follows the ethlambda
+  pattern: the tick triggers it, a `spawn_blocking` worker computes it, and the finished
+  aggregate re-enters through ②.
+- **③ is the only place load is shed, and only pre-verification.** Backpressure runs backwards
+  through the pipeline so that when the node falls behind, what gets dropped is raw bytes at
+  the network edge — never a value that verification effort was already spent on. Everything
+  dropped there is peer-recoverable by construction: `BlocksByRange` responders MUST serve
+  3,600 slots (leanSpec floor) and Verity itself retains proofs for 21,600 slots
+  ([STORAGE.md](STORAGE.md)). Range sync is pull-based, so it cannot flood ③ beyond what the
+  node itself requested.
+- **Biased ordering cannot starve** ① or ② in practice — their rates are bounded by the slot
+  clock, not the network — and the bias is the desired property stated directly: time and the
+  node's own duties are processed ahead of any volume of gossip.
+
+## Verification obligations introduced by this model
+
+What this document adds to the [MODEL_CHECK.md](MODEL_CHECK.md) map, concretely:
+
+- **Loom targets:** the chain task's select loop, channel endpoints, and snapshot publication
+  — the only interleaving spaces this design leaves alive.
+- **Refinement check:** chain-task behavior as a fold of the transition functions over the
+  inbound event order, exercised end-to-end by the leanSpec fixture suite in CI.
+- **Kani / bolero targets:** the `Verified*` constructor boundary in the verification stage —
+  no-panic-on-any-input for decode and proof verification, and rejection ⇒ no store effect.

--- a/KEY_MANAGEMENT.md
+++ b/KEY_MANAGEMENT.md
@@ -1,0 +1,198 @@
+# Validator Key Management — XMSS Signing State
+
+> Status: pre-implementation. Decisions ratified 2026-08-16. This document settles how Verity
+> manages its validators' XMSS keys: the crash-safe no-reuse guarantee, key material loading,
+> and preparation scheduling. It extends [STORAGE.md](STORAGE.md) with one column family and
+> plugs into the runtime model of [CONCURRENCY.md](CONCURRENCY.md).
+
+The stake is unusual and worth stating first. XMSS is a **stateful one-time signature
+scheme**: signing two *different* messages with the same key at the same epoch does not incur
+a protocol penalty — the lean protocol has no slashing at all — it **breaks the key
+cryptographically**, exposing enough one-time-chain state that signatures can be forged. The
+asset being protected is the secret key's soundness itself. Everything below is sized against
+that, not against a fine.
+
+## What the spec and the library fix
+
+Read at leanSpec `main` = `cce7955`, leanSig `main` = `c08a3ba`.
+
+**leanSpec** (`src/lean_spec/spec/crypto/xmss/`, `.../lstar/containers/validator.py`):
+
+- **Epoch is the slot, exactly.** `sign()` and `verify()` take the consensus `Slot` and pass it
+  unmodified as the XMSS epoch index. No offset, no mapping.
+- **Two independent keys per validator** — `attestation_public_key` and `proposal_public_key`
+  in the registry entry. A proposer signs a block *and* an attestation in its slot; one
+  one-time key cannot cover both, so the spec separates the roles at the key level and the
+  reference node refuses to load identical keys for both roles.
+- **Signatures are deterministic** in `(secret_key, slot, message)`: re-signing the *same*
+  message at the same slot yields the identical signature and is harmless. The prohibition is
+  precisely: *never two different messages for the same (key, slot)*.
+- **Key lifetime is a non-issue**: production `LOG_LIFETIME = 32` → 2³² slots ≈ 544 years at
+  4-second slots. There is no key-rotation mechanism in the spec, and none is needed.
+- **The protocol tolerates equivocation**: fork choice accepts two blocks from one proposer at
+  one slot; no slashing container exists. The reference node keeps signing state in memory
+  only and persists nothing across restarts.
+
+**leanSig** (Rust, the library `verity-crypto` wraps):
+
+- `sign(sk: &SecretKey, epoch: u32, msg)` takes an **immutable** reference and has **no
+  anti-reuse guard whatsoever** — same `(sk, epoch)` with a second message silently produces
+  the forgery catastrophe. The README makes non-reuse entirely the caller's responsibility.
+- `sign` **panics** (`assert!`) when the epoch is outside the key's activation interval or its
+  *prepared interval* — it does not return an error.
+- The ~33.5 MB secret key holds a top Merkle tree plus a sliding window of **two bottom
+  trees**, each covering 2¹⁶ = 65,536 epochs. The prepared (signable) window is therefore
+  131,072 slots ≈ **6 days**. `advance_preparation(&mut self)` slides the window one bottom
+  tree (≈ 3 days) forward by rebuilding 65,536 one-time chains — a genuinely expensive,
+  rayon-parallel computation. The window state is derived: it can always be recomputed from
+  the PRF seed, at the cost of one rebuild per 3-day step since the key's activation.
+- Canonical serialization is hand-written SSZ (`ethereum_ssz`). **No loader from the
+  ecosystem's key-file formats exists in any repository** — leanSig ships none, and
+  `leansig-test-keys` is data only (8 production-scheme keypairs, attestation role only,
+  JSON-hex envelopes produced by leanSpec's Python tooling).
+
+## Survey — what other clients do
+
+Read at ethlambda `e16f477`, ream `842a709`, zeam `6495beb`, qlean-mini `55b6eb3`.
+
+| Client | Persisted signing state | Anti-double-sign guard | `advance_preparation` |
+|---|---|---|---|
+| ethlambda | none | none | per-slot pre-advance on the chain actor + startup catch-up |
+| ream | none | in-memory block-prebuild flag only | **never called in production code** |
+| zeam | none | none; **falls back to one key for both roles** when only one file is present | lazily, inline inside `sign`, under the signing mutex |
+| qlean-mini | none | none | none |
+
+Every client derives the signing epoch from the wall clock at the moment of signing and
+persists nothing. The entire ecosystem's no-reuse guarantee is an implicit bet on clock
+monotonicity. The survey also produced two live counterexamples of what unmanaged key state
+looks like: ream will panic at the prepared-window boundary because nothing ever advances it,
+and zeam's single-key fallback reproduces exactly the dual-role reuse the spec's reference
+loader rejects.
+
+Three scenarios break the clock-monotonicity bet:
+
+1. **Intra-slot crash-restart.** The process restarts within one 4-second slot; the node's
+   view (head) has changed; the validator re-attests the same slot with different data — two
+   different messages under one `(key, slot)`. A restarted proposer rebuilding its block hits
+   the same trap.
+2. **Clock step-back** (NTP correction, VM resume) — the derived slot rewinds into
+   already-signed territory.
+3. **Operational error** — restoring a datadir from backup, or accidentally running two
+   instances with the same keys.
+
+## Decision 1 — signing watermark, persist-before-sign
+
+Verity persists a **signing watermark**: the last slot signed, per `(validator, role)`, in a
+dedicated `verity-db` column family (`signing_watermarks`, defined in
+[STORAGE.md](STORAGE.md#column-families)). The signing path enforces, in this order:
+
+1. derive the message for slot `s`;
+2. require `s > watermark(validator, role)` — **equality is refused**, even for a
+   byte-identical message;
+3. durably write `watermark := s` (write-ahead log + fsync);
+4. only then sign and release the signature to the rest of the process.
+
+A signature therefore cannot exist — not in channel ②, not on the wire — unless a watermark
+at or above its slot is already on disk. A crash between steps 3 and 4 costs exactly one
+duty (one vote or one proposal in the crash slot), which carries no protocol penalty; the
+alternative it buys off is key compromise. Refusing equality (rather than allowing the
+idempotent re-sign leanSig's determinism would permit) is deliberate: the rescue value of one
+duty in a 4-second-slot protocol is negligible, and slot-only state keeps the mechanism two
+`u64`s per validator instead of a message-root log.
+
+- **Ownership.** The validator signing path is the sole writer of `signing_watermarks` — the
+  one documented exception to the chain task's write ownership (see STORAGE.md). This keeps
+  the check-write-sign sequence synchronous inside the signing path; routing it through the
+  chain task would add a query channel that [CONCURRENCY.md](CONCURRENCY.md) deliberately
+  does not have. One keyspace, one writer still holds — per family, not per database.
+- **Write cost.** At most two fsynced single-row writes per slot per validator; negligible
+  against the storage engine's proof workload.
+- **Startup.** Watermarks are read before validator readiness. If a watermark is *ahead* of
+  the current wall-clock slot, the clock has rewound (scenario 2 or 3): the node fails closed
+  — duties for that validator stay disabled until the clock passes the watermark, and the
+  condition is logged loudly. It is never treated as corruption to repair automatically.
+- **Scenario coverage.** (1) is covered by the equality refusal, (2) by the startup check plus
+  the per-sign comparison, (3) partially: a restored backup restores an old watermark, but the
+  per-sign comparison still refuses any slot at or below it *if the restored node's clock is
+  honest*; two concurrent instances sharing keys are out of scope of any local mechanism and
+  remain an operator responsibility, stated in the operator documentation.
+
+## Decision 2 — key material: follow the de-facto standard, harden the loader
+
+The ecosystem has a de-facto standard Verity does not deviate from: lean-quickstart's genesis
+generator emits `validator-config.yaml`, `annotated_validators.yaml`, and a `hash-sig-keys/`
+directory of leanSig-SSZ secret-key files, and all four surveyed clients consume variants of
+it. Interop with that tooling is the entire point of key loading, so:
+
+- **Format and layout: lean-quickstart compatible.** leanSig-SSZ key files under
+  `hash-sig-keys/`, indexed by the YAML manifest. No encrypted keystore (no EIP-2335
+  analogue): devnet keys are disposable and no ecosystem precedent exists; revisit only when
+  a persistent network makes keys worth stealing.
+- **The loader is Verity's own, in `verity-crypto`** — none exists anywhere to reuse. The
+  manifest's role declarations are authoritative; file-name substring inference (the
+  ethlambda/zeam convention) is not used.
+- **Startup rejections, fail-closed.** Missing either role's key, identical attestation and
+  proposal keys (zeam's fallback is explicitly the counterexample), or a loaded public key
+  that does not match the manifest ⇒ refuse to start. These are the reference loader's checks,
+  kept.
+- **Fully memory-resident**, like every surveyed client: production scheme ≈ 33.5 MB × 2
+  roles ≈ **67 MB per validator** (64 validators ≈ 4.3 GB). That linear bound is recorded
+  here as fact; mmap or partial loading is not built until a measured need exists.
+- **CI note.** `leansig-test-keys` provides 8 production-scheme keypairs for the attestation
+  role only; proposal-role keys for tests come from lean-quickstart's generator.
+
+## Decision 3 — preparation scheduling
+
+The prepared window is 6 days wide and costs one heavy rebuild per 3-day step; ream (never
+advances → future panic) and zeam (advances inside `sign` → the signing call stalls at the
+window boundary) mark the two failure modes to design out.
+
+- **Steady state.** Each validator-duty tick performs a cheap comparison: has the current
+  slot passed the midpoint of this key's prepared interval? If so, an advance is started on
+  `spawn_blocking` — leanSig's own intended cadence (≈ every 3 days per key, with ≈ 3 days of
+  margin).
+- **Clone-advance-swap: signing never waits.** `advance_preparation` needs `&mut`; handing
+  the live key to a worker (or locking it) would stall signing for the rebuild duration. So
+  the worker receives a **clone** (a ~33.5 MB memcpy), advances the clone off-thread while
+  the original keeps signing in the still-valid old window, and the validator task swaps the
+  advanced clone in between sign calls. The task is single-threaded, so the swap is a plain
+  field replacement with no torn state. Both key objects are the same key; no-reuse is
+  enforced by the watermark on the signing path, independent of which clone signs.
+- **Persist the advanced key.** After each successful advance, the key file is rewritten
+  atomically (temp file + rename; public key verified against the manifest on load). No
+  surveyed client does this, and the omission is why a year-old node would owe ~120
+  consecutive rebuilds (minutes to hours) at startup: the on-disk key never moves off its
+  activation window. With periodic persistence, startup catch-up is bounded by the downtime,
+  not the node's age. Safety is unaffected — a stale key file only costs extra catch-up, and
+  the watermark, not the key file, carries the no-reuse guarantee.
+- **Panic containment.** leanSig's `sign` asserts; Runtime Shell code must not panic. The
+  `verity-crypto` wrapper checks the activation and prepared intervals first and returns a
+  typed error — the assert becomes unreachable, and Kani's target is exactly that
+  unreachability.
+- **Startup order.** Load keys → read watermarks (clock-rewind check) → advance each key
+  until the current slot is inside its prepared interval (on `spawn_blocking`; may take a
+  while after long downtime, progress logged) → only then validator readiness. This extends
+  the [CONCURRENCY.md](CONCURRENCY.md#lifecycle) startup sequence: validator-duty tasks wait
+  on the first `ChainView` *and* on their keys being prepared.
+
+## Deliberately out of scope
+
+- **Remote signers** and any signing API surface.
+- **Key generation ceremony / tooling** — devnet keys come from lean-quickstart's generator;
+  Verity ships no keygen.
+- **Hot key reload** — key set changes require a restart.
+- **A separate slashing-protection database** — the protocol has no slashing; the watermark
+  *is* the double-sign protection, and an eth2-style interchange format has no counterpart
+  here yet.
+
+## Verification obligations introduced by this model
+
+- **The watermark ordering property** is the consensus-critical invariant of this document:
+  *no signature is released whose slot is not durably watermarked*. It is a
+  sequential-ordering property of the signing path, targeted with property tests
+  (crash-injection between write and release) rather than Loom — no concurrency is involved.
+- **Kani / bolero:** the loader (no-panic-on-any-input over manifest and key bytes; reject ⇒
+  no partial registry) and the sign wrapper (leanSig's asserts unreachable given the
+  wrapper's pre-checks).
+- **The swap** needs no Loom target: clone and swap happen on one task; the only shared edge
+  is the `spawn_blocking` result channel, already covered by the CONCURRENCY.md targets.

--- a/KEY_MANAGEMENT.md
+++ b/KEY_MANAGEMENT.md
@@ -182,16 +182,16 @@ window boundary) mark the two failure modes to design out.
   typed error — the assert becomes unreachable, and Kani's target is exactly that
   unreachability.
 - **Startup order — who runs it, and when.** Key preparation is `verity-validator`'s own
-  initialization, running as its own task: the `verity` binary hands it the key directory
-  and the `signing_watermarks` handle at construction, and it then loads keys, reads
-  watermarks (clock-rewind check), and advances each key on `spawn_blocking` until the
-  current slot is inside its prepared interval (which may take a while after long downtime —
-  progress is logged). None of this needs consensus state, so it runs **in parallel with**
-  the chain task's own startup, not ordered against `ChainView` publication. The duty loop
-  begins serving only when **both** gates are open: the first `ChainView` has been observed
-  on its `watch` receiver (the CONCURRENCY.md readiness signal, unchanged) *and* key
-  preparation has completed. This is a join of two independent conditions, not an extra step
-  inserted into the [CONCURRENCY.md](CONCURRENCY.md#lifecycle) sequence.
+  initialization: the `verity` binary **spawns the validator task at process start, alongside
+  the chain task**, handing it the key directory and the `signing_watermarks` handle at
+  construction. The task then loads keys, reads watermarks (clock-rewind check), and advances
+  each key on `spawn_blocking` until the current slot is inside its prepared interval (which
+  may take a while after long downtime — progress is logged). None of this needs consensus
+  state, so it runs in parallel with the chain task's own startup — per
+  [CONCURRENCY.md](CONCURRENCY.md#lifecycle), what the first `ChainView` gates is *serving*,
+  not construction. The duty loop begins serving only when **both** gates are open: the first
+  `ChainView` has been observed on its `watch` receiver (the CONCURRENCY.md readiness signal,
+  unchanged) *and* key preparation has completed — a join of two independent conditions.
 
 ## Deliberately out of scope
 

--- a/KEY_MANAGEMENT.md
+++ b/KEY_MANAGEMENT.md
@@ -107,10 +107,14 @@ duty in a 4-second-slot protocol is negligible, and slot-only state keeps the me
   does not have. One keyspace, one writer still holds — per family, not per database.
 - **Write cost.** At most two fsynced single-row writes per slot per validator; negligible
   against the storage engine's proof workload.
-- **Startup.** Watermarks are read before validator readiness. If a watermark is *ahead* of
-  the current wall-clock slot, the clock has rewound (scenario 2 or 3): the node fails closed
-  — duties for that validator stay disabled until the clock passes the watermark, and the
-  condition is logged loudly. It is never treated as corruption to repair automatically.
+- **Startup.** Watermarks are read before validator readiness. An **absent row is the normal
+  first-run state** — the validator has never signed; signing is permitted and the first
+  signature creates the row. A **present row with `watermark ≥ current_slot`** means the
+  clock has rewound relative to a signature that already exists (scenario 2 or 3): the node
+  fails closed — duties for that validator stay disabled until `current_slot > watermark`,
+  and the condition is logged loudly. (`≥`, not `>`: at equality the sign path would refuse
+  anyway, so readiness gates on the same comparison the sign path enforces.) It is never
+  treated as corruption to repair automatically.
 - **Scenario coverage.** (1) is covered by the equality refusal, (2) by the startup check plus
   the per-sign comparison, (3) partially: a restored backup restores an old watermark, but the
   per-sign comparison still refuses any slot at or below it *if the restored node's clock is
@@ -154,26 +158,40 @@ window boundary) mark the two failure modes to design out.
 - **Clone-advance-swap: signing never waits.** `advance_preparation` needs `&mut`; handing
   the live key to a worker (or locking it) would stall signing for the rebuild duration. So
   the worker receives a **clone** (a ~33.5 MB memcpy), advances the clone off-thread while
-  the original keeps signing in the still-valid old window, and the validator task swaps the
-  advanced clone in between sign calls. The task is single-threaded, so the swap is a plain
-  field replacement with no torn state. Both key objects are the same key; no-reuse is
-  enforced by the watermark on the signing path, independent of which clone signs.
-- **Persist the advanced key.** After each successful advance, the key file is rewritten
-  atomically (temp file + rename; public key verified against the manifest on load). No
-  surveyed client does this, and the omission is why a year-old node would owe ~120
-  consecutive rebuilds (minutes to hours) at startup: the on-disk key never moves off its
-  activation window. With periodic persistence, startup catch-up is bounded by the downtime,
-  not the node's age. Safety is unaffected — a stale key file only costs extra catch-up, and
-  the watermark, not the key file, carries the no-reuse guarantee.
+  the original keeps signing, and the validator task swaps the advanced clone in between
+  sign calls. The task is single-threaded, so the swap is a plain field replacement with no
+  torn state. **Why the original stays valid throughout:** the windows overlap. Advancing at
+  the midpoint means the current slot sits in the old window's *second* bottom tree; the
+  advance produces a window of that same second tree plus the next one. Old and new windows
+  therefore share ≈ 3 days of coverage around the current slot — there is no moment at which
+  either key object is unable to sign for "now", however long the rebuild takes within that
+  margin. Both key objects are the same key; no-reuse is enforced by the watermark on the
+  signing path, independent of which clone signs.
+- **Persist the advanced key.** The `spawn_blocking` worker itself, as the final step of the
+  advance job and *before* returning the advanced clone, rewrites the key file atomically
+  (temp file + rename; public key verified against the manifest on load) — so a key the
+  validator task swaps in is already durable. A failed file write is logged and is
+  **non-fatal**: the swap still proceeds, because persistence only bounds restart cost while
+  the watermark, not the key file, carries the no-reuse guarantee; a stale file costs extra
+  catch-up and nothing else. No surveyed client persists advanced keys, and the omission is
+  why a year-old node would owe ~120 consecutive rebuilds (minutes to hours) at startup: the
+  on-disk key never moves off its activation window. With periodic persistence, startup
+  catch-up is bounded by the downtime, not the node's age.
 - **Panic containment.** leanSig's `sign` asserts; Runtime Shell code must not panic. The
   `verity-crypto` wrapper checks the activation and prepared intervals first and returns a
   typed error — the assert becomes unreachable, and Kani's target is exactly that
   unreachability.
-- **Startup order.** Load keys → read watermarks (clock-rewind check) → advance each key
-  until the current slot is inside its prepared interval (on `spawn_blocking`; may take a
-  while after long downtime, progress logged) → only then validator readiness. This extends
-  the [CONCURRENCY.md](CONCURRENCY.md#lifecycle) startup sequence: validator-duty tasks wait
-  on the first `ChainView` *and* on their keys being prepared.
+- **Startup order — who runs it, and when.** Key preparation is `verity-validator`'s own
+  initialization, running as its own task: the `verity` binary hands it the key directory
+  and the `signing_watermarks` handle at construction, and it then loads keys, reads
+  watermarks (clock-rewind check), and advances each key on `spawn_blocking` until the
+  current slot is inside its prepared interval (which may take a while after long downtime —
+  progress is logged). None of this needs consensus state, so it runs **in parallel with**
+  the chain task's own startup, not ordered against `ChainView` publication. The duty loop
+  begins serving only when **both** gates are open: the first `ChainView` has been observed
+  on its `watch` receiver (the CONCURRENCY.md readiness signal, unchanged) *and* key
+  preparation has completed. This is a join of two independent conditions, not an extra step
+  inserted into the [CONCURRENCY.md](CONCURRENCY.md#lifecycle) sequence.
 
 ## Deliberately out of scope
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -54,7 +54,12 @@ corruption, not an absent value.
 | `fork_choice_blocks` | `slot_be ‖ block_root` | `parent_root` | Processed fork-choice tree; retained |
 | `known_votes` | `validator_index_be` | `SSZ(AttestationData)` | Latest counted vote per validator |
 | `pending_votes` | `validator_index_be` | `SSZ(AttestationData)` | Latest not-yet-counted vote per validator |
+| `signing_watermarks` | `validator_index_be ‖ role` | `SSZ(uint64)` last-signed slot | Local XMSS no-reuse state; retained; see [Key Management](KEY_MANAGEMENT.md) |
 | `metadata` | fixed ASCII key | typed scalar or SSZ value | Database identity and current view pointers |
+
+`role` is one byte: `0x00` attestation, `0x01` proposal. `signing_watermarks` rows exist only
+for validators this node operates; they are never pruned and never touched by any range
+tombstone.
 
 Blocks are stored unsigned: header and body are separate rows, while the signed envelope's aggregate
 proof is the `block_proofs` row. `MultiMessageAggregate` is persisted as the entire SSZ container,
@@ -128,8 +133,12 @@ automatically: an operator must select a new directory and explicitly checkpoint
 ## Writer, batches, and restart
 
 `verity-chain` — initially the chain module inside the single `verity-consensus` crate — owns the
-only write capability. P2P, RPC, validator duties, and maintenance submit requests to it rather than
-writing the backend directly. Read-only snapshot views may run concurrently.
+only write capability, with **one documented exception**: `signing_watermarks` is written solely by
+the validator signing path, because its persist-before-sign ordering must stay synchronous inside
+that path (see [Key Management](KEY_MANAGEMENT.md#decision-1--signing-watermark-persist-before-sign)).
+The discipline is one writer per column family, not one writer per database. Watermark writes always
+fsync. P2P, RPC, validator duties, and maintenance otherwise submit requests to the chain writer
+rather than writing the backend directly. Read-only snapshot views may run concurrently.
 
 A processed block commits in one cross-column-family `WriteBatch`:
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -16,3 +16,8 @@ ser = "ser"
 # "symetric" — the real directory name in leanMultisig (`crates/backend/symetric`), misspelled
 # upstream. Correcting it in our docs would point readers at a path that does not exist.
 symetric = "symetric"
+
+[default.extend-identifiers]
+# Abbreviated git commit SHA of leanEthereum/leanSig cited in KEY_MANAGEMENT.md; the
+# trailing "ba" is not a typo of "by"/"be".
+c08a3ba = "c08a3ba"


### PR DESCRIPTION
## Summary

Settles design area ② of the client-specific design campaign: management of stateful XMSS validator keys — the crash-safe no-reuse guarantee, key material loading, and prepared-window scheduling. Adds `KEY_MANAGEMENT.md` and extends `STORAGE.md` with the `signing_watermarks` column family.

**Stacked on #20** (references `CONCURRENCY.md`); will auto-retarget to `main` when #20 merges.

The framing fact: the lean protocol has no slashing. Signing two different messages at one (key, slot) costs no fine — it cryptographically breaks the key (forgeability). The design protects the key's soundness.

## Decisions

1. **Signing watermark, persist-before-sign.** Last-signed slot per (validator, role) in a dedicated column family, written with WAL + fsync **before** any signature leaves the process. Equality refused even for byte-identical messages (worst case: one duty lost in a crash slot). Clock-rewind detected at startup fails closed. The validator signing path is the family's sole writer — the documented exception to the chain writer's ownership: one writer per column family, not per database (keeps CONCURRENCY.md's no-query-channel rule intact).
2. **Key material.** lean-quickstart-compatible layout (the de-facto standard all four clients consume); loader written in `verity-crypto` (none exists anywhere in the ecosystem); manifest roles authoritative, no filename inference; fail-closed startup rejects (missing role key / identical keys for both roles / pubkey mismatch); fully memory-resident with the ~67 MB/validator bound recorded.
3. **Preparation scheduling.** Midpoint check per duty tick → advance on `spawn_blocking`; **clone-advance-swap** so signing never waits on the ~3-daily bottom-tree rebuild; advanced key persisted by atomic replace (bounds startup catch-up by downtime, not node age — no surveyed client does this); panic-containing sign wrapper (leanSig asserts made unreachable); startup catch-up gated before validator readiness, extending CONCURRENCY.md's lifecycle.

## Evidence

- leanSpec `cce7955`: epoch = slot exactly; two independent keys per validator (proposer signs block + attestation in one slot); deterministic signatures — the prohibition is precisely 'two *different* messages per (key, slot)'; no slashing; reference node persists no signing state.
- leanSig `c08a3ba`: no anti-reuse guard at all; `sign` panics outside the ~6-day prepared window; `advance_preparation` rebuilds a 65,536-leaf bottom tree per 3-day step; canonical SSZ serialization; no key loader exists in any repo.
- Four-client survey (ethlambda `e16f477`, ream `842a709`, zeam `6495beb`, qlean-mini `55b6eb3`): all rely solely on wall-clock monotonicity; ream never calls `advance_preparation` in production code (future panic); zeam falls back to one key for both roles when only one file is present — exactly the reuse pattern the spec's reference loader rejects.