### PR TITLE
feat(chain): add justification candidacy and the slot clock

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,14 +97,22 @@ jobs:
           fi
           sha256sum -c crates/verity-types/fixtures.sha256
 
-      - name: Extract SSZ container vectors
+      # Only the suites a crate actually consumes. tar fails when a pattern matches nothing,
+      # so a suite leanSpec renames or drops breaks the job here rather than quietly halving
+      # the vector count downstream.
+      - name: Extract consumed fixture suites
         run: |
           mkdir -p fixtures-prod
           tar -xzf fixtures-prod-scheme.tar.gz -C fixtures-prod \
             --wildcards '*/ssz/*/ssz/test_consensus_containers/*.json' \
-            '*/ssz/*/ssz/test_xmss_containers/*.json'
+            '*/ssz/*/ssz/test_xmss_containers/*.json' \
+            '*/justifiability/*/state_transition/test_justifiability/*.json' \
+            '*/slot_clock/*/chain/test_slot_clock/*.json'
 
-      - name: SSZ fixture conformance
+      # The whole workspace, so a crate that starts consuming fixtures is picked up without
+      # editing this job. Every fixture test skips when VERITY_FIXTURES is unset, which is
+      # what keeps the fast gate fast.
+      - name: Fixture conformance
         env:
           VERITY_FIXTURES: ${{ github.workspace }}/fixtures-prod
-        run: cargo test -p verity-types --test ssz_fixtures -- --nocapture
+        run: cargo test --workspace -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "verity-chain"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "verity-types",
+]
+
+[[package]]
 name = "verity-types"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,10 @@ libp2p = { version = "0.56", default-features = false, features = [
 # See ARCHITECTURE.md "Storage engine and retention" for why an LSM engine and not a B-tree one.
 rocksdb = "0.24"
 
+# --- Workspace members ---------------------------------------------------------------------
+# Declared here so a member's path appears in one place, like every external dependency.
+verity-types = { path = "crates/verity-types" }
+
 # --- Test-only -----------------------------------------------------------------------------
 # Scoped to SSZ round-trip properties in `verity-types`. This is a deliberate, narrow exception
 # to the kickoff decision that no verification harness ships on day one: a codec is one of the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,11 @@ rocksdb = "0.24"
 
 # --- Workspace members ---------------------------------------------------------------------
 # Declared here so a member's path appears in one place, like every external dependency.
-verity-types = { path = "crates/verity-types" }
+#
+# `version` is redundant for a path dependency inside the workspace, but omitting it leaves a
+# wildcard requirement, which `deny.toml` bans for the same reason it bans one on a git
+# dependency: nothing in the manifest then states what the dependent was built against.
+verity-types = { path = "crates/verity-types", version = "0.0.0" }
 
 # --- Test-only -----------------------------------------------------------------------------
 # Scoped to SSZ round-trip properties in `verity-types`. This is a deliberate, narrow exception

--- a/crates/verity-chain/Cargo.toml
+++ b/crates/verity-chain/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "verity-chain"
+description = "Consensus decisions over the container types: justification candidacy and the slot clock."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+
+# Pure decisions over `verity-types` shapes. No storage, no networking, no cryptography, and
+# no wall clock: every function here takes the time it should reason about as an argument.
+[dependencies]
+verity-types.workspace = true
+
+[dev-dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/verity-chain/src/justification.rs
+++ b/crates/verity-chain/src/justification.rs
@@ -18,7 +18,7 @@ pub const IMMEDIATE_JUSTIFICATION_WINDOW: u64 = 5;
 ///
 /// Returns `None` for a slot at or behind the boundary: those are justified by definition and
 /// carry no tracked index. Slot `finalized + 1` maps to index 0.
-#[must_use]
+#[must_use = "this only locates the bit; reading or setting it in the state is the caller's job"]
 pub fn justified_index_after(slot: Slot, finalized: Slot) -> Option<usize> {
     if slot.0 <= finalized.0 {
         return None;
@@ -33,7 +33,7 @@ pub fn justified_index_after(slot: Slot, finalized: Slot) -> Option<usize> {
 /// Per 3SF-mini, the distance from the finalized slot must be within the immediate window, a
 /// perfect square, or a pronic number (`n(n+1)`: 6, 12, 20, …). A slot behind the boundary is
 /// already settled and is never a future candidate.
-#[must_use]
+#[must_use = "this answers the question; it neither records the verdict nor rejects the slot"]
 pub fn is_justifiable_after(slot: Slot, finalized: Slot) -> bool {
     if slot.0 < finalized.0 {
         return false;
@@ -61,7 +61,7 @@ pub fn is_justifiable_after(slot: Slot, finalized: Slot) -> bool {
 ///
 /// Selection is by slot alone. That the candidate descends from `current` is a separate store
 /// invariant and is not checked here.
-#[must_use]
+#[must_use = "this returns the advanced checkpoint; neither argument is modified"]
 pub fn advance_checkpoint(current: Checkpoint, candidate: Checkpoint) -> Checkpoint {
     if candidate.slot.0 > current.slot.0 {
         candidate

--- a/crates/verity-chain/src/justification.rs
+++ b/crates/verity-chain/src/justification.rs
@@ -1,0 +1,160 @@
+//! Justification candidacy — which slots may be justified after a given finalized boundary.
+//!
+//! leanSpec defines these as methods on `Slot` and `Checkpoint`. Verity keeps them off the
+//! container types on purpose: they are the leading candidates to move into the Verified
+//! Core, and binding them to `verity-types` would make every crate that merely uses a slot
+//! link the FFI boundary once that move happens. See `ARCHITECTURE.md`, "Capability
+//! contracts".
+//!
+//! Transcribed from leanSpec `src/lean_spec/spec/forks/lstar/slot.py`, read at commit
+//! `0588c2d215a955a516378677a92db2a5666802f3`.
+
+use verity_types::{Checkpoint, Slot};
+
+/// Slots within this distance of the finalized boundary are always justification candidates.
+pub const IMMEDIATE_JUSTIFICATION_WINDOW: u64 = 5;
+
+/// Position of `slot` in the justification bitfield anchored at `finalized`.
+///
+/// Returns `None` for a slot at or behind the boundary: those are justified by definition and
+/// carry no tracked index. Slot `finalized + 1` maps to index 0.
+#[must_use]
+pub fn justified_index_after(slot: Slot, finalized: Slot) -> Option<usize> {
+    if slot.0 <= finalized.0 {
+        return None;
+    }
+    // The subtraction cannot underflow: the branch above established `slot > finalized`, so
+    // the difference is at least 1 and the decrement stays in range.
+    Some((slot.0 - finalized.0 - 1) as usize)
+}
+
+/// Whether `slot` is a valid justification candidate after `finalized`.
+///
+/// Per 3SF-mini, the distance from the finalized slot must be within the immediate window, a
+/// perfect square, or a pronic number (`n(n+1)`: 6, 12, 20, …). A slot behind the boundary is
+/// already settled and is never a future candidate.
+#[must_use]
+pub fn is_justifiable_after(slot: Slot, finalized: Slot) -> bool {
+    if slot.0 < finalized.0 {
+        return false;
+    }
+    let delta = slot.0 - finalized.0;
+
+    // Most candidates land here, so this runs before either square root.
+    if delta <= IMMEDIATE_JUSTIFICATION_WINDOW {
+        return true;
+    }
+
+    // Squares 1 and 4 already returned above; the first to reach here is 9.
+    if is_perfect_square(u128::from(delta)) {
+        return true;
+    }
+
+    // For a pronic delta = n(n+1), 4*delta + 1 = (2n+1)^2. Widened to u128 because 4*delta + 1
+    // overflows u64 near the top of the slot range. The parity test mirrors leanSpec; an odd
+    // square always has an odd root, so it never changes the answer on its own.
+    let discriminant = 4 * u128::from(delta) + 1;
+    is_perfect_square(discriminant) && discriminant.isqrt() % 2 == 1
+}
+
+/// The later of two checkpoints, keeping `current` on a slot tie.
+///
+/// Selection is by slot alone. That the candidate descends from `current` is a separate store
+/// invariant and is not checked here.
+#[must_use]
+pub fn advance_checkpoint(current: Checkpoint, candidate: Checkpoint) -> Checkpoint {
+    if candidate.slot.0 > current.slot.0 {
+        candidate
+    } else {
+        current
+    }
+}
+
+fn is_perfect_square(value: u128) -> bool {
+    let root = value.isqrt();
+    root * root == value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{advance_checkpoint, is_justifiable_after, justified_index_after};
+    use verity_types::{Checkpoint, Slot};
+
+    #[test]
+    fn should_report_no_index_when_slot_is_at_or_behind_the_finalized_boundary() {
+        assert_eq!(justified_index_after(Slot(10), Slot(10)), None);
+        assert_eq!(justified_index_after(Slot(9), Slot(10)), None);
+    }
+
+    #[test]
+    fn should_map_the_first_slot_after_the_boundary_to_index_zero() {
+        assert_eq!(justified_index_after(Slot(11), Slot(10)), Some(0));
+        assert_eq!(justified_index_after(Slot(13), Slot(10)), Some(2));
+    }
+
+    #[test]
+    fn should_reject_when_the_slot_is_behind_the_finalized_boundary() {
+        assert!(!is_justifiable_after(Slot(9), Slot(10)));
+    }
+
+    #[test]
+    fn should_accept_every_delta_inside_the_immediate_window() {
+        assert!((0..=5).all(|delta| is_justifiable_after(Slot(100 + delta), Slot(100))));
+    }
+
+    #[test]
+    fn should_reject_a_delta_that_is_neither_square_nor_pronic() {
+        for delta in [7, 8, 10, 11, 13, 14, 15] {
+            assert!(
+                !is_justifiable_after(Slot(delta), Slot(0)),
+                "delta {delta} should not be justifiable"
+            );
+        }
+    }
+
+    #[test]
+    fn should_accept_a_square_delta_beyond_the_immediate_window() {
+        for delta in [9, 16, 25, 36] {
+            assert!(is_justifiable_after(Slot(delta), Slot(0)), "delta {delta}");
+        }
+    }
+
+    #[test]
+    fn should_accept_a_pronic_delta_beyond_the_immediate_window() {
+        for delta in [6, 12, 20, 30, 42] {
+            assert!(is_justifiable_after(Slot(delta), Slot(0)), "delta {delta}");
+        }
+    }
+
+    #[test]
+    fn should_not_overflow_when_the_delta_is_near_the_slot_ceiling() {
+        // 4 * delta + 1 leaves u64 here; the answer matters less than the absence of a panic.
+        assert!(!is_justifiable_after(Slot(u64::MAX), Slot(0)));
+    }
+
+    #[test]
+    fn should_keep_the_current_checkpoint_when_the_candidate_ties_on_slot() {
+        let current = Checkpoint {
+            root: [1u8; 32],
+            slot: Slot(7),
+        };
+        let candidate = Checkpoint {
+            root: [2u8; 32],
+            slot: Slot(7),
+        };
+        assert_eq!(advance_checkpoint(current, candidate), current);
+    }
+
+    #[test]
+    fn should_take_the_candidate_when_it_is_strictly_later() {
+        let current = Checkpoint {
+            root: [1u8; 32],
+            slot: Slot(7),
+        };
+        let candidate = Checkpoint {
+            root: [2u8; 32],
+            slot: Slot(8),
+        };
+        assert_eq!(advance_checkpoint(current, candidate), candidate);
+    }
+}

--- a/crates/verity-chain/src/lib.rs
+++ b/crates/verity-chain/src/lib.rs
@@ -1,0 +1,18 @@
+//! Consensus decisions over the `verity-types` container shapes.
+//!
+//! This crate holds the pure functions the state transition and fork choice are built from.
+//! It is where leanSpec's container methods live in Verity: `verity-types` carries shape and
+//! serialization only, and every decision over those shapes sits behind the capability that
+//! owns it, so re-binding one to the Verified Core later touches this crate and not the type
+//! every other crate depends on.
+//!
+//! Nothing here reads a clock, a socket, or a database. `slot_clock` takes the instant it
+//! should reason about as an argument for exactly that reason.
+
+pub mod justification;
+pub mod slot_clock;
+
+pub use justification::{
+    IMMEDIATE_JUSTIFICATION_WINDOW, advance_checkpoint, is_justifiable_after, justified_index_after,
+};
+pub use slot_clock::{SlotClock, intervals_at_slot_start};

--- a/crates/verity-chain/src/slot_clock.rs
+++ b/crates/verity-chain/src/slot_clock.rs
@@ -1,0 +1,143 @@
+//! Conversion between wall-clock time and consensus slots and intervals.
+//!
+//! The clock holds no time source. Every accessor takes the instant it should reason about,
+//! in milliseconds since the Unix epoch, so the arithmetic stays pure and testable against
+//! the spec's vectors. Reading the actual clock belongs to the orchestrator that drives the
+//! node — see `ARCHITECTURE.md`, "I/O Edge".
+//!
+//! Transcribed from leanSpec `src/lean_spec/node/chain/clock.py`, read at commit
+//! `0588c2d215a955a516378677a92db2a5666802f3`.
+
+use std::time::Duration;
+
+use verity_types::config::{INTERVALS_PER_SLOT, MILLISECONDS_PER_INTERVAL, MILLISECONDS_PER_SLOT};
+use verity_types::{Interval, Slot};
+
+/// Converts wall-clock time to consensus slots and intervals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SlotClock {
+    genesis_time: u64,
+}
+
+impl SlotClock {
+    /// Builds a clock anchored at `genesis_time`, a Unix timestamp in **seconds**.
+    #[must_use]
+    pub const fn new(genesis_time: u64) -> Self {
+        Self { genesis_time }
+    }
+
+    /// The Unix timestamp, in seconds, at which slot 0 began.
+    #[must_use]
+    pub const fn genesis_time(&self) -> u64 {
+        self.genesis_time
+    }
+
+    /// Milliseconds elapsed since genesis, saturating to 0 before it.
+    ///
+    /// Clamping rather than signing is what makes every accessor below total: a node started
+    /// ahead of genesis reports slot 0 and interval 0 instead of failing.
+    #[must_use]
+    pub const fn milliseconds_since_genesis(&self, now_milliseconds: u64) -> u64 {
+        now_milliseconds.saturating_sub(self.genesis_time * 1000)
+    }
+
+    /// The slot containing `now_milliseconds`, or slot 0 before genesis.
+    #[must_use]
+    pub const fn current_slot(&self, now_milliseconds: u64) -> Slot {
+        Slot(self.milliseconds_since_genesis(now_milliseconds) / MILLISECONDS_PER_SLOT)
+    }
+
+    /// The interval within the current slot, in `0..INTERVALS_PER_SLOT`.
+    #[must_use]
+    pub const fn current_interval(&self, now_milliseconds: u64) -> Interval {
+        let into_slot = self.milliseconds_since_genesis(now_milliseconds) % MILLISECONDS_PER_SLOT;
+        Interval(into_slot / MILLISECONDS_PER_INTERVAL)
+    }
+
+    /// Intervals elapsed since genesis, counting across slot boundaries.
+    #[must_use]
+    pub const fn total_intervals(&self, now_milliseconds: u64) -> Interval {
+        Interval(self.milliseconds_since_genesis(now_milliseconds) / MILLISECONDS_PER_INTERVAL)
+    }
+
+    /// Time remaining until the next interval boundary.
+    ///
+    /// Before genesis the next boundary is genesis itself. Exactly on a boundary this returns
+    /// a full interval rather than zero, so a caller looping on it always advances.
+    #[must_use]
+    pub const fn until_next_interval(&self, now_milliseconds: u64) -> Duration {
+        let genesis_milliseconds = self.genesis_time * 1000;
+        if now_milliseconds < genesis_milliseconds {
+            return Duration::from_millis(genesis_milliseconds - now_milliseconds);
+        }
+        let into_interval =
+            self.milliseconds_since_genesis(now_milliseconds) % MILLISECONDS_PER_INTERVAL;
+        Duration::from_millis(MILLISECONDS_PER_INTERVAL - into_interval)
+    }
+}
+
+/// The interval count at the start of `slot`.
+///
+/// Slot boundaries fall on exact multiples of the per-slot interval count.
+#[must_use]
+pub const fn intervals_at_slot_start(slot: Slot) -> Interval {
+    Interval(slot.0 * INTERVALS_PER_SLOT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SlotClock, intervals_at_slot_start};
+    use std::time::Duration;
+    use verity_types::{Interval, Slot};
+
+    /// Genesis used by leanSpec's own slot-clock vectors.
+    const GENESIS: u64 = 1_700_000_000;
+    const GENESIS_MS: u64 = GENESIS * 1000;
+
+    #[test]
+    fn should_report_slot_zero_when_the_instant_precedes_genesis() {
+        let clock = SlotClock::new(GENESIS);
+        assert_eq!(clock.current_slot(GENESIS_MS - 10_000), Slot(0));
+        assert_eq!(clock.current_interval(GENESIS_MS - 10_000), Interval(0));
+        assert_eq!(clock.total_intervals(GENESIS_MS - 10_000), Interval(0));
+    }
+
+    #[test]
+    fn should_advance_the_slot_exactly_on_the_boundary_and_not_before() {
+        let clock = SlotClock::new(GENESIS);
+        assert_eq!(clock.current_slot(GENESIS_MS + 3_999), Slot(0));
+        assert_eq!(clock.current_slot(GENESIS_MS + 4_000), Slot(1));
+    }
+
+    #[test]
+    fn should_wrap_the_interval_when_the_slot_rolls_over() {
+        let clock = SlotClock::new(GENESIS);
+        assert_eq!(clock.current_interval(GENESIS_MS + 3_200), Interval(4));
+        assert_eq!(clock.current_interval(GENESIS_MS + 4_000), Interval(0));
+        assert_eq!(clock.total_intervals(GENESIS_MS + 4_000), Interval(5));
+    }
+
+    #[test]
+    fn should_return_a_full_interval_when_sitting_exactly_on_a_boundary() {
+        let clock = SlotClock::new(GENESIS);
+        assert_eq!(
+            clock.until_next_interval(GENESIS_MS + 800),
+            Duration::from_millis(800)
+        );
+    }
+
+    #[test]
+    fn should_count_down_to_genesis_when_called_before_it() {
+        let clock = SlotClock::new(GENESIS);
+        assert_eq!(
+            clock.until_next_interval(GENESIS_MS - 1_500),
+            Duration::from_millis(1_500)
+        );
+    }
+
+    #[test]
+    fn should_land_on_the_slot_start_when_converting_a_slot_to_intervals() {
+        assert_eq!(intervals_at_slot_start(Slot(0)), Interval(0));
+        assert_eq!(intervals_at_slot_start(Slot(10)), Interval(50));
+    }
+}

--- a/crates/verity-chain/src/slot_clock.rs
+++ b/crates/verity-chain/src/slot_clock.rs
@@ -21,13 +21,13 @@ pub struct SlotClock {
 
 impl SlotClock {
     /// Builds a clock anchored at `genesis_time`, a Unix timestamp in **seconds**.
-    #[must_use]
+    #[must_use = "a clock is a value; constructing one starts nothing and registers nothing"]
     pub const fn new(genesis_time: u64) -> Self {
         Self { genesis_time }
     }
 
     /// The Unix timestamp, in seconds, at which slot 0 began.
-    #[must_use]
+    #[must_use = "this reads the anchor the clock was built with; it cannot move it"]
     pub const fn genesis_time(&self) -> u64 {
         self.genesis_time
     }
@@ -36,26 +36,26 @@ impl SlotClock {
     ///
     /// Clamping rather than signing is what makes every accessor below total: a node started
     /// ahead of genesis reports slot 0 and interval 0 instead of failing.
-    #[must_use]
+    #[must_use = "this measures against the instant passed in; the clock stores no time of its own"]
     pub const fn milliseconds_since_genesis(&self, now_milliseconds: u64) -> u64 {
         now_milliseconds.saturating_sub(self.genesis_time * 1000)
     }
 
     /// The slot containing `now_milliseconds`, or slot 0 before genesis.
-    #[must_use]
+    #[must_use = "the slot is derived from the argument, not from a clock this type reads"]
     pub const fn current_slot(&self, now_milliseconds: u64) -> Slot {
         Slot(self.milliseconds_since_genesis(now_milliseconds) / MILLISECONDS_PER_SLOT)
     }
 
     /// The interval within the current slot, in `0..INTERVALS_PER_SLOT`.
-    #[must_use]
+    #[must_use = "the position inside the slot, not a count since genesis; see `total_intervals`"]
     pub const fn current_interval(&self, now_milliseconds: u64) -> Interval {
         let into_slot = self.milliseconds_since_genesis(now_milliseconds) % MILLISECONDS_PER_SLOT;
         Interval(into_slot / MILLISECONDS_PER_INTERVAL)
     }
 
     /// Intervals elapsed since genesis, counting across slot boundaries.
-    #[must_use]
+    #[must_use = "a count since genesis, not the position inside a slot; see `current_interval`"]
     pub const fn total_intervals(&self, now_milliseconds: u64) -> Interval {
         Interval(self.milliseconds_since_genesis(now_milliseconds) / MILLISECONDS_PER_INTERVAL)
     }
@@ -64,7 +64,7 @@ impl SlotClock {
     ///
     /// Before genesis the next boundary is genesis itself. Exactly on a boundary this returns
     /// a full interval rather than zero, so a caller looping on it always advances.
-    #[must_use]
+    #[must_use = "this returns how long to wait; it does not wait"]
     pub const fn until_next_interval(&self, now_milliseconds: u64) -> Duration {
         let genesis_milliseconds = self.genesis_time * 1000;
         if now_milliseconds < genesis_milliseconds {
@@ -79,7 +79,7 @@ impl SlotClock {
 /// The interval count at the start of `slot`.
 ///
 /// Slot boundaries fall on exact multiples of the per-slot interval count.
-#[must_use]
+#[must_use = "this converts a slot to its interval count; it reads no clock and changes no slot"]
 pub const fn intervals_at_slot_start(slot: Slot) -> Interval {
     Interval(slot.0 * INTERVALS_PER_SLOT)
 }

--- a/crates/verity-chain/tests/common/mod.rs
+++ b/crates/verity-chain/tests/common/mod.rs
@@ -1,0 +1,55 @@
+//! Shared plumbing for the leanSpec fixture suites.
+//!
+//! Both suites are gated on `VERITY_FIXTURES` pointing at an extracted `fixtures-prod-scheme`
+//! tree. The fast `cargo test` gate leaves it unset and the tests return; CI's fixtures job
+//! always sets it, and each suite fails if no case matched.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The extracted fixture tree, when the environment points at one.
+pub fn fixtures_dir() -> Option<PathBuf> {
+    std::env::var_os("VERITY_FIXTURES").map(PathBuf::from)
+}
+
+/// Every `*.json` under a directory named `suite`, anywhere in the tree.
+///
+/// Matching on the suite directory rather than a fixed depth keeps this working when leanSpec
+/// moves a suite, which it has already done once.
+pub fn collect_suite_json(root: &Path, suite: &str) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    walk(root, suite, &mut out);
+    out.sort();
+    out
+}
+
+fn walk(dir: &Path, suite: &str, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, suite, out);
+            continue;
+        }
+        let is_json = path.extension().is_some_and(|ext| ext == "json");
+        let in_suite = path.components().any(|c| c.as_os_str() == suite);
+        if is_json && in_suite {
+            out.push(path);
+        }
+    }
+}
+
+/// Reads every case in a suite, keyed by the leanSpec test id that produced it.
+pub fn read_cases<T: serde::de::DeserializeOwned>(paths: &[PathBuf]) -> Vec<(String, T)> {
+    let mut cases = Vec::new();
+    for path in paths {
+        let text = fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("{}: read error: {error}", path.display()));
+        let file: std::collections::BTreeMap<String, T> = serde_json::from_str(&text)
+            .unwrap_or_else(|error| panic!("{}: json: {error}", path.display()));
+        cases.extend(file);
+    }
+    cases
+}

--- a/crates/verity-chain/tests/justifiability_fixtures.rs
+++ b/crates/verity-chain/tests/justifiability_fixtures.rs
@@ -1,0 +1,97 @@
+//! Conformance against leanSpec's justifiability vectors (`justifiability_test` format).
+//!
+//! Source: leanSpec `tests/consensus/lstar/state_transition/test_justifiability.py`, filled
+//! into the `fixtures-prod-scheme.tar.gz` release asset that
+//! `crates/verity-types/fixtures.sha256` pins.
+
+mod common;
+
+use serde::Deserialize;
+use verity_chain::{is_justifiable_after, justified_index_after};
+use verity_types::Slot;
+
+const SUITE: &str = "test_justifiability";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Case {
+    slot: u64,
+    finalized_slot: u64,
+    output: Output,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Output {
+    /// Signed on purpose: leanSpec emits a negative delta for a slot behind the boundary.
+    delta: i64,
+    is_justifiable: bool,
+}
+
+#[test]
+fn should_match_leanspec_justifiability_vectors_when_fixtures_are_present() {
+    let Some(root) = common::fixtures_dir() else {
+        eprintln!("skipping: set VERITY_FIXTURES to run leanSpec justifiability vectors");
+        return;
+    };
+    let files = common::collect_suite_json(&root, SUITE);
+    assert!(
+        !files.is_empty(),
+        "no JSON under {} (expected **/{SUITE}/*.json)",
+        root.display()
+    );
+
+    let cases: Vec<(String, Case)> = common::read_cases(&files);
+    let mut failures = Vec::new();
+    for (id, case) in &cases {
+        if let Err(error) = check(case) {
+            failures.push(format!("{id}: {error}"));
+        }
+    }
+
+    eprintln!("matched {} leanSpec justifiability vectors", cases.len());
+    assert!(
+        failures.is_empty(),
+        "{} justifiability vector(s) disagreed with leanSpec:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+    assert!(!cases.is_empty(), "no justifiability vector matched");
+}
+
+fn check(case: &Case) -> Result<(), String> {
+    // The fixture's own delta is checked first. It is the spec's statement of how far apart
+    // the two slots are, so a disagreement here means the vector was read wrong and every
+    // verdict below it would be judged against the wrong question.
+    let delta = i128::from(case.slot) - i128::from(case.finalized_slot);
+    if delta != i128::from(case.output.delta) {
+        return Err(format!(
+            "delta mismatch: computed {delta}, fixture says {}",
+            case.output.delta
+        ));
+    }
+
+    let slot = Slot(case.slot);
+    let finalized = Slot(case.finalized_slot);
+
+    let justifiable = is_justifiable_after(slot, finalized);
+    if justifiable != case.output.is_justifiable {
+        return Err(format!(
+            "slot {} after finalized {}: got is_justifiable={justifiable}, want {}",
+            case.slot, case.finalized_slot, case.output.is_justifiable
+        ));
+    }
+
+    // The bitfield index is not part of this fixture format, but it is defined over the same
+    // pair and must stay consistent with the delta the vector states.
+    let expected_index = (delta > 0).then(|| (delta - 1) as usize);
+    let index = justified_index_after(slot, finalized);
+    if index != expected_index {
+        return Err(format!(
+            "slot {} after finalized {}: got index {index:?}, want {expected_index:?}",
+            case.slot, case.finalized_slot
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/verity-chain/tests/slot_clock_fixtures.rs
+++ b/crates/verity-chain/tests/slot_clock_fixtures.rs
@@ -1,0 +1,203 @@
+//! Conformance against leanSpec's slot-clock vectors.
+//!
+//! Source: leanSpec `tests/consensus/lstar/chain/test_slot_clock.py`, filled into the
+//! `fixtures-prod-scheme.tar.gz` release asset that `crates/verity-types/fixtures.sha256`
+//! pins.
+
+mod common;
+
+use serde::Deserialize;
+use verity_chain::{SlotClock, intervals_at_slot_start};
+use verity_types::Slot;
+use verity_types::config::{
+    INTERVALS_PER_SLOT, MILLISECONDS_PER_INTERVAL, MILLISECONDS_PER_SLOT, SECONDS_PER_SLOT,
+};
+
+const SUITE: &str = "test_slot_clock";
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    operation: Operation,
+    config: Config,
+    output: Output,
+}
+
+/// The timing constants the vector was generated under.
+///
+/// Checked rather than ignored: the constants live in `verity-types` as compile-time values,
+/// so a spec change to slot timing would otherwise surface as a pile of arithmetic mismatches
+/// instead of the one fact that actually moved.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Config {
+    seconds_per_slot: u64,
+    intervals_per_slot: u64,
+    milliseconds_per_interval: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+enum Operation {
+    FromUnixTime {
+        genesis_time: u64,
+        unix_seconds: f64,
+    },
+    TotalIntervals {
+        genesis_time: u64,
+        current_time_milliseconds: f64,
+    },
+    CurrentSlot {
+        genesis_time: u64,
+        current_time_milliseconds: f64,
+    },
+    CurrentInterval {
+        genesis_time: u64,
+        current_time_milliseconds: f64,
+    },
+    FromSlot {
+        slot: u64,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Output {
+    #[serde(default)]
+    slot: Option<u64>,
+    #[serde(default)]
+    interval: Option<u64>,
+    #[serde(default)]
+    total_intervals: Option<u64>,
+}
+
+#[test]
+fn should_match_leanspec_slot_clock_vectors_when_fixtures_are_present() {
+    let Some(root) = common::fixtures_dir() else {
+        eprintln!("skipping: set VERITY_FIXTURES to run leanSpec slot-clock vectors");
+        return;
+    };
+    let files = common::collect_suite_json(&root, SUITE);
+    assert!(
+        !files.is_empty(),
+        "no JSON under {} (expected **/{SUITE}/*.json)",
+        root.display()
+    );
+
+    let cases: Vec<(String, Case)> = common::read_cases(&files);
+    let mut failures = Vec::new();
+    for (id, case) in &cases {
+        if let Err(error) = check(case) {
+            failures.push(format!("{id}: {error}"));
+        }
+    }
+
+    eprintln!("matched {} leanSpec slot-clock vectors", cases.len());
+    assert!(
+        failures.is_empty(),
+        "{} slot-clock vector(s) disagreed with leanSpec:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+    assert!(!cases.is_empty(), "no slot-clock vector matched");
+}
+
+fn check(case: &Case) -> Result<(), String> {
+    check_config(&case.config)?;
+    match case.operation {
+        // A Unix instant in seconds counts the same intervals as the millisecond form; the
+        // spec reaches both through one accessor over a common millisecond time base.
+        Operation::FromUnixTime {
+            genesis_time,
+            unix_seconds,
+        } => expect(
+            "interval",
+            SlotClock::new(genesis_time)
+                .total_intervals(to_milliseconds(unix_seconds * 1000.0))
+                .0,
+            case.output.interval,
+        ),
+        Operation::TotalIntervals {
+            genesis_time,
+            current_time_milliseconds,
+        } => expect(
+            "totalIntervals",
+            SlotClock::new(genesis_time)
+                .total_intervals(to_milliseconds(current_time_milliseconds))
+                .0,
+            case.output.total_intervals,
+        ),
+        Operation::CurrentSlot {
+            genesis_time,
+            current_time_milliseconds,
+        } => expect(
+            "slot",
+            SlotClock::new(genesis_time)
+                .current_slot(to_milliseconds(current_time_milliseconds))
+                .0,
+            case.output.slot,
+        ),
+        Operation::CurrentInterval {
+            genesis_time,
+            current_time_milliseconds,
+        } => expect(
+            "interval",
+            SlotClock::new(genesis_time)
+                .current_interval(to_milliseconds(current_time_milliseconds))
+                .0,
+            case.output.interval,
+        ),
+        Operation::FromSlot { slot } => expect(
+            "interval",
+            intervals_at_slot_start(Slot(slot)).0,
+            case.output.interval,
+        ),
+    }
+}
+
+fn check_config(config: &Config) -> Result<(), String> {
+    let expected = [
+        ("secondsPerSlot", config.seconds_per_slot, SECONDS_PER_SLOT),
+        (
+            "intervalsPerSlot",
+            config.intervals_per_slot,
+            INTERVALS_PER_SLOT,
+        ),
+        (
+            "millisecondsPerInterval",
+            config.milliseconds_per_interval,
+            MILLISECONDS_PER_INTERVAL,
+        ),
+    ];
+    for (name, fixture, ours) in expected {
+        if fixture != ours {
+            return Err(format!(
+                "{name}: fixture generated with {fixture}, this build uses {ours}"
+            ));
+        }
+    }
+    // Not a fixture field, but the relation the other three rest on.
+    if MILLISECONDS_PER_SLOT != config.seconds_per_slot * 1000 {
+        return Err(format!(
+            "MILLISECONDS_PER_SLOT {MILLISECONDS_PER_SLOT} disagrees with secondsPerSlot {}",
+            config.seconds_per_slot
+        ));
+    }
+    Ok(())
+}
+
+fn expect(field: &str, got: u64, want: Option<u64>) -> Result<(), String> {
+    let want = want.ok_or_else(|| format!("vector carries no `{field}` output"))?;
+    if got == want {
+        return Ok(());
+    }
+    Err(format!("{field}: got {got}, want {want}"))
+}
+
+/// leanSpec reads its time source as a float and truncates to whole milliseconds.
+fn to_milliseconds(value: f64) -> u64 {
+    value.trunc().max(0.0) as u64
+}


### PR DESCRIPTION
The first consensus logic in the tree. Everything before this was container shape.

Both pieces are what `verity-types` deliberately left out. leanSpec defines them as methods on `Slot` and `Checkpoint`; Verity keeps them off the foundational crate, because they are the leading candidates to move into the Verified Core and binding them there would make every crate that merely uses a slot link the FFI boundary once that move happens.

## What lands

**`justification`** — `is_justifiable_after`, `justified_index_after`, `advance_checkpoint`.

The 3SF-mini rule: a slot is a justification candidate when its distance from the finalized boundary is within five, a perfect square, or a pronic number (`n(n+1)`: 6, 12, 20, …). This is the same function ethlambda tried to formalize in Lean before closing the PR, so it is also the first candidate to move inward.

The pronic test widens to `u128`: `4 * delta + 1` overflows `u64` near the top of the slot range, and there is a unit test pinning that it does not panic there.

**`slot_clock`** — `current_slot`, `current_interval`, `total_intervals`, `until_next_interval`, `intervals_at_slot_start`.

The clock holds no time source. Every accessor takes the instant it should reason about, in milliseconds since the epoch. That is what lets the spec's own vectors run against it directly; reading the wall clock belongs to the orchestrator, per ARCHITECTURE.md's I/O Edge.

## Verification

| | |
|---|---|
| leanSpec justifiability vectors | **35 matched** |
| leanSpec slot-clock vectors | **25 matched** |
| unit tests | 16 |

Both suites were mutation-checked rather than assumed to bite:

- Narrowing `IMMEDIATE_JUSTIFICATION_WINDOW` from 5 to 4 fails `test_delta_5`. (Widening it to 6 changes nothing, because 6 is already pronic — the window is only load-bearing at deltas 3 and 5.)
- Rounding the slot up instead of down fails `test_current_slot_before_boundary` and `test_current_slot_mid_slot`.

The slot-clock test also asserts the fixture's own `config` block against this build's constants, so a spec change to slot timing surfaces as the one fact that moved rather than a pile of arithmetic mismatches.

## CI

The `fixtures` job now runs `cargo test --workspace` instead of one named test, so a crate that starts consuming vectors is picked up without editing the workflow. Extraction still names each suite explicitly: `tar` fails when a pattern matches nothing, so a suite leanSpec renames or drops breaks the job rather than quietly halving the vector count.

Vector totals in CI after this change: 31 SSZ + 35 justifiability + 25 slot clock.

## What this opens

`state_transition` (74 fixture files) and `fork_choice` (122) both call these. Fixing them against the spec first means a failure there is a failure of the transition, not of a predicate underneath it.

## Source

leanSpec `src/lean_spec/spec/forks/lstar/slot.py` and `src/lean_spec/node/chain/clock.py`, read at `0588c2d215a955a516378677a92db2a5666802f3` — the same commit `verity-types` was transcribed from.

## Call-site guidance

All eleven public functions are `#[must_use]`, each with a message naming the misreading its name invites. The default lint text reports only that a value was dropped; it cannot say why dropping it is a mistake, and here the mistake is always the same shape — the name reads like a command, so a caller writes it as a statement and nothing happens:

```
error: unused return value of `slot_clock::SlotClock::until_next_interval` that must be used
   = note: this returns how long to wait; it does not wait
```

`current_interval` and `total_intervals` point at each other, since neither the name nor the return type distinguishes a position inside a slot from a count since genesis.

These are errors rather than warnings in this repo because the `check` job runs `clippy -- -D warnings`, which promotes `unused_must_use`.
