### PR TITLE
feat(chain): implement the state transition function

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,6 +100,10 @@ jobs:
       # Only the suites a crate actually consumes. tar fails when a pattern matches nothing,
       # so a suite leanSpec renames or drops breaks the job here rather than quietly halving
       # the vector count downstream.
+      #
+      # The state-transition tree is taken whole rather than suite by suite: its harness
+      # already names all fifteen suites and fails on any that matches no file, so listing
+      # them again here would only put the same list in two places.
       - name: Extract consumed fixture suites
         run: |
           mkdir -p fixtures-prod
@@ -107,7 +111,8 @@ jobs:
             --wildcards '*/ssz/*/ssz/test_consensus_containers/*.json' \
             '*/ssz/*/ssz/test_xmss_containers/*.json' \
             '*/justifiability/*/state_transition/test_justifiability/*.json' \
-            '*/slot_clock/*/chain/test_slot_clock/*.json'
+            '*/slot_clock/*/chain/test_slot_clock/*.json' \
+            '*/state_transition/*/state_transition/*/*.json'
 
       # The whole workspace, so a crate that starts consuming fixtures is picked up without
       # editing this job. Every fixture test skips when VERITY_FIXTURES is unset, which is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,8 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 name = "verity-chain"
 version = "0.0.0"
 dependencies = [
+ "libssz-merkle",
+ "libssz-types",
  "serde",
  "serde_json",
  "verity-types",

--- a/crates/verity-chain/Cargo.toml
+++ b/crates/verity-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verity-chain"
-description = "Consensus decisions over the container types: justification candidacy and the slot clock."
+description = "Consensus decisions over the container types: the state transition, justification candidacy, and the slot clock."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,14 @@ publish = false
 
 # Pure decisions over `verity-types` shapes. No storage, no networking, no cryptography, and
 # no wall clock: every function here takes the time it should reason about as an argument.
+#
+# `libssz-merkle` is here for one reason: the state transition commits to `hash_tree_root` of
+# the state, the parent header, and the block body, so the decision cannot be expressed
+# without it. It is the same Serialization capability `verity-types` already depends on, not
+# a new supplier.
 [dependencies]
+libssz-merkle.workspace = true
+libssz-types.workspace = true
 verity-types.workspace = true
 
 [dev-dependencies]

--- a/crates/verity-chain/src/error.rs
+++ b/crates/verity-chain/src/error.rs
@@ -1,0 +1,130 @@
+//! Why the spec rejects an input.
+//!
+//! This is the `ProcessingError` of `ARCHITECTURE.md`'s capability contracts — a plain enum,
+//! no structured payload, because rejection reasons are a small closed set and nothing but
+//! the discriminant has to survive a future trip across the C ABI. It is named after the
+//! leanSpec enum it mirrors so the two stay greppable against each other.
+//!
+//! Only the reasons Verity can currently produce are defined. leanSpec's enum has 36; the
+//! rest belong to fork choice and gossip validation, and land with them. An unmodelled
+//! reason is not silently tolerated: [`RejectionReason::as_str`] is what the fixture suites
+//! compare against, so a vector expecting a reason this enum lacks fails the run.
+//!
+//! One variant is here ahead of the code that leanSpec raises it from.
+//! [`RejectionReason::BlockSlotGapTooLarge`] guards the transition's empty-slot walk, which
+//! leanSpec guards from fork choice instead — see `state_transition::process_slots`.
+//!
+//! Transcribed from leanSpec `src/lean_spec/spec/forks/lstar/errors.py`, read at commit
+//! `0588c2d215a955a516378677a92db2a5666802f3`.
+
+use core::fmt;
+
+/// Language-neutral reason the spec rejects an invalid input.
+///
+/// The variant names, and the strings [`RejectionReason::as_str`] returns, are leanSpec's
+/// verbatim. They are the wire form: fixtures carry them as `rejectionReason`, and a future
+/// FFI status code maps one-to-one onto them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RejectionReason {
+    /// The block slot is not strictly greater than the current state slot.
+    BlockSlotNotInFuture,
+    /// The block slot runs so far beyond its parent it would force an unbounded empty-slot walk.
+    BlockSlotGapTooLarge,
+    /// The block slot disagrees with the state slot after slot processing.
+    BlockSlotMismatch,
+    /// The block slot is not newer than the latest block header.
+    BlockOlderThanLatestHeader,
+    /// The block parent root disagrees with the latest block header root.
+    ParentRootMismatch,
+    /// The block state root disagrees with the computed post-state root.
+    StateRootMismatch,
+    /// The block proposer is not the scheduled proposer for its slot.
+    WrongProposer,
+    /// The registry holds no validators, so no proposer can be scheduled for any slot.
+    EmptyValidatorRegistry,
+    /// A set aggregation bit points outside the validator registry.
+    ValidatorIndexOutOfRange,
+    /// The block carries more distinct attestation data entries than allowed.
+    TooManyAttestationData,
+    /// An aggregated attestation references no validator at all.
+    EmptyAggregationBits,
+    /// The flat vote list length is not the tracked-root count times the validator count.
+    JustificationVotesLengthMismatch,
+    /// A queried slot is active but outside the tracked justification range.
+    JustifiedSlotOutOfRange,
+    /// A tracked justification root is the zero hash, which marks a slot with no block.
+    ZeroHashJustificationRoot,
+}
+
+impl RejectionReason {
+    /// The leanSpec name for this reason, as it appears in a test vector.
+    #[must_use = "this renders the reason; it does not raise or record it"]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::BlockSlotNotInFuture => "BLOCK_SLOT_NOT_IN_FUTURE",
+            Self::BlockSlotGapTooLarge => "BLOCK_SLOT_GAP_TOO_LARGE",
+            Self::BlockSlotMismatch => "BLOCK_SLOT_MISMATCH",
+            Self::BlockOlderThanLatestHeader => "BLOCK_OLDER_THAN_LATEST_HEADER",
+            Self::ParentRootMismatch => "PARENT_ROOT_MISMATCH",
+            Self::StateRootMismatch => "STATE_ROOT_MISMATCH",
+            Self::WrongProposer => "WRONG_PROPOSER",
+            Self::EmptyValidatorRegistry => "EMPTY_VALIDATOR_REGISTRY",
+            Self::ValidatorIndexOutOfRange => "VALIDATOR_INDEX_OUT_OF_RANGE",
+            Self::TooManyAttestationData => "TOO_MANY_ATTESTATION_DATA",
+            Self::EmptyAggregationBits => "EMPTY_AGGREGATION_BITS",
+            Self::JustificationVotesLengthMismatch => "JUSTIFICATION_VOTES_LENGTH_MISMATCH",
+            Self::JustifiedSlotOutOfRange => "JUSTIFIED_SLOT_OUT_OF_RANGE",
+            Self::ZeroHashJustificationRoot => "ZERO_HASH_JUSTIFICATION_ROOT",
+        }
+    }
+}
+
+impl fmt::Display for RejectionReason {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl core::error::Error for RejectionReason {}
+
+#[cfg(test)]
+mod tests {
+    use super::RejectionReason;
+
+    /// Every variant, so a new one cannot be added without giving it a wire name here.
+    const ALL: &[RejectionReason] = &[
+        RejectionReason::BlockSlotNotInFuture,
+        RejectionReason::BlockSlotGapTooLarge,
+        RejectionReason::BlockSlotMismatch,
+        RejectionReason::BlockOlderThanLatestHeader,
+        RejectionReason::ParentRootMismatch,
+        RejectionReason::StateRootMismatch,
+        RejectionReason::WrongProposer,
+        RejectionReason::EmptyValidatorRegistry,
+        RejectionReason::ValidatorIndexOutOfRange,
+        RejectionReason::TooManyAttestationData,
+        RejectionReason::EmptyAggregationBits,
+        RejectionReason::JustificationVotesLengthMismatch,
+        RejectionReason::JustifiedSlotOutOfRange,
+        RejectionReason::ZeroHashJustificationRoot,
+    ];
+
+    #[test]
+    fn should_render_a_distinct_screaming_snake_name_when_each_reason_is_displayed() {
+        let mut names: Vec<&str> = ALL.iter().map(|reason| reason.as_str()).collect();
+        names.sort_unstable();
+        let count = names.len();
+        names.dedup();
+        assert_eq!(names.len(), count, "two reasons share a wire name");
+        assert!(
+            ALL.iter().all(|reason| {
+                let name = reason.as_str();
+                !name.is_empty()
+                    && name
+                        .bytes()
+                        .all(|byte| byte.is_ascii_uppercase() || byte == b'_')
+            }),
+            "a wire name is not SCREAMING_SNAKE_CASE"
+        );
+    }
+}

--- a/crates/verity-chain/src/justification.rs
+++ b/crates/verity-chain/src/justification.rs
@@ -9,7 +9,10 @@
 //! Transcribed from leanSpec `src/lean_spec/spec/forks/lstar/slot.py`, read at commit
 //! `0588c2d215a955a516378677a92db2a5666802f3`.
 
-use verity_types::{Checkpoint, Slot};
+use verity_types::config::HISTORICAL_ROOTS_LIMIT;
+use verity_types::{Checkpoint, JustifiedSlots, Slot};
+
+use crate::error::RejectionReason;
 
 /// Slots within this distance of the finalized boundary are always justification candidates.
 pub const IMMEDIATE_JUSTIFICATION_WINDOW: u64 = 5;
@@ -70,6 +73,67 @@ pub fn advance_checkpoint(current: Checkpoint, candidate: Checkpoint) -> Checkpo
     }
 }
 
+/// Whether `slot` is already justified, per the bitfield anchored at `finalized`.
+///
+/// A slot at or behind the boundary is justified by definition and is not looked up.
+///
+/// # Errors
+///
+/// [`RejectionReason::JustifiedSlotOutOfRange`] when the slot is ahead of the boundary but
+/// past the end of the tracked bitfield. leanSpec surfaces the same out-of-range access as a
+/// domain rejection rather than letting an index error escape block processing.
+#[must_use = "this answers whether the slot is justified; it does not justify it"]
+pub fn is_slot_justified(
+    justified_slots: &JustifiedSlots,
+    finalized: Slot,
+    slot: Slot,
+) -> Result<bool, RejectionReason> {
+    let Some(index) = justified_index_after(slot, finalized) else {
+        return Ok(true);
+    };
+    justified_slots
+        .get(index)
+        .ok_or(RejectionReason::JustifiedSlotOutOfRange)
+}
+
+/// Grows the tracked bitfield until `slot` is addressable, filling new positions with `false`.
+///
+/// Returns the bitfield unchanged when `slot` is at or behind the boundary, or when the
+/// bitfield already reaches it.
+///
+/// # Errors
+///
+/// [`RejectionReason::JustifiedSlotOutOfRange`] when addressing `slot` would need more bits
+/// than [`HISTORICAL_ROOTS_LIMIT`] allows. That bound is the bitfield's SSZ limit, so a
+/// larger one is not representable in the state at all.
+#[must_use = "this returns the grown bitfield; the argument is left untouched"]
+pub fn extend_justified_slots_to(
+    justified_slots: &JustifiedSlots,
+    finalized: Slot,
+    slot: Slot,
+) -> Result<JustifiedSlots, RejectionReason> {
+    let Some(index) = justified_index_after(slot, finalized) else {
+        return Ok(justified_slots.clone());
+    };
+
+    // Zero-based index, so covering it takes one more bit than its value.
+    let required = index.saturating_add(1);
+    if required <= justified_slots.len() {
+        return Ok(justified_slots.clone());
+    }
+    if required > HISTORICAL_ROOTS_LIMIT {
+        return Err(RejectionReason::JustifiedSlotOutOfRange);
+    }
+
+    let mut extended = justified_slots.clone();
+    while extended.len() < required {
+        extended
+            .push(false)
+            .map_err(|_| RejectionReason::JustifiedSlotOutOfRange)?;
+    }
+    Ok(extended)
+}
+
 fn is_perfect_square(value: u128) -> bool {
     let root = value.isqrt();
     root * root == value
@@ -77,8 +141,12 @@ fn is_perfect_square(value: u128) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{advance_checkpoint, is_justifiable_after, justified_index_after};
-    use verity_types::{Checkpoint, Slot};
+    use super::{
+        advance_checkpoint, extend_justified_slots_to, is_justifiable_after, is_slot_justified,
+        justified_index_after,
+    };
+    use crate::error::RejectionReason;
+    use verity_types::{Checkpoint, JustifiedSlots, Slot};
 
     #[test]
     fn should_report_no_index_when_slot_is_at_or_behind_the_finalized_boundary() {
@@ -156,5 +224,61 @@ mod tests {
             slot: Slot(8),
         };
         assert_eq!(advance_checkpoint(current, candidate), candidate);
+    }
+
+    fn bitfield(bits: &[bool]) -> JustifiedSlots {
+        JustifiedSlots::try_from(bits.to_vec()).expect("fits well under the tracked limit")
+    }
+
+    #[test]
+    fn should_report_justified_when_the_slot_is_at_or_behind_the_finalized_boundary() {
+        let empty = bitfield(&[]);
+        assert_eq!(is_slot_justified(&empty, Slot(10), Slot(10)), Ok(true));
+        assert_eq!(is_slot_justified(&empty, Slot(10), Slot(3)), Ok(true));
+    }
+
+    #[test]
+    fn should_read_the_tracked_bit_when_the_slot_is_ahead_of_the_boundary() {
+        let tracked = bitfield(&[false, true, false]);
+        assert_eq!(is_slot_justified(&tracked, Slot(0), Slot(1)), Ok(false));
+        assert_eq!(is_slot_justified(&tracked, Slot(0), Slot(2)), Ok(true));
+    }
+
+    #[test]
+    fn should_reject_when_the_queried_slot_is_past_the_tracked_range() {
+        assert_eq!(
+            is_slot_justified(&bitfield(&[false]), Slot(0), Slot(9)),
+            Err(RejectionReason::JustifiedSlotOutOfRange)
+        );
+    }
+
+    #[test]
+    fn should_grow_with_unset_flags_when_the_bitfield_falls_short_of_the_slot() {
+        let grown = extend_justified_slots_to(&bitfield(&[true]), Slot(0), Slot(4)).unwrap();
+        assert_eq!(grown.len(), 4);
+        assert_eq!(grown.get(0), Some(true));
+        assert_eq!(grown.count_ones(), 1);
+    }
+
+    #[test]
+    fn should_leave_the_bitfield_alone_when_it_already_reaches_the_slot() {
+        let tracked = bitfield(&[true, true, true]);
+        let unchanged = extend_justified_slots_to(&tracked, Slot(0), Slot(2)).unwrap();
+        assert_eq!(unchanged.len(), 3, "reaching the slot must not shrink it");
+    }
+
+    #[test]
+    fn should_leave_the_bitfield_alone_when_the_slot_is_behind_the_boundary() {
+        let tracked = bitfield(&[true]);
+        let unchanged = extend_justified_slots_to(&tracked, Slot(7), Slot(7)).unwrap();
+        assert_eq!(unchanged.len(), 1);
+    }
+
+    #[test]
+    fn should_reject_when_covering_the_slot_would_overrun_the_tracked_limit() {
+        assert_eq!(
+            extend_justified_slots_to(&bitfield(&[]), Slot(0), Slot(u64::MAX)),
+            Err(RejectionReason::JustifiedSlotOutOfRange)
+        );
     }
 }

--- a/crates/verity-chain/src/lib.rs
+++ b/crates/verity-chain/src/lib.rs
@@ -7,12 +7,26 @@
 //! every other crate depends on.
 //!
 //! Nothing here reads a clock, a socket, or a database. `slot_clock` takes the instant it
-//! should reason about as an argument for exactly that reason.
+//! should reason about as an argument, and `state_transition` takes the block, for exactly
+//! that reason. Signature verification happens before the transition is called, so this
+//! crate carries no cryptographic dependency either.
 
+pub mod error;
 pub mod justification;
+pub mod merkle;
+pub mod proposer;
 pub mod slot_clock;
+pub mod state_transition;
 
+pub use error::RejectionReason;
 pub use justification::{
-    IMMEDIATE_JUSTIFICATION_WINDOW, advance_checkpoint, is_justifiable_after, justified_index_after,
+    IMMEDIATE_JUSTIFICATION_WINDOW, advance_checkpoint, extend_justified_slots_to,
+    is_justifiable_after, is_slot_justified, justified_index_after,
 };
+pub use merkle::hash_tree_root;
+pub use proposer::proposer_for_slot;
 pub use slot_clock::{SlotClock, intervals_at_slot_start};
+pub use state_transition::{
+    generate_genesis, process_attestations, process_block, process_block_header, process_slots,
+    state_transition,
+};

--- a/crates/verity-chain/src/merkle.rs
+++ b/crates/verity-chain/src/merkle.rs
@@ -1,0 +1,14 @@
+//! The one place the hash tree root hasher is chosen.
+//!
+//! `hash_tree_root` is a capability contract in `ARCHITECTURE.md`, currently satisfied by the
+//! external SSZ library. Routing every call in this crate through one function is what keeps
+//! that swap a one-file change: nothing else names a hasher.
+
+use libssz_merkle::{HashTreeRoot, Sha2Hasher};
+use verity_types::Bytes32;
+
+/// The SSZ hash tree root of a consensus value.
+#[must_use = "this computes the root; it does not store or commit to it"]
+pub fn hash_tree_root<T: HashTreeRoot>(value: &T) -> Bytes32 {
+    value.hash_tree_root(&Sha2Hasher)
+}

--- a/crates/verity-chain/src/proposer.rs
+++ b/crates/verity-chain/src/proposer.rs
@@ -1,0 +1,62 @@
+//! Which validator is scheduled to propose in a slot.
+//!
+//! Proposer selection lives chain-side, next to the state transition and fork choice, rather
+//! than in the validator crate: the state transition validates a block's proposer with the
+//! same function a validator uses to learn it is on duty, and there is only one schedule.
+//!
+//! leanSpec defines this as a `ValidatorIndex` classmethod. Verity keeps it off the type for
+//! the same reason as the justification predicates — see `justification`.
+//!
+//! Transcribed from leanSpec `src/lean_spec/spec/forks/lstar/containers/identifiers.py`, read
+//! at commit `0588c2d215a955a516378677a92db2a5666802f3`.
+
+use verity_types::ValidatorIndex;
+use verity_types::primitives::Slot;
+
+use crate::error::RejectionReason;
+
+/// The validator scheduled to propose at `slot`, by round-robin over the registry.
+///
+/// # Errors
+///
+/// [`RejectionReason::EmptyValidatorRegistry`] when the registry is empty. Returning rather
+/// than dividing keeps the modulo below total.
+#[must_use = "this names the scheduled proposer; it does not check the block's claim"]
+pub const fn proposer_for_slot(
+    slot: Slot,
+    validator_count: u64,
+) -> Result<ValidatorIndex, RejectionReason> {
+    if validator_count == 0 {
+        return Err(RejectionReason::EmptyValidatorRegistry);
+    }
+    Ok(ValidatorIndex(slot.0 % validator_count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RejectionReason, Slot, ValidatorIndex, proposer_for_slot};
+
+    #[test]
+    fn should_cycle_through_the_registry_when_slots_advance() {
+        let schedule: Vec<u64> = (0..7)
+            .map(|slot| proposer_for_slot(Slot(slot), 3).unwrap().0)
+            .collect();
+        assert_eq!(schedule, vec![0, 1, 2, 0, 1, 2, 0]);
+    }
+
+    #[test]
+    fn should_reject_when_the_registry_is_empty() {
+        assert_eq!(
+            proposer_for_slot(Slot(0), 0),
+            Err(RejectionReason::EmptyValidatorRegistry)
+        );
+    }
+
+    #[test]
+    fn should_stay_within_the_registry_at_the_top_of_the_slot_range() {
+        assert_eq!(
+            proposer_for_slot(Slot(u64::MAX), 3),
+            Ok(ValidatorIndex(u64::MAX % 3))
+        );
+    }
+}

--- a/crates/verity-chain/src/state_transition/attestations.rs
+++ b/crates/verity-chain/src/state_transition/attestations.rs
@@ -47,14 +47,14 @@ pub fn process_attestations(
     state: &State,
     attestations: &[AggregatedAttestation],
 ) -> Result<State, RejectionReason> {
-    // Each distinct data builds a per-root vote table sized to the validator set, so the
-    // distinct count is what drives work. Aggregates split over one target share their data
-    // and count once.
-    let distinct: HashSet<&AttestationData> = attestations
+    // Each unique AttestationData builds a per-root vote table sized to the validator set,
+    // so the unique count is what drives work. Aggregates split over one target share their
+    // data and count once.
+    let unique_attestation_data: HashSet<&AttestationData> = attestations
         .iter()
         .map(|attestation| &attestation.data)
         .collect();
-    if distinct.len() > MAX_ATTESTATIONS_DATA as usize {
+    if unique_attestation_data.len() > MAX_ATTESTATIONS_DATA as usize {
         return Err(RejectionReason::TooManyAttestationData);
     }
 

--- a/crates/verity-chain/src/state_transition/attestations.rs
+++ b/crates/verity-chain/src/state_transition/attestations.rs
@@ -178,7 +178,7 @@ impl JustificationState {
             return Ok(false);
         }
         // Both roots must match the canonical chain; this also rejects zero-hash roots.
-        if !lies_on_chain(data, &state.historical_block_hashes) {
+        if !is_on_chain(data, &state.historical_block_hashes) {
             return Ok(false);
         }
         if target.slot.0 <= source.slot.0 {
@@ -275,7 +275,7 @@ impl JustificationState {
 }
 
 /// Whether every checkpoint in the data points at the chain view's block for its slot.
-fn lies_on_chain(data: &AttestationData, chain: &HistoricalBlockHashes) -> bool {
+fn is_on_chain(data: &AttestationData, chain: &HistoricalBlockHashes) -> bool {
     // Empty slots carry the zero hash, so a vote recording one is meaningless.
     if data.source.root == ZERO_HASH || data.target.root == ZERO_HASH || data.head.root == ZERO_HASH
     {

--- a/crates/verity-chain/src/state_transition/attestations.rs
+++ b/crates/verity-chain/src/state_transition/attestations.rs
@@ -1,0 +1,447 @@
+//! Applying a block's attestations, and the justification and finalization that follow.
+//!
+//! This is the 3SF-mini accounting. The state stores votes as one flat bitlist segmented by
+//! tracked root; this module unpacks that layout into a per-root tally, applies the block's
+//! votes, and packs it back.
+//!
+//! ```text
+//!     roots:  [root_0,  root_1,  ...]
+//!     votes:  [<--N-->][<--N-->] ...        N = validator count
+//! ```
+//!
+//! Every capacity failure here surfaces as [`RejectionReason::JustifiedSlotOutOfRange`]
+//! rather than a panic. All of them are unreachable: the tracked roots are bounded by the
+//! chain view's own SSZ limit and the votes per root by the registry's, so their product is
+//! exactly the flat bitlist's capacity. They exist so these functions are total.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use libssz_types::SszBitlist;
+use verity_types::config::MAX_ATTESTATIONS_DATA;
+use verity_types::primitives::{Bytes32, Slot, ZERO_HASH};
+use verity_types::{
+    AggregatedAttestation, AggregationBits, AttestationData, Checkpoint, HistoricalBlockHashes,
+    JustificationRoots, JustificationValidators, JustifiedSlots, State,
+};
+
+use crate::error::RejectionReason;
+use crate::justification::{is_justifiable_after, is_slot_justified, justified_index_after};
+
+/// Applies `attestations` to `state`, moving the justified and finalized checkpoints.
+///
+/// # Errors
+///
+/// - [`RejectionReason::TooManyAttestationData`] when the block carries more distinct
+///   attestation data entries than [`MAX_ATTESTATIONS_DATA`].
+/// - [`RejectionReason::EmptyValidatorRegistry`] when there is no segment width to unpack by.
+/// - [`RejectionReason::JustificationVotesLengthMismatch`] when the flat vote list is not the
+///   tracked-root count times the validator count.
+/// - [`RejectionReason::ZeroHashJustificationRoot`] when a tracked root marks an empty slot.
+/// - [`RejectionReason::EmptyAggregationBits`] when an accepted vote names no validator.
+/// - [`RejectionReason::ValidatorIndexOutOfRange`] when a set bit is outside the registry.
+/// - [`RejectionReason::JustifiedSlotOutOfRange`] when a vote reaches past the tracked window.
+#[must_use = "this returns the state after the votes; the argument keeps its old checkpoints"]
+pub fn process_attestations(
+    state: &State,
+    attestations: &[AggregatedAttestation],
+) -> Result<State, RejectionReason> {
+    // Each distinct data builds a tally sized to the validator set, so the distinct count is
+    // what drives work. Aggregates split over one target share their data and count once.
+    let distinct: HashSet<&AttestationData> = attestations
+        .iter()
+        .map(|attestation| &attestation.data)
+        .collect();
+    if distinct.len() > MAX_ATTESTATIONS_DATA as usize {
+        return Err(RejectionReason::TooManyAttestationData);
+    }
+
+    let validator_count = state.validators.len();
+    if validator_count == 0 {
+        return Err(RejectionReason::EmptyValidatorRegistry);
+    }
+
+    let mut tally = Tally::unpack(state, validator_count)?;
+    let root_to_slot = index_chain_by_slot(state);
+
+    for attestation in attestations {
+        tally.apply(attestation, state, &root_to_slot, validator_count)?;
+    }
+
+    tally.repack(state, validator_count)
+}
+
+/// Every unfinalized root in the chain view, mapped to the slot it sits at.
+///
+/// Used only to prune tallies once finalization moves; a root absent from it is off-chain.
+fn index_chain_by_slot(state: &State) -> HashMap<Bytes32, Slot> {
+    let start = state.latest_finalized.slot.0.saturating_add(1) as usize;
+    state
+        .historical_block_hashes
+        .iter()
+        .enumerate()
+        .skip(start)
+        .map(|(slot, root)| (*root, Slot(slot as u64)))
+        .collect()
+}
+
+/// The accounting carried across a block's votes, applied to the state in one step at the end.
+struct Tally {
+    /// Per-root vote flags. Ordered by root, which is what makes the repack canonical.
+    justifications: BTreeMap<Bytes32, Vec<bool>>,
+    justified_slots: JustifiedSlots,
+    latest_justified: Checkpoint,
+    latest_finalized: Checkpoint,
+}
+
+impl Tally {
+    /// Recovers the per-root tallies from the state's flat segmented layout.
+    fn unpack(state: &State, validator_count: usize) -> Result<Self, RejectionReason> {
+        let expected = state.justifications_roots.len() * validator_count;
+        if state.justifications_validators.len() != expected {
+            return Err(RejectionReason::JustificationVotesLengthMismatch);
+        }
+        // The zero hash marks a skipped slot, never a block, so it cannot carry votes.
+        if state.justifications_roots.contains(&ZERO_HASH) {
+            return Err(RejectionReason::ZeroHashJustificationRoot);
+        }
+
+        let flat = to_bits(&state.justifications_validators);
+        Ok(Self {
+            justifications: state
+                .justifications_roots
+                .iter()
+                .zip(flat.chunks_exact(validator_count))
+                .map(|(root, segment)| (*root, segment.to_vec()))
+                .collect(),
+            justified_slots: state.justified_slots.clone(),
+            latest_justified: state.latest_justified,
+            latest_finalized: state.latest_finalized,
+        })
+    }
+
+    /// Applies one aggregate, ignoring it when any vote filter drops it.
+    fn apply(
+        &mut self,
+        attestation: &AggregatedAttestation,
+        state: &State,
+        root_to_slot: &HashMap<Bytes32, Slot>,
+        validator_count: usize,
+    ) -> Result<(), RejectionReason> {
+        let (source, target) = (attestation.data.source, attestation.data.target);
+        if !self.counts(&attestation.data, state)? {
+            return Ok(());
+        }
+
+        let voters = voting_validator_indices(&attestation.aggregation_bits)?;
+        // A bit outside the registry has no flag in the tally. This guards the unsigned path,
+        // where no signature stage catches it first.
+        if voters.iter().any(|index| *index >= validator_count) {
+            return Err(RejectionReason::ValidatorIndexOutOfRange);
+        }
+
+        let votes = self
+            .justifications
+            .entry(target.root)
+            .or_insert_with(|| vec![false; validator_count]);
+        // Re-marking a voter is idempotent, so no guard is needed.
+        for index in voters {
+            votes[index] = true;
+        }
+
+        // Justified once two thirds of validators vote for the target. Compared as integers
+        // to keep floating point out of a consensus decision.
+        let count = votes.iter().filter(|voted| **voted).count();
+        if 3 * count >= 2 * validator_count {
+            self.justify(source, target, root_to_slot)?;
+        }
+        Ok(())
+    }
+
+    /// Whether a vote survives every filter and should be tallied.
+    ///
+    /// The order is leanSpec's: the two justification lookups can reject a vote outright, so
+    /// they must run before the cheaper chain and distance checks.
+    fn counts(&self, data: &AttestationData, state: &State) -> Result<bool, RejectionReason> {
+        let (source, target) = (data.source, data.target);
+        let finalized = self.latest_finalized.slot;
+
+        // A vote may only anchor on an already-justified source, and an already-justified
+        // target gains nothing from more votes.
+        if !is_slot_justified(&self.justified_slots, finalized, source.slot)? {
+            return Ok(false);
+        }
+        if is_slot_justified(&self.justified_slots, finalized, target.slot)? {
+            return Ok(false);
+        }
+        // Both roots must match the canonical chain; this also rejects zero-hash roots.
+        if !lies_on_chain(data, &state.historical_block_hashes) {
+            return Ok(false);
+        }
+        if target.slot.0 <= source.slot.0 {
+            return Ok(false);
+        }
+        // 3SF-mini admits a target only at a justifiable distance from the boundary.
+        Ok(is_justifiable_after(target.slot, finalized))
+    }
+
+    /// Records `target` as justified, then finalizes `source` when nothing sits between them.
+    fn justify(
+        &mut self,
+        source: Checkpoint,
+        target: Checkpoint,
+        root_to_slot: &HashMap<Bytes32, Slot>,
+    ) -> Result<(), RejectionReason> {
+        let finalized = self.latest_finalized.slot;
+
+        // Targets within one block can resolve out of order, so an earlier target seen after
+        // a later one must not drag the checkpoint back.
+        if target.slot.0 > self.latest_justified.slot.0 {
+            self.latest_justified = target;
+        }
+
+        // In range: `apply` already dropped every target at or behind the boundary, and the
+        // header stage grew the bitfield to cover the block's slot.
+        let index = justified_index_after(target.slot, finalized)
+            .ok_or(RejectionReason::JustifiedSlotOutOfRange)?;
+        self.justified_slots
+            .set(index, true)
+            .map_err(|_| RejectionReason::JustifiedSlotOutOfRange)?;
+
+        // The target is justified; its individual votes no longer matter.
+        self.justifications.remove(&target.root);
+
+        // Finalize the source when no justifiable slot sits strictly between it and the
+        // target. A source at or behind the boundary is already final.
+        let nothing_between = ((source.slot.0 + 1)..target.slot.0)
+            .all(|slot| !is_justifiable_after(Slot(slot), finalized));
+        if source.slot.0 > finalized.0 && nothing_between {
+            self.rebase_onto(source, finalized, root_to_slot)?;
+        }
+        Ok(())
+    }
+
+    /// Moves the finalized boundary to `source` and drops what it leaves behind.
+    fn rebase_onto(
+        &mut self,
+        source: Checkpoint,
+        old_finalized: Slot,
+        root_to_slot: &HashMap<Bytes32, Slot>,
+    ) -> Result<(), RejectionReason> {
+        self.latest_finalized = source;
+        let finalized = source.slot;
+
+        // Flags start one past the finalized slot, so advancing the boundary drops that many
+        // from the front.
+        let delta = (finalized.0 - old_finalized.0) as usize;
+        if delta > 0 {
+            let mut bits = to_bits(&self.justified_slots);
+            bits.drain(..delta.min(bits.len()));
+            self.justified_slots = from_bits(bits)?;
+
+            // A root absent from the chain view is off-chain and can never justify. Drop such
+            // a tally rather than tracking or rejecting it.
+            self.justifications.retain(|root, _| {
+                root_to_slot
+                    .get(root)
+                    .is_some_and(|slot| slot.0 > finalized.0)
+            });
+        }
+        Ok(())
+    }
+
+    /// Flattens the tallies back into the state's segmented layout, roots first.
+    fn repack(self, state: &State, validator_count: usize) -> Result<State, RejectionReason> {
+        let mut roots = JustificationRoots::default();
+        let mut votes: Vec<bool> = Vec::with_capacity(self.justifications.len() * validator_count);
+        for (root, segment) in &self.justifications {
+            roots
+                .push(*root)
+                .map_err(|_| RejectionReason::JustifiedSlotOutOfRange)?;
+            votes.extend_from_slice(segment);
+        }
+        let justifications_validators: JustificationValidators = from_bits(votes)?;
+
+        Ok(State {
+            justifications_roots: roots,
+            justifications_validators,
+            justified_slots: self.justified_slots,
+            latest_justified: self.latest_justified,
+            latest_finalized: self.latest_finalized,
+            ..state.clone()
+        })
+    }
+}
+
+/// Whether every checkpoint in the data points at the chain view's block for its slot.
+fn lies_on_chain(data: &AttestationData, chain: &HistoricalBlockHashes) -> bool {
+    // Empty slots carry the zero hash, so a vote recording one is meaningless.
+    if data.source.root == ZERO_HASH || data.target.root == ZERO_HASH || data.head.root == ZERO_HASH
+    {
+        return false;
+    }
+    let length = chain.len() as u64;
+    if data.source.slot.0 >= length || data.target.slot.0 >= length || data.head.slot.0 >= length {
+        return false;
+    }
+    chain[data.source.slot.0 as usize] == data.source.root
+        && chain[data.target.slot.0 as usize] == data.target.root
+        && chain[data.head.slot.0 as usize] == data.head.root
+}
+
+/// The validator indices an aggregate names, ascending.
+///
+/// # Errors
+///
+/// [`RejectionReason::EmptyAggregationBits`] when the aggregate names nobody.
+fn voting_validator_indices(bits: &AggregationBits) -> Result<Vec<usize>, RejectionReason> {
+    let indices: Vec<usize> = (0..bits.len())
+        .filter(|index| bits.get(*index) == Some(true))
+        .collect();
+    if indices.is_empty() {
+        return Err(RejectionReason::EmptyAggregationBits);
+    }
+    Ok(indices)
+}
+
+/// Reads a bitlist out as plain flags, for the operations SSZ bitlists do not offer.
+fn to_bits<const N: usize>(bitlist: &SszBitlist<N>) -> Vec<bool> {
+    (0..bitlist.len())
+        .map(|index| bitlist.get(index).unwrap_or(false))
+        .collect()
+}
+
+/// Rebuilds a bitlist from plain flags.
+fn from_bits<const N: usize>(bits: Vec<bool>) -> Result<SszBitlist<N>, RejectionReason> {
+    SszBitlist::try_from(bits).map_err(|_| RejectionReason::JustifiedSlotOutOfRange)
+}
+
+#[cfg(test)]
+mod tests {
+    use verity_types::{AttestationData, Checkpoint};
+
+    use crate::state_transition::testing::genesis_with;
+
+    use super::{
+        AggregatedAttestation, AggregationBits, MAX_ATTESTATIONS_DATA, RejectionReason, Slot,
+        State, ZERO_HASH, process_attestations,
+    };
+
+    /// Genesis with the justification bitfield already grown, as the header stage leaves it.
+    ///
+    /// Without it every lookup past the boundary is out of range, which is a state no block
+    /// can reach: `process_block_header` grows the bitfield before attestations are applied.
+    fn tracked_genesis(validators: u64) -> State {
+        let mut state = genesis_with(validators);
+        state.justified_slots = super::from_bits(vec![false; 8]).expect("eight bits fit");
+        state
+    }
+
+    fn attestation(target_slot: u64, bits: &[bool]) -> AggregatedAttestation {
+        AggregatedAttestation {
+            aggregation_bits: AggregationBits::try_from(bits.to_vec())
+                .expect("well under the registry limit"),
+            data: AttestationData {
+                slot: Slot(target_slot),
+                head: Checkpoint {
+                    root: [1u8; 32],
+                    slot: Slot(target_slot),
+                },
+                target: Checkpoint {
+                    root: [1u8; 32],
+                    slot: Slot(target_slot),
+                },
+                source: Checkpoint {
+                    root: [2u8; 32],
+                    slot: Slot(0),
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn should_reject_more_distinct_attestation_data_than_the_cap() {
+        let state = tracked_genesis(4);
+        let votes: Vec<_> = (1..=u64::from(MAX_ATTESTATIONS_DATA) + 1)
+            .map(|slot| attestation(slot, &[true]))
+            .collect();
+        assert_eq!(
+            process_attestations(&state, &votes),
+            Err(RejectionReason::TooManyAttestationData)
+        );
+    }
+
+    #[test]
+    fn should_count_repeated_data_once_against_the_cap() {
+        let state = tracked_genesis(4);
+        let votes: Vec<_> = (0..u64::from(MAX_ATTESTATIONS_DATA) + 4)
+            .map(|_| attestation(1, &[true]))
+            .collect();
+        assert!(
+            process_attestations(&state, &votes).is_ok(),
+            "split aggregates for one target share their data and count once"
+        );
+    }
+
+    #[test]
+    fn should_reject_when_the_registry_is_empty() {
+        let state = genesis_with(0);
+        assert_eq!(
+            process_attestations(&state, &[]),
+            Err(RejectionReason::EmptyValidatorRegistry)
+        );
+    }
+
+    #[test]
+    fn should_reject_a_vote_list_that_does_not_segment_by_the_registry() {
+        let mut state = tracked_genesis(4);
+        state.justifications_roots.push([3u8; 32]).unwrap();
+        // One root and four validators need four flags; three cannot be segmented.
+        state.justifications_validators =
+            super::from_bits(vec![false, false, false]).expect("three bits fit");
+        assert_eq!(
+            process_attestations(&state, &[]),
+            Err(RejectionReason::JustificationVotesLengthMismatch)
+        );
+    }
+
+    #[test]
+    fn should_reject_a_tracked_root_that_marks_an_empty_slot() {
+        let mut state = tracked_genesis(4);
+        state.justifications_roots.push(ZERO_HASH).unwrap();
+        state.justifications_validators = super::from_bits(vec![false; 4]).expect("four bits fit");
+        assert_eq!(
+            process_attestations(&state, &[]),
+            Err(RejectionReason::ZeroHashJustificationRoot)
+        );
+    }
+
+    #[test]
+    fn should_leave_the_state_alone_when_a_vote_names_no_block_on_the_chain() {
+        let state: State = tracked_genesis(4);
+        // The chain view is empty at genesis, so no checkpoint can be on it.
+        let post = process_attestations(&state, &[attestation(1, &[true])]).unwrap();
+        assert_eq!(post.latest_justified, state.latest_justified);
+        assert_eq!(post.latest_finalized, state.latest_finalized);
+        assert!(post.justifications_roots.is_empty());
+    }
+
+    #[test]
+    fn should_reject_an_aggregate_that_names_nobody_before_it_reaches_the_tally() {
+        assert_eq!(
+            super::voting_validator_indices(
+                &AggregationBits::try_from(vec![false, false]).unwrap()
+            ),
+            Err(RejectionReason::EmptyAggregationBits)
+        );
+    }
+
+    #[test]
+    fn should_list_every_set_bit_in_ascending_order() {
+        assert_eq!(
+            super::voting_validator_indices(
+                &AggregationBits::try_from(vec![false, true, false, true]).unwrap()
+            ),
+            Ok(vec![1, 3])
+        );
+    }
+}

--- a/crates/verity-chain/src/state_transition/attestations.rs
+++ b/crates/verity-chain/src/state_transition/attestations.rs
@@ -1,7 +1,7 @@
 //! Applying a block's attestations, and the justification and finalization that follow.
 //!
 //! This is the 3SF-mini accounting. The state stores votes as one flat bitlist segmented by
-//! tracked root; this module unpacks that layout into a per-root tally, applies the block's
+//! tracked root; this module unpacks that layout into per-root vote flags, applies the block's
 //! votes, and packs it back.
 //!
 //! ```text
@@ -25,7 +25,9 @@ use verity_types::{
 };
 
 use crate::error::RejectionReason;
-use crate::justification::{is_justifiable_after, is_slot_justified, justified_index_after};
+use crate::justification::{
+    advance_checkpoint, is_justifiable_after, is_slot_justified, justified_index_after,
+};
 
 /// Applies `attestations` to `state`, moving the justified and finalized checkpoints.
 ///
@@ -45,8 +47,9 @@ pub fn process_attestations(
     state: &State,
     attestations: &[AggregatedAttestation],
 ) -> Result<State, RejectionReason> {
-    // Each distinct data builds a tally sized to the validator set, so the distinct count is
-    // what drives work. Aggregates split over one target share their data and count once.
+    // Each distinct data builds a per-root vote table sized to the validator set, so the
+    // distinct count is what drives work. Aggregates split over one target share their data
+    // and count once.
     let distinct: HashSet<&AttestationData> = attestations
         .iter()
         .map(|attestation| &attestation.data)
@@ -60,19 +63,19 @@ pub fn process_attestations(
         return Err(RejectionReason::EmptyValidatorRegistry);
     }
 
-    let mut tally = Tally::unpack(state, validator_count)?;
+    let mut justification_state = JustificationState::unpack(state, validator_count)?;
     let root_to_slot = index_chain_by_slot(state);
 
     for attestation in attestations {
-        tally.apply(attestation, state, &root_to_slot, validator_count)?;
+        justification_state.apply(attestation, state, &root_to_slot, validator_count)?;
     }
 
-    tally.repack(state, validator_count)
+    justification_state.repack(state, validator_count)
 }
 
 /// Every unfinalized root in the chain view, mapped to the slot it sits at.
 ///
-/// Used only to prune tallies once finalization moves; a root absent from it is off-chain.
+/// Used only to prune tracked roots once finalization moves; a root absent from it is off-chain.
 fn index_chain_by_slot(state: &State) -> HashMap<Bytes32, Slot> {
     let start = state.latest_finalized.slot.0.saturating_add(1) as usize;
     state
@@ -84,8 +87,9 @@ fn index_chain_by_slot(state: &State) -> HashMap<Bytes32, Slot> {
         .collect()
 }
 
-/// The accounting carried across a block's votes, applied to the state in one step at the end.
-struct Tally {
+/// The justification and finalization accounting carried across a block's votes,
+/// applied to the state in one step at the end.
+struct JustificationState {
     /// Per-root vote flags. Ordered by root, which is what makes the repack canonical.
     justifications: BTreeMap<Bytes32, Vec<bool>>,
     justified_slots: JustifiedSlots,
@@ -93,8 +97,8 @@ struct Tally {
     latest_finalized: Checkpoint,
 }
 
-impl Tally {
-    /// Recovers the per-root tallies from the state's flat segmented layout.
+impl JustificationState {
+    /// Recovers the per-root vote flags from the state's flat segmented layout.
     fn unpack(state: &State, validator_count: usize) -> Result<Self, RejectionReason> {
         let expected = state.justifications_roots.len() * validator_count;
         if state.justifications_validators.len() != expected {
@@ -133,8 +137,8 @@ impl Tally {
         }
 
         let voters = voting_validator_indices(&attestation.aggregation_bits)?;
-        // A bit outside the registry has no flag in the tally. This guards the unsigned path,
-        // where no signature stage catches it first.
+        // A bit outside the registry has no flag in the per-root vote table. This guards the
+        // unsigned path, where no signature stage catches it first.
         if voters.iter().any(|index| *index >= validator_count) {
             return Err(RejectionReason::ValidatorIndexOutOfRange);
         }
@@ -157,7 +161,7 @@ impl Tally {
         Ok(())
     }
 
-    /// Whether a vote survives every filter and should be tallied.
+    /// Whether a vote survives every filter and should be counted.
     ///
     /// The order is leanSpec's: the two justification lookups can reject a vote outright, so
     /// they must run before the cheaper chain and distance checks.
@@ -195,9 +199,7 @@ impl Tally {
 
         // Targets within one block can resolve out of order, so an earlier target seen after
         // a later one must not drag the checkpoint back.
-        if target.slot.0 > self.latest_justified.slot.0 {
-            self.latest_justified = target;
-        }
+        self.latest_justified = advance_checkpoint(self.latest_justified, target);
 
         // In range: `apply` already dropped every target at or behind the boundary, and the
         // header stage grew the bitfield to cover the block's slot.
@@ -239,7 +241,7 @@ impl Tally {
             self.justified_slots = from_bits(bits)?;
 
             // A root absent from the chain view is off-chain and can never justify. Drop such
-            // a tally rather than tracking or rejecting it.
+            // a per-root vote table rather than tracking or rejecting it.
             self.justifications.retain(|root, _| {
                 root_to_slot
                     .get(root)
@@ -249,7 +251,7 @@ impl Tally {
         Ok(())
     }
 
-    /// Flattens the tallies back into the state's segmented layout, roots first.
+    /// Flattens the per-root vote flags back into the state's segmented layout, roots first.
     fn repack(self, state: &State, validator_count: usize) -> Result<State, RejectionReason> {
         let mut roots = JustificationRoots::default();
         let mut votes: Vec<bool> = Vec::with_capacity(self.justifications.len() * validator_count);
@@ -426,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn should_reject_an_aggregate_that_names_nobody_before_it_reaches_the_tally() {
+    fn should_reject_an_aggregate_that_names_nobody_before_it_reaches_the_vote_table() {
         assert_eq!(
             super::voting_validator_indices(
                 &AggregationBits::try_from(vec![false, false]).unwrap()

--- a/crates/verity-chain/src/state_transition/genesis.rs
+++ b/crates/verity-chain/src/state_transition/genesis.rs
@@ -1,0 +1,85 @@
+//! The genesis state a chain starts from.
+
+use verity_types::primitives::{Slot, ValidatorIndex, ZERO_HASH};
+use verity_types::{BlockBody, BlockHeader, Checkpoint, GenesisConfig, State, Validators};
+
+use crate::merkle::hash_tree_root;
+
+/// Builds the genesis state for a registry, anchored at `genesis_time` (Unix seconds).
+///
+/// History is empty and both checkpoints are the zero anchor. The genesis header's body root
+/// is the root of an empty body, which is what makes the first real block's `parent_root`
+/// computable before any block exists.
+#[must_use = "this builds the genesis state; it neither stores nor starts a chain"]
+pub fn generate_genesis(genesis_time: u64, validators: Validators) -> State {
+    let genesis_header = BlockHeader {
+        slot: Slot(0),
+        proposer_index: ValidatorIndex(0),
+        parent_root: ZERO_HASH,
+        state_root: ZERO_HASH,
+        body_root: hash_tree_root(&BlockBody::default()),
+    };
+
+    State {
+        config: GenesisConfig { genesis_time },
+        slot: Slot(0),
+        latest_block_header: genesis_header,
+        latest_justified: Checkpoint {
+            root: ZERO_HASH,
+            slot: Slot(0),
+        },
+        latest_finalized: Checkpoint {
+            root: ZERO_HASH,
+            slot: Slot(0),
+        },
+        historical_block_hashes: Default::default(),
+        justified_slots: Default::default(),
+        validators,
+        justifications_roots: Default::default(),
+        justifications_validators: Default::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use verity_types::primitives::ZERO_HASH;
+
+    use crate::merkle::hash_tree_root;
+    use crate::state_transition::testing::genesis_with;
+
+    use super::{BlockBody, Slot, generate_genesis};
+
+    #[test]
+    fn should_root_the_empty_body_into_the_genesis_header() {
+        let state = genesis_with(4);
+        assert_eq!(
+            state.latest_block_header.body_root,
+            hash_tree_root(&BlockBody::default()),
+            "the first block's parent root depends on this"
+        );
+    }
+
+    #[test]
+    fn should_anchor_both_checkpoints_at_the_zero_root_and_slot_zero() {
+        let state = genesis_with(4);
+        for checkpoint in [state.latest_justified, state.latest_finalized] {
+            assert_eq!(checkpoint.root, ZERO_HASH);
+            assert_eq!(checkpoint.slot, Slot(0));
+        }
+    }
+
+    #[test]
+    fn should_start_with_no_history_and_no_votes_in_flight() {
+        let state = genesis_with(4);
+        assert!(state.historical_block_hashes.is_empty());
+        assert!(state.justified_slots.is_empty());
+        assert!(state.justifications_roots.is_empty());
+        assert!(state.justifications_validators.is_empty());
+    }
+
+    #[test]
+    fn should_carry_the_genesis_time_it_was_given() {
+        let state = generate_genesis(1_234_567_890, genesis_with(1).validators);
+        assert_eq!(state.config.genesis_time, 1_234_567_890);
+    }
+}

--- a/crates/verity-chain/src/state_transition/header.rs
+++ b/crates/verity-chain/src/state_transition/header.rs
@@ -1,0 +1,219 @@
+//! Header validation and the header-linked state it updates.
+
+use verity_types::primitives::{Slot, ZERO_HASH};
+use verity_types::{Block, BlockHeader, Checkpoint, State};
+
+use crate::error::RejectionReason;
+use crate::justification::extend_justified_slots_to;
+use crate::merkle::hash_tree_root;
+use crate::proposer::proposer_for_slot;
+
+/// Validates `block`'s header against `state` and applies what the header alone determines.
+///
+/// The body is not read here beyond its root. Attestations are applied afterwards, by
+/// [`crate::state_transition::process_attestations`].
+///
+/// # Errors
+///
+/// - [`RejectionReason::BlockSlotMismatch`] when the block does not sit at the state's slot.
+/// - [`RejectionReason::BlockOlderThanLatestHeader`] when it does not advance past the tip.
+/// - [`RejectionReason::EmptyValidatorRegistry`] when no proposer can be scheduled.
+/// - [`RejectionReason::WrongProposer`] when the proposer is not the scheduled one.
+/// - [`RejectionReason::ParentRootMismatch`] when it does not point at the known parent.
+/// - [`RejectionReason::BlockSlotGapTooLarge`] when recording the skipped slots would overrun
+///   the chain view's SSZ limit.
+/// - [`RejectionReason::JustifiedSlotOutOfRange`] when the justification bitfield cannot grow
+///   to cover the block's slot.
+#[must_use = "this returns the state after the header; the argument is left untouched"]
+pub fn process_block_header(state: &State, block: &Block) -> Result<State, RejectionReason> {
+    let parent_header = state.latest_block_header;
+    let parent_root = hash_tree_root(&parent_header);
+
+    validate(state, block, parent_root)?;
+    let (latest_justified, latest_finalized) = anchor_checkpoints(state, parent_root);
+    let historical_block_hashes = record_parent_and_skipped_slots(state, block, parent_root)?;
+
+    // Flags are stored relative to the finalized boundary. The current slot is not
+    // materialized until its header finishes, so tracking stops one short of it.
+    let justified_slots = extend_justified_slots_to(
+        &state.justified_slots,
+        latest_finalized.slot,
+        Slot(block.slot.0 - 1),
+    )?;
+
+    Ok(State {
+        latest_justified,
+        latest_finalized,
+        historical_block_hashes,
+        justified_slots,
+        // The state root stays empty until the body is processed or the next slot begins.
+        latest_block_header: BlockHeader {
+            slot: block.slot,
+            proposer_index: block.proposer_index,
+            parent_root: block.parent_root,
+            state_root: ZERO_HASH,
+            body_root: hash_tree_root(&block.body),
+        },
+        ..state.clone()
+    })
+}
+
+/// Every header check, in leanSpec's order.
+fn validate(
+    state: &State,
+    block: &Block,
+    parent_root: verity_types::Bytes32,
+) -> Result<(), RejectionReason> {
+    // The block must sit at the slot the state was advanced to.
+    if block.slot != state.slot {
+        return Err(RejectionReason::BlockSlotMismatch);
+    }
+    // It must be newer than the latest header.
+    if block.slot.0 <= state.latest_block_header.slot.0 {
+        return Err(RejectionReason::BlockOlderThanLatestHeader);
+    }
+    // It must come from the validator assigned to this slot.
+    let validator_count = state.validators.len() as u64;
+    if block.proposer_index != proposer_for_slot(state.slot, validator_count)? {
+        return Err(RejectionReason::WrongProposer);
+    }
+    // It must point at the known parent.
+    if block.parent_root != parent_root {
+        return Err(RejectionReason::ParentRootMismatch);
+    }
+    Ok(())
+}
+
+/// The justified and finalized checkpoints the header stage leaves in place.
+///
+/// Genesis is the chain's anchor, justified and finalized by definition, so the first block
+/// forces its parent to both. Every later block keeps what only attestations move.
+fn anchor_checkpoints(
+    state: &State,
+    parent_root: verity_types::Bytes32,
+) -> (Checkpoint, Checkpoint) {
+    if state.latest_block_header.slot.0 != 0 {
+        return (state.latest_justified, state.latest_finalized);
+    }
+    let anchor = Checkpoint {
+        root: parent_root,
+        slot: Slot(0),
+    };
+    (anchor, anchor)
+}
+
+/// Appends the parent root, then one zero hash per slot missed since the parent.
+fn record_parent_and_skipped_slots(
+    state: &State,
+    block: &Block,
+    parent_root: verity_types::Bytes32,
+) -> Result<verity_types::HistoricalBlockHashes, RejectionReason> {
+    // Cannot underflow: the caller established `block.slot > parent_header.slot`.
+    let empty_slots = block.slot.0 - state.latest_block_header.slot.0 - 1;
+
+    let mut hashes = state.historical_block_hashes.clone();
+    hashes
+        .push(parent_root)
+        .map_err(|_| RejectionReason::BlockSlotGapTooLarge)?;
+    for _ in 0..empty_slots {
+        hashes
+            .push(ZERO_HASH)
+            .map_err(|_| RejectionReason::BlockSlotGapTooLarge)?;
+    }
+    Ok(hashes)
+}
+
+#[cfg(test)]
+mod tests {
+    use verity_types::primitives::ZERO_HASH;
+
+    use crate::state_transition::process_slots;
+    use crate::state_transition::testing::{empty_block_at, genesis_with};
+
+    use super::{RejectionReason, Slot, process_block_header};
+
+    /// Genesis advanced to slot 1, which is where a first block is applied from.
+    fn at_slot_one() -> verity_types::State {
+        process_slots(&genesis_with(4), Slot(1)).expect("slot 1 is ahead of genesis")
+    }
+
+    #[test]
+    fn should_accept_the_first_block_after_genesis() {
+        let state = at_slot_one();
+        let block = empty_block_at(&state, 1);
+        let post = process_block_header(&state, &block).expect("a well-formed first block");
+        assert_eq!(post.latest_block_header.slot, Slot(1));
+        assert_eq!(
+            post.latest_block_header.state_root, ZERO_HASH,
+            "the root is filled by the next slot, not by the header stage"
+        );
+    }
+
+    #[test]
+    fn should_reject_when_the_block_does_not_sit_at_the_state_slot() {
+        let state = at_slot_one();
+        let mut block = empty_block_at(&state, 1);
+        block.slot = Slot(2);
+        assert_eq!(
+            process_block_header(&state, &block),
+            Err(RejectionReason::BlockSlotMismatch)
+        );
+    }
+
+    #[test]
+    fn should_reject_when_the_proposer_is_not_the_scheduled_one() {
+        let state = at_slot_one();
+        let mut block = empty_block_at(&state, 1);
+        block.proposer_index = verity_types::ValidatorIndex(block.proposer_index.0 + 1);
+        assert_eq!(
+            process_block_header(&state, &block),
+            Err(RejectionReason::WrongProposer)
+        );
+    }
+
+    #[test]
+    fn should_reject_when_the_parent_root_does_not_match_the_tip() {
+        let state = at_slot_one();
+        let mut block = empty_block_at(&state, 1);
+        block.parent_root = [9u8; 32];
+        assert_eq!(
+            process_block_header(&state, &block),
+            Err(RejectionReason::ParentRootMismatch)
+        );
+    }
+
+    #[test]
+    fn should_anchor_both_checkpoints_on_the_parent_when_it_is_genesis() {
+        let state = at_slot_one();
+        let block = empty_block_at(&state, 1);
+        let post = process_block_header(&state, &block).unwrap();
+        assert_eq!(post.latest_justified.root, block.parent_root);
+        assert_eq!(post.latest_finalized.root, block.parent_root);
+        assert_eq!(post.latest_justified.slot, Slot(0));
+    }
+
+    #[test]
+    fn should_record_the_parent_then_one_zero_hash_per_slot_missed() {
+        let state = process_slots(&genesis_with(4), Slot(4)).unwrap();
+        let block = empty_block_at(&state, 4);
+        let post = process_block_header(&state, &block).unwrap();
+
+        let recorded: Vec<_> = post.historical_block_hashes.iter().copied().collect();
+        assert_eq!(
+            recorded,
+            vec![block.parent_root, ZERO_HASH, ZERO_HASH, ZERO_HASH],
+            "slots 1 through 3 were missed"
+        );
+    }
+
+    #[test]
+    fn should_grow_the_justification_bitfield_to_one_short_of_the_block() {
+        let state = process_slots(&genesis_with(4), Slot(4)).unwrap();
+        let post = process_block_header(&state, &empty_block_at(&state, 4)).unwrap();
+        assert_eq!(
+            post.justified_slots.len(),
+            3,
+            "the block's own slot is not materialized until its header finishes"
+        );
+    }
+}

--- a/crates/verity-chain/src/state_transition/header.rs
+++ b/crates/verity-chain/src/state_transition/header.rs
@@ -30,7 +30,7 @@ pub fn process_block_header(state: &State, block: &Block) -> Result<State, Rejec
     let parent_root = hash_tree_root(&parent_header);
 
     validate(state, block, parent_root)?;
-    let (latest_justified, latest_finalized) = anchor_checkpoints(state, parent_root);
+    let (latest_justified, latest_finalized) = derive_header_checkpoints(state, parent_root);
     let historical_block_hashes = record_parent_and_skipped_slots(state, block, parent_root)?;
 
     // Flags are stored relative to the finalized boundary. The current slot is not
@@ -84,11 +84,11 @@ fn validate(
     Ok(())
 }
 
-/// The justified and finalized checkpoints the header stage leaves in place.
+/// Derives the justified and finalized checkpoints for the post-header state.
 ///
 /// Genesis is the chain's anchor, justified and finalized by definition, so the first block
 /// forces its parent to both. Every later block keeps what only attestations move.
-fn anchor_checkpoints(
+fn derive_header_checkpoints(
     state: &State,
     parent_root: verity_types::Bytes32,
 ) -> (Checkpoint, Checkpoint) {

--- a/crates/verity-chain/src/state_transition/mod.rs
+++ b/crates/verity-chain/src/state_transition/mod.rs
@@ -1,0 +1,129 @@
+//! The state transition: how a block moves the consensus state forward.
+//!
+//! Signatures are verified before any of this runs. Nothing here reads a key, a clock, a
+//! socket, or a database — the transition is a pure function from a pre-state and a block to
+//! a post-state, which is what keeps it a candidate to move into the Verified Core whole.
+//!
+//! Transcribed from leanSpec `src/lean_spec/spec/forks/lstar/state_transition.py`, read at
+//! commit `0588c2d215a955a516378677a92db2a5666802f3`.
+
+pub mod attestations;
+pub mod genesis;
+pub mod header;
+pub mod slots;
+
+pub use attestations::process_attestations;
+pub use genesis::generate_genesis;
+pub use header::process_block_header;
+pub use slots::process_slots;
+
+use verity_types::{Block, State};
+
+use crate::error::RejectionReason;
+use crate::merkle::hash_tree_root;
+
+/// Applies `block` to `state`, advancing through any empty slots first.
+///
+/// # Errors
+///
+/// Any [`RejectionReason`] the stages below produce, plus
+/// [`RejectionReason::StateRootMismatch`] when the block does not commit to the post-state it
+/// actually produces.
+#[must_use = "this returns the post-state; the argument is not advanced in place"]
+pub fn state_transition(state: &State, block: &Block) -> Result<State, RejectionReason> {
+    let advanced = process_slots(state, block.slot)?;
+    let post = process_block(&advanced, block)?;
+
+    if block.state_root != hash_tree_root(&post) {
+        return Err(RejectionReason::StateRootMismatch);
+    }
+    Ok(post)
+}
+
+/// Applies a block that already sits at the state's slot: header first, then the body.
+///
+/// # Errors
+///
+/// Any [`RejectionReason`] from header validation or attestation processing.
+#[must_use = "this returns the state after the block; the argument is left untouched"]
+pub fn process_block(state: &State, block: &Block) -> Result<State, RejectionReason> {
+    let with_header = process_block_header(state, block)?;
+    process_attestations(&with_header, &block.body.attestations)
+}
+
+#[cfg(test)]
+pub(crate) mod testing {
+    //! Builders shared by the unit tests of this module's submodules.
+
+    use verity_types::primitives::ZERO_HASH;
+    use verity_types::{Block, BlockBody, Slot, State, Validator, ValidatorIndex, Validators};
+
+    use crate::merkle::hash_tree_root;
+    use crate::proposer::proposer_for_slot;
+
+    use super::generate_genesis;
+
+    /// A genesis state holding `count` distinguishable validators.
+    pub(crate) fn genesis_with(count: u64) -> State {
+        let mut validators = Validators::default();
+        for index in 0..count {
+            let seed = u8::try_from(index % 256).expect("modulo keeps this in range");
+            validators
+                .push(Validator {
+                    attestation_public_key: [seed; 52],
+                    proposal_public_key: [seed.wrapping_add(128); 52],
+                    index: ValidatorIndex(index),
+                })
+                .expect("count stays well under the registry limit");
+        }
+        generate_genesis(0, validators)
+    }
+
+    /// An empty block that `state` should accept, assuming it already sits at `slot`.
+    pub(crate) fn empty_block_at(state: &State, slot: u64) -> Block {
+        Block {
+            slot: Slot(slot),
+            proposer_index: proposer_for_slot(Slot(slot), state.validators.len() as u64)
+                .expect("the registry is not empty"),
+            parent_root: hash_tree_root(&state.latest_block_header),
+            state_root: ZERO_HASH,
+            body: BlockBody::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use verity_types::Slot;
+
+    use crate::error::RejectionReason;
+    use crate::merkle::hash_tree_root;
+
+    use super::testing::{empty_block_at, genesis_with};
+    use super::{process_slots, state_transition};
+
+    #[test]
+    fn should_reject_a_block_that_does_not_commit_to_the_state_it_produces() {
+        let genesis = genesis_with(4);
+        let advanced = process_slots(&genesis, Slot(1)).unwrap();
+        let mut block = empty_block_at(&advanced, 1);
+        block.state_root = [5u8; 32];
+
+        assert_eq!(
+            state_transition(&genesis, &block),
+            Err(RejectionReason::StateRootMismatch)
+        );
+    }
+
+    #[test]
+    fn should_accept_a_block_committing_to_its_own_post_state() {
+        let genesis = genesis_with(4);
+        let advanced = process_slots(&genesis, Slot(1)).unwrap();
+        let mut block = empty_block_at(&advanced, 1);
+        block.state_root = hash_tree_root(&super::process_block(&advanced, &block).unwrap());
+
+        let post = state_transition(&genesis, &block).expect("a self-consistent block");
+        assert_eq!(post.slot, Slot(1));
+        assert_eq!(hash_tree_root(&post), block.state_root);
+    }
+}

--- a/crates/verity-chain/src/state_transition/slots.rs
+++ b/crates/verity-chain/src/state_transition/slots.rs
@@ -1,0 +1,102 @@
+//! Advancing the state through slots that carry no block.
+
+use verity_types::State;
+use verity_types::config::HISTORICAL_ROOTS_LIMIT;
+use verity_types::primitives::{Slot, ZERO_HASH};
+
+use crate::error::RejectionReason;
+use crate::merkle::hash_tree_root;
+
+/// Advances `state` through empty slots up to, but not including, `target_slot`.
+///
+/// The pre-block state root is cached into the latest header at most once per block: the
+/// header's root is empty only on the first empty slot after a block, and later slots reuse
+/// what that one filled in.
+///
+/// # Errors
+///
+/// - [`RejectionReason::BlockSlotNotInFuture`] when `target_slot` is not ahead of the state.
+/// - [`RejectionReason::BlockSlotGapTooLarge`] when the walk would run longer than
+///   [`HISTORICAL_ROOTS_LIMIT`] slots. leanSpec places this guard in fork choice, immediately
+///   before it calls the transition; Verity places it at the transition's own entry so the
+///   loop is bounded by the function's own signature rather than by its caller. The threshold
+///   is leanSpec's, unchanged.
+#[must_use = "this returns the advanced state; the argument is left at its original slot"]
+pub fn process_slots(state: &State, target_slot: Slot) -> Result<State, RejectionReason> {
+    if state.slot.0 >= target_slot.0 {
+        return Err(RejectionReason::BlockSlotNotInFuture);
+    }
+    // The subtraction cannot underflow: the branch above established `target_slot > slot`.
+    if target_slot.0 - state.slot.0 > HISTORICAL_ROOTS_LIMIT as u64 {
+        return Err(RejectionReason::BlockSlotGapTooLarge);
+    }
+
+    let mut advanced = state.clone();
+    while advanced.slot.0 < target_slot.0 {
+        if advanced.latest_block_header.state_root == ZERO_HASH {
+            // Rooted before the slot moves, so the cached root is the pre-advance state.
+            advanced.latest_block_header.state_root = hash_tree_root(&advanced);
+        }
+        advanced.slot = Slot(advanced.slot.0 + 1);
+    }
+    Ok(advanced)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::merkle::hash_tree_root;
+    use crate::state_transition::testing::genesis_with;
+
+    use super::{HISTORICAL_ROOTS_LIMIT, RejectionReason, Slot, ZERO_HASH, process_slots};
+
+    #[test]
+    fn should_reject_when_the_target_slot_is_not_ahead_of_the_state() {
+        let state = genesis_with(4);
+        assert_eq!(
+            process_slots(&state, Slot(0)),
+            Err(RejectionReason::BlockSlotNotInFuture)
+        );
+    }
+
+    #[test]
+    fn should_stop_at_the_target_slot() {
+        let advanced = process_slots(&genesis_with(4), Slot(3)).unwrap();
+        assert_eq!(advanced.slot, Slot(3));
+    }
+
+    #[test]
+    fn should_cache_the_pre_block_state_root_once_and_then_leave_it_alone() {
+        let genesis = genesis_with(4);
+        let expected = hash_tree_root(&genesis);
+
+        let one = process_slots(&genesis, Slot(1)).unwrap();
+        assert_eq!(
+            one.latest_block_header.state_root, expected,
+            "the first empty slot fills the header's empty root"
+        );
+
+        let many = process_slots(&genesis, Slot(9)).unwrap();
+        assert_eq!(
+            many.latest_block_header.state_root, expected,
+            "later empty slots must reuse it, not re-root the advanced state"
+        );
+    }
+
+    #[test]
+    fn should_leave_the_header_root_untouched_when_it_is_already_filled() {
+        let mut state = genesis_with(4);
+        state.latest_block_header.state_root = [7u8; 32];
+        let advanced = process_slots(&state, Slot(4)).unwrap();
+        assert_eq!(advanced.latest_block_header.state_root, [7u8; 32]);
+        assert_ne!(advanced.latest_block_header.state_root, ZERO_HASH);
+    }
+
+    #[test]
+    fn should_reject_a_walk_longer_than_the_tracked_history_rather_than_spin() {
+        let state = genesis_with(4);
+        assert_eq!(
+            process_slots(&state, Slot(HISTORICAL_ROOTS_LIMIT as u64 + 1)),
+            Err(RejectionReason::BlockSlotGapTooLarge)
+        );
+    }
+}

--- a/crates/verity-chain/tests/state_transition_fixtures.rs
+++ b/crates/verity-chain/tests/state_transition_fixtures.rs
@@ -1,0 +1,692 @@
+//! Conformance against leanSpec's state-transition vectors (`state_transition_test` format).
+//!
+//! Every case is a pre-state and a list of blocks. An accepting case carries `postStateRoot`,
+//! which pins the entire post-state in one comparison, plus a `post` block of partial
+//! assertions the Python harness uses for readable failures — those are checked too, so a
+//! mismatch says which field moved rather than only that a root differs. A rejecting case
+//! carries `rejectionReason` and no post-state.
+//!
+//! The JSON containers are mirrored here rather than derived on the `verity-types` shapes.
+//! Consensus values travel as SSZ, never as JSON; the `{"data": [...]}` wrappers and camelCase
+//! names below are a test-generator convention, not part of any container's shape.
+//!
+//! Source: leanSpec `tests/consensus/lstar/state_transition/`, filled into the
+//! `fixtures-prod-scheme.tar.gz` release asset that `crates/verity-types/fixtures.sha256`
+//! pins. leanSpec `main` @ `0588c2d215a955a516378677a92db2a5666802f3`.
+
+mod common;
+
+use serde::Deserialize;
+use verity_chain::{generate_genesis, hash_tree_root, process_block, state_transition};
+use verity_types::{
+    AggregatedAttestation, AggregatedAttestations, AggregationBits, AttestationData, Block,
+    BlockBody, BlockHeader, Bytes32, Bytes52, Checkpoint, GenesisConfig, HistoricalBlockHashes,
+    JustificationValidators, JustifiedSlots, Slot, State, Validator, ValidatorIndex, Validators,
+};
+
+/// Every suite under leanSpec's `state_transition` fixture directory.
+const SUITES: &[&str] = &[
+    "test_aggregation_bits",
+    "test_attestation_chain_binding",
+    "test_attestation_data_limits",
+    "test_block_processing",
+    "test_empty_validator_registry",
+    "test_finalization",
+    "test_genesis",
+    "test_justification",
+    "test_justification_accounting",
+    "test_justification_votes_length_mismatch",
+    "test_justified_slot_out_of_range",
+    "test_skipped_slot_history",
+    "test_slot_monotonicity",
+    "test_small_validator_quorums",
+    "test_zero_hash_justification_root",
+];
+
+/// Cases the generator applied with `process_block` rather than `state_transition`.
+///
+/// leanSpec's filler picks the entry point from `BlockSpec.skip_slot_processing`, which it
+/// does not serialize — see `packages/testing/src/consensus_testing/test_fixtures/`
+/// `state_transition.py`, the block loop's `elif`. Both cases here exercise a guard inside
+/// header validation that `process_slots` makes unreachable from the transition's own entry
+/// point, so the entry point has to be carried here. It cannot be inferred from the vector:
+/// a zero `stateRoot` marks the failing block of any rejection case, not just these.
+const PROCESS_BLOCK_ONLY: &[&str] = &[
+    "test_block_with_wrong_slot",
+    "test_block_at_parent_slot_rejected_when_slot_processing_skipped",
+];
+
+/// Cases that carry no block at all, and so cannot be replayed by any client.
+///
+/// The filler builds a block before applying it, and a rejection raised during construction
+/// is recorded with an empty `blocks` list. What this one records — proposer selection
+/// against an empty registry — is covered by a unit test on `proposer_for_slot` instead.
+const NO_BLOCK_TO_REPLAY: &[&str] = &["test_proposer_scheduling_on_empty_registry_rejected"];
+
+/// Which entry point a case is replayed through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Entry {
+    /// The full transition, including slot advancement and the post-state-root commitment.
+    Transition,
+    /// Header and body only, against a state the vector already advanced.
+    BlockOnly,
+}
+
+#[test]
+fn should_match_leanspec_state_transition_vectors_when_fixtures_are_present() {
+    let Some(root) = common::fixtures_dir() else {
+        eprintln!("skipping: set VERITY_FIXTURES to run leanSpec state-transition vectors");
+        return;
+    };
+
+    let mut failures = Vec::new();
+    let mut matched: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut checked = 0usize;
+    let mut skipped = 0usize;
+    for suite in SUITES {
+        let files = common::collect_suite_json(&root, suite);
+        assert!(
+            !files.is_empty(),
+            "no JSON under {} (expected **/{suite}/*.json)",
+            root.display()
+        );
+        for (id, case) in common::read_cases::<Case>(&files) {
+            if let Some(name) = listed(&id, NO_BLOCK_TO_REPLAY) {
+                matched.insert(name);
+                skipped += 1;
+                continue;
+            }
+            checked += 1;
+            let entry = match listed(&id, PROCESS_BLOCK_ONLY) {
+                Some(name) => {
+                    matched.insert(name);
+                    Entry::BlockOnly
+                }
+                None => Entry::Transition,
+            };
+            if let Err(error) = check(&case, entry) {
+                failures.push(format!("{id}: {error}"));
+            }
+        }
+    }
+
+    // A name that stopped matching is a rename upstream, not a case that quietly passes.
+    for name in PROCESS_BLOCK_ONLY.iter().chain(NO_BLOCK_TO_REPLAY) {
+        assert!(
+            matched.contains(*name),
+            "{name} matched no vector; leanSpec renamed or dropped it"
+        );
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {checked} state-transition vectors failed:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+    eprintln!("state transition: {checked} vectors matched, {skipped} carried no block");
+}
+
+/// The listed test function the leanSpec test id names, if any.
+fn listed(id: &str, names: &[&'static str]) -> Option<&'static str> {
+    names.iter().copied().find(|name| id.contains(name))
+}
+
+/// Runs one case: apply every block in order, then check what the case asserts.
+fn check(case: &Case, entry: Entry) -> Result<(), String> {
+    let mut state = case.pre.build()?;
+    check_generated_genesis(&state)?;
+
+    for (index, block) in case.blocks.iter().enumerate() {
+        let block = block.build()?;
+        let applied = match entry {
+            Entry::Transition => state_transition(&state, &block),
+            Entry::BlockOnly => process_block(&state, &block),
+        };
+        match applied {
+            Ok(post) => state = post,
+            Err(reason) => {
+                let expected = case.rejection_reason.as_deref().ok_or_else(|| {
+                    format!("block {index} rejected as {reason}, expected accept")
+                })?;
+                if reason.as_str() != expected {
+                    return Err(format!(
+                        "block {index} rejected as {reason}, expected {expected}"
+                    ));
+                }
+                return Ok(());
+            }
+        }
+    }
+
+    if let Some(expected) = &case.rejection_reason {
+        return Err(format!(
+            "every block applied, expected rejection {expected}"
+        ));
+    }
+    check_post_state_root(case, &state)?;
+    case.post
+        .as_ref()
+        .map_or(Ok(()), |assertions| assertions.check(&state))
+}
+
+/// Cross-checks [`generate_genesis`] against any pre-state that is one.
+///
+/// No vector calls the generator directly, but 68 of them start from its output. A pre-state
+/// with an empty history at slot 0 is a genesis state, and everything the generator has to get
+/// right beyond its two arguments — the zero checkpoints, and the empty body's root in the
+/// genesis header — is asserted here against a value leanSpec produced.
+fn check_generated_genesis(pre: &State) -> Result<(), String> {
+    let untouched = pre.slot.0 == 0
+        && pre.historical_block_hashes.is_empty()
+        && pre.justified_slots.is_empty()
+        && pre.justifications_roots.is_empty()
+        && pre.justifications_validators.is_empty();
+    if !untouched {
+        return Ok(());
+    }
+
+    let generated = generate_genesis(pre.config.genesis_time, pre.validators.clone());
+    if generated == *pre {
+        return Ok(());
+    }
+    Err(format!(
+        "generate_genesis root {}, expected {}",
+        hex(&hash_tree_root(&generated)),
+        hex(&hash_tree_root(pre))
+    ))
+}
+
+fn check_post_state_root(case: &Case, state: &State) -> Result<(), String> {
+    let expected = case
+        .post_state_root
+        .as_deref()
+        .ok_or("accepting case carries no postStateRoot")?;
+    let actual = hex(&hash_tree_root(state));
+    if actual == expected {
+        return Ok(());
+    }
+    Err(format!("post state root {actual}, expected {expected}"))
+}
+
+// ---------------------------------------------------------------------------------------
+// Fixture shapes
+// ---------------------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Case {
+    #[allow(dead_code)]
+    network: String,
+    #[allow(dead_code)]
+    lean_env: String,
+    #[allow(dead_code)]
+    proof_setting: u8,
+    pre: StateJson,
+    blocks: Vec<BlockJson>,
+    #[serde(default)]
+    post: Option<PostAssertions>,
+    #[serde(default)]
+    post_state_root: Option<String>,
+    #[serde(default)]
+    rejection_reason: Option<String>,
+    #[serde(rename = "_info")]
+    #[allow(dead_code)]
+    info: serde_json::Value,
+}
+
+/// leanSpec wraps every SSZ collection in a `data` key.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DataList<T> {
+    data: Vec<T>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct StateJson {
+    config: GenesisConfigJson,
+    slot: u64,
+    latest_block_header: BlockHeaderJson,
+    latest_justified: CheckpointJson,
+    latest_finalized: CheckpointJson,
+    historical_block_hashes: DataList<String>,
+    justified_slots: DataList<bool>,
+    validators: DataList<ValidatorJson>,
+    justifications_roots: DataList<String>,
+    justifications_validators: DataList<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct GenesisConfigJson {
+    genesis_time: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct BlockHeaderJson {
+    slot: u64,
+    proposer_index: u64,
+    parent_root: String,
+    state_root: String,
+    body_root: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CheckpointJson {
+    root: String,
+    slot: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ValidatorJson {
+    attestation_public_key: String,
+    proposal_public_key: String,
+    index: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct BlockJson {
+    slot: u64,
+    proposer_index: u64,
+    parent_root: String,
+    state_root: String,
+    body: BlockBodyJson,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BlockBodyJson {
+    attestations: DataList<AggregatedAttestationJson>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AggregatedAttestationJson {
+    aggregation_bits: DataList<bool>,
+    data: AttestationDataJson,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AttestationDataJson {
+    slot: u64,
+    head: CheckpointJson,
+    target: CheckpointJson,
+    source: CheckpointJson,
+}
+
+impl StateJson {
+    fn build(&self) -> Result<State, String> {
+        Ok(State {
+            config: GenesisConfig {
+                genesis_time: self.config.genesis_time,
+            },
+            slot: Slot(self.slot),
+            latest_block_header: self.latest_block_header.build()?,
+            latest_justified: self.latest_justified.build()?,
+            latest_finalized: self.latest_finalized.build()?,
+            historical_block_hashes: roots(&self.historical_block_hashes)?,
+            justified_slots: bitlist::<JustifiedSlots>(&self.justified_slots.data)?,
+            validators: validators(&self.validators)?,
+            justifications_roots: roots(&self.justifications_roots)?,
+            justifications_validators: bitlist::<JustificationValidators>(
+                &self.justifications_validators.data,
+            )?,
+        })
+    }
+}
+
+impl BlockHeaderJson {
+    fn build(&self) -> Result<BlockHeader, String> {
+        Ok(BlockHeader {
+            slot: Slot(self.slot),
+            proposer_index: ValidatorIndex(self.proposer_index),
+            parent_root: bytes32(&self.parent_root)?,
+            state_root: bytes32(&self.state_root)?,
+            body_root: bytes32(&self.body_root)?,
+        })
+    }
+}
+
+impl CheckpointJson {
+    fn build(&self) -> Result<Checkpoint, String> {
+        Ok(Checkpoint {
+            root: bytes32(&self.root)?,
+            slot: Slot(self.slot),
+        })
+    }
+}
+
+impl BlockJson {
+    fn build(&self) -> Result<Block, String> {
+        let mut attestations = AggregatedAttestations::default();
+        for attestation in &self.body.attestations.data {
+            attestations
+                .push(attestation.build()?)
+                .map_err(|error| format!("attestations: {error:?}"))?;
+        }
+        Ok(Block {
+            slot: Slot(self.slot),
+            proposer_index: ValidatorIndex(self.proposer_index),
+            parent_root: bytes32(&self.parent_root)?,
+            state_root: bytes32(&self.state_root)?,
+            body: BlockBody { attestations },
+        })
+    }
+}
+
+impl AggregatedAttestationJson {
+    fn build(&self) -> Result<AggregatedAttestation, String> {
+        Ok(AggregatedAttestation {
+            aggregation_bits: bitlist::<AggregationBits>(&self.aggregation_bits.data)?,
+            data: AttestationData {
+                slot: Slot(self.data.slot),
+                head: self.data.head.build()?,
+                target: self.data.target.build()?,
+                source: self.data.source.build()?,
+            },
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------------------
+// Partial post-state assertions
+// ---------------------------------------------------------------------------------------
+
+/// The `post` block a case may carry.
+///
+/// `deny_unknown_fields` is what keeps this honest: a field leanSpec adds fails the run
+/// instead of being skipped. The three `*Label` fields are the deliberate exception — they
+/// carry symbolic block names such as `"block_2"`, resolvable only against the generator's own
+/// labelling, and `postStateRoot` already pins every value they describe.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+struct PostAssertions {
+    slot: Option<u64>,
+    config_genesis_time: Option<u64>,
+    latest_justified_slot: Option<u64>,
+    latest_justified_root: Option<String>,
+    latest_finalized_slot: Option<u64>,
+    latest_finalized_root: Option<String>,
+    latest_block_header_slot: Option<u64>,
+    latest_block_header_proposer_index: Option<u64>,
+    latest_block_header_parent_root: Option<String>,
+    latest_block_header_state_root: Option<String>,
+    latest_block_header_body_root: Option<String>,
+    historical_block_hashes: Option<DataList<String>>,
+    historical_block_hashes_count: Option<usize>,
+    justified_slots: Option<DataList<bool>>,
+    justifications_roots: Option<DataList<String>>,
+    justifications_roots_count: Option<usize>,
+    justifications_validators: Option<DataList<bool>>,
+    justifications_validators_count: Option<usize>,
+    validators: Option<DataList<ValidatorJson>>,
+    validator_count: Option<usize>,
+    latest_justified_root_label: Option<String>,
+    latest_finalized_root_label: Option<String>,
+    justifications_roots_labels: Option<Vec<String>>,
+}
+
+impl PostAssertions {
+    fn check(&self, state: &State) -> Result<(), String> {
+        let mut failures = Vec::new();
+        self.check_scalars(state, &mut failures);
+        self.check_roots(state, &mut failures);
+        self.check_collections(state, &mut failures);
+        if failures.is_empty() {
+            return Ok(());
+        }
+        Err(failures.join("; "))
+    }
+
+    fn check_scalars(&self, state: &State, failures: &mut Vec<String>) {
+        let header = &state.latest_block_header;
+        compare(&mut *failures, "slot", self.slot, Some(state.slot.0));
+        compare(
+            failures,
+            "configGenesisTime",
+            self.config_genesis_time,
+            Some(state.config.genesis_time),
+        );
+        compare(
+            failures,
+            "latestJustifiedSlot",
+            self.latest_justified_slot,
+            Some(state.latest_justified.slot.0),
+        );
+        compare(
+            failures,
+            "latestFinalizedSlot",
+            self.latest_finalized_slot,
+            Some(state.latest_finalized.slot.0),
+        );
+        compare(
+            failures,
+            "latestBlockHeaderSlot",
+            self.latest_block_header_slot,
+            Some(header.slot.0),
+        );
+        compare(
+            failures,
+            "latestBlockHeaderProposerIndex",
+            self.latest_block_header_proposer_index,
+            Some(header.proposer_index.0),
+        );
+    }
+
+    fn check_roots(&self, state: &State, failures: &mut Vec<String>) {
+        let header = &state.latest_block_header;
+        for (name, expected, actual) in [
+            (
+                "latestJustifiedRoot",
+                &self.latest_justified_root,
+                state.latest_justified.root,
+            ),
+            (
+                "latestFinalizedRoot",
+                &self.latest_finalized_root,
+                state.latest_finalized.root,
+            ),
+            (
+                "latestBlockHeaderParentRoot",
+                &self.latest_block_header_parent_root,
+                header.parent_root,
+            ),
+            (
+                "latestBlockHeaderStateRoot",
+                &self.latest_block_header_state_root,
+                header.state_root,
+            ),
+            (
+                "latestBlockHeaderBodyRoot",
+                &self.latest_block_header_body_root,
+                header.body_root,
+            ),
+        ] {
+            compare(failures, name, expected.clone(), Some(hex(&actual)));
+        }
+    }
+
+    fn check_collections(&self, state: &State, failures: &mut Vec<String>) {
+        let hashes: Vec<String> = state
+            .historical_block_hashes
+            .iter()
+            .map(|root| hex(root))
+            .collect();
+        compare(
+            failures,
+            "historicalBlockHashes",
+            self.historical_block_hashes.as_ref().map(|list| &list.data),
+            Some(&hashes),
+        );
+        compare(
+            failures,
+            "historicalBlockHashesCount",
+            self.historical_block_hashes_count,
+            Some(state.historical_block_hashes.len()),
+        );
+
+        let tracked: Vec<String> = state
+            .justifications_roots
+            .iter()
+            .map(|root| hex(root))
+            .collect();
+        compare(
+            failures,
+            "justificationsRoots",
+            self.justifications_roots.as_ref().map(|list| &list.data),
+            Some(&tracked),
+        );
+        compare(
+            failures,
+            "justificationsRootsCount",
+            self.justifications_roots_count,
+            Some(state.justifications_roots.len()),
+        );
+        compare(
+            failures,
+            "justificationsValidatorsCount",
+            self.justifications_validators_count,
+            Some(state.justifications_validators.len()),
+        );
+        compare(
+            failures,
+            "justifiedSlots",
+            self.justified_slots.as_ref().map(|list| &list.data),
+            Some(&flags(state.justified_slots.len(), |index| {
+                state.justified_slots.get(index)
+            })),
+        );
+        compare(
+            failures,
+            "justificationsValidators",
+            self.justifications_validators
+                .as_ref()
+                .map(|list| &list.data),
+            Some(&flags(state.justifications_validators.len(), |index| {
+                state.justifications_validators.get(index)
+            })),
+        );
+        compare(
+            failures,
+            "validatorCount",
+            self.validator_count,
+            Some(state.validators.len()),
+        );
+        if let Some(expected) = &self.validators {
+            let actual: Vec<(String, String, u64)> = state
+                .validators
+                .iter()
+                .map(|validator| {
+                    (
+                        hex(&validator.attestation_public_key),
+                        hex(&validator.proposal_public_key),
+                        validator.index.0,
+                    )
+                })
+                .collect();
+            let wanted: Vec<(String, String, u64)> = expected
+                .data
+                .iter()
+                .map(|validator| {
+                    (
+                        validator.attestation_public_key.clone(),
+                        validator.proposal_public_key.clone(),
+                        validator.index,
+                    )
+                })
+                .collect();
+            compare(failures, "validators", Some(wanted), Some(actual));
+        }
+    }
+}
+
+/// Records a mismatch when the case asserts a value and it disagrees.
+fn compare<T: PartialEq + std::fmt::Debug>(
+    failures: &mut Vec<String>,
+    name: &str,
+    expected: Option<T>,
+    actual: Option<T>,
+) {
+    let (Some(expected), Some(actual)) = (expected, actual) else {
+        return;
+    };
+    if expected != actual {
+        failures.push(format!("{name}: got {actual:?}, expected {expected:?}"));
+    }
+}
+
+// ---------------------------------------------------------------------------------------
+// Primitive conversions
+// ---------------------------------------------------------------------------------------
+
+fn flags(length: usize, read: impl Fn(usize) -> Option<bool>) -> Vec<bool> {
+    (0..length)
+        .map(|index| read(index).unwrap_or(false))
+        .collect()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(2 + bytes.len() * 2);
+    out.push_str("0x");
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn unhex(text: &str) -> Result<Vec<u8>, String> {
+    let body = text
+        .strip_prefix("0x")
+        .ok_or_else(|| format!("{text}: missing 0x prefix"))?;
+    (0..body.len())
+        .step_by(2)
+        .map(|index| {
+            u8::from_str_radix(&body[index..index + 2], 16)
+                .map_err(|error| format!("{text}: {error}"))
+        })
+        .collect()
+}
+
+fn bytes32(text: &str) -> Result<Bytes32, String> {
+    unhex(text)?
+        .try_into()
+        .map_err(|_| format!("{text}: not 32 bytes"))
+}
+
+fn bytes52(text: &str) -> Result<Bytes52, String> {
+    unhex(text)?
+        .try_into()
+        .map_err(|_| format!("{text}: not 52 bytes"))
+}
+
+fn roots(list: &DataList<String>) -> Result<HistoricalBlockHashes, String> {
+    let mut out = HistoricalBlockHashes::default();
+    for text in &list.data {
+        out.push(bytes32(text)?)
+            .map_err(|error| format!("roots: {error:?}"))?;
+    }
+    Ok(out)
+}
+
+fn validators(list: &DataList<ValidatorJson>) -> Result<Validators, String> {
+    let mut out = Validators::default();
+    for entry in &list.data {
+        out.push(Validator {
+            attestation_public_key: bytes52(&entry.attestation_public_key)?,
+            proposal_public_key: bytes52(&entry.proposal_public_key)?,
+            index: ValidatorIndex(entry.index),
+        })
+        .map_err(|error| format!("validators: {error:?}"))?;
+    }
+    Ok(out)
+}
+
+fn bitlist<T: TryFrom<Vec<bool>>>(bits: &[bool]) -> Result<T, String> {
+    T::try_from(bits.to_vec())
+        .map_err(|_| format!("bitlist of {} bits exceeds its limit", bits.len()))
+}


### PR DESCRIPTION
The state transition, transcribed from leanSpec. This is the first code in the tree that decides whether a block is valid.

## What lands

**`state_transition`** — `process_slots` → `process_block_header` → `process_attestations`, then the post-state-root commitment. Plus `generate_genesis` and `proposer_for_slot`.

`process_attestations` is the bulk of it: the 3SF-mini accounting. The state stores votes as one flat bitlist segmented by tracked root, so the module unpacks that layout into a per-root tally, applies the block's votes under five filters, and packs it back. Roots are held in a `BTreeMap`, which is what makes the repack canonical without a sort.

**No cryptography.** leanSpec is explicit that signatures are verified before the transition is called, so `verity-chain` still depends on nothing but `verity-types` — plus `libssz-merkle`, because the transition commits to `hash_tree_root` of the state, the parent header, and the block body, and that commitment cannot be written without it.

**No capability-contract trait.** `ARCHITECTURE.md` leaves the crate placement to implementation time. There is one implementation and the kickoff rule is to split only when a second earns it, so `state_transition` is a free function and `RejectionReason` is the plain enum the contract describes — thirteen leanSpec reasons, the ones the vectors reach, named verbatim so the two stay greppable against each other.

## One deliberate deviation

`process_slots` guards its empty-slot walk against a gap larger than `HISTORICAL_ROOTS_LIMIT` and returns `BLOCK_SLOT_GAP_TOO_LARGE`. leanSpec raises that same reason with that same threshold, but from fork choice, immediately before it calls the transition. Moving it to the transition's own entry is what makes the loop bounded by this function's signature instead of by its caller. No vector changes behaviour.
