### PR TITLE
refactor(design): withdraw the persisted signing watermark

### DIFF
--- a/crates/verity-crypto/src/key.rs
+++ b/crates/verity-crypto/src/key.rs
@@ -62,11 +62,12 @@ impl PublicKey {
 /// # Stateful, and the state is the whole point
 ///
 /// XMSS signs at most once per epoch. Signing two *different* messages at one epoch does not
-/// cost a penalty — the lean protocol has no slashing — it exposes enough one-time-chain
-/// state to forge. This type does not enforce that: the no-reuse guarantee is a persisted
-/// signing watermark on the validator's signing path, because a guarantee that lives in
-/// memory does not survive the crash-restart it exists to defend against. See
-/// `docs/design/key-management.md`, Decision 1.
+/// cost a penalty — the lean protocol has no slashing — it exposes that epoch's one-time-chain
+/// values, making a forgery possible at that one slot. Epochs are independent (each chain start
+/// comes from the PRF applied to its own epoch), so the rest of the key is untouched. This type
+/// does not enforce non-reuse: the guarantee is the validator duty loop's once-per-slot
+/// structure, held in memory and never persisted. See `docs/design/key-management.md`,
+/// Decision 1.
 ///
 /// What this type does enforce is the weaker precondition leanSig asserts on: that the slot
 /// is inside the key's activation range and its prepared window. leanSig panics on both, and
@@ -191,7 +192,8 @@ impl SecretKey {
     /// clone-advance-swap: hand a clone to a blocking worker, keep signing with the original,
     /// swap when the worker returns. The windows overlap by about three days around the
     /// current slot, so the original stays able to sign throughout. Both objects are the same
-    /// key; no-reuse is carried by the watermark, not by which clone signed.
+    /// key; no-reuse is carried by the duty loop's once-per-slot dedup, not by which clone
+    /// signed.
     ///
     /// Advancing past the end of the activation interval does nothing, which is why this
     /// returns no error and why [`Self::advance_preparation_to`] bounds its own loop instead

--- a/crates/verity-crypto/src/lib.rs
+++ b/crates/verity-crypto/src/lib.rs
@@ -19,9 +19,10 @@
 //! key does not cost a penalty, it breaks the key. This crate refuses the preconditions
 //! leanSig would panic on — a slot outside the key's activation range or its prepared
 //! window — but it cannot refuse a second, different message at a slot it already signed,
-//! because a call carries no memory of the last one. That guarantee is a persisted signing
-//! watermark on the validator's signing path, checked and durably written before [`sign`] is
-//! reached. See `docs/design/key-management.md`, Decision 1.
+//! because a call carries no memory of the last one. That guarantee is the validator duty
+//! loop's structure: block production runs once per slot at interval 0, and attestation is
+//! collapsed to one signature per slot by an in-memory already-attested set. Nothing about
+//! signing is persisted. See `docs/design/key-management.md`, Decision 1.
 //!
 //! # Two SSZ libraries meet here
 //!

--- a/crates/verity-crypto/src/signature.rs
+++ b/crates/verity-crypto/src/signature.rs
@@ -1,9 +1,9 @@
 //! Signing and verification of one validator's XMSS signature.
 //!
 //! Two functions and the bridge between the wire shape and the library's own. Everything
-//! that decides *whether* a signature should be produced — duty scheduling, the persisted
-//! signing watermark, key preparation — lives above this crate; what is here is the
-//! operation itself, with leanSig's two panicking preconditions turned into typed errors.
+//! that decides *whether* a signature should be produced — duty scheduling, the once-per-slot
+//! dedup, key preparation — lives above this crate; what is here is the operation itself, with
+//! leanSig's two panicking preconditions turned into typed errors.
 
 use leansig::serialization::Serializable;
 use leansig::signature::SignatureScheme;
@@ -41,10 +41,10 @@ impl Signature {
 /// # This function does not prevent key reuse
 ///
 /// Determinism means re-signing the *same* message at the same slot returns the identical
-/// signature and is harmless. Signing a *different* message at that slot breaks the key.
-/// Nothing here can tell the two apart, because a second call carries no memory of the
-/// first. The guarantee is the persisted watermark on the validator's signing path, checked
-/// and durably written *before* this is called — see `docs/design/key-management.md`.
+/// signature and is harmless. Signing a *different* message at that slot exposes that epoch's
+/// one-time-chain values. Nothing here can tell the two apart, because a second call carries no
+/// memory of the first. The guarantee is the validator duty loop's once-per-slot structure —
+/// see `docs/design/key-management.md`, Decision 1.
 ///
 /// # Errors
 ///

--- a/crates/verity-crypto/tests/xmss_signing.rs
+++ b/crates/verity-crypto/tests/xmss_signing.rs
@@ -65,8 +65,8 @@ fn should_survive_its_own_encoding_when_a_real_signature_is_round_tripped() {
 }
 
 /// leanSig derandomizes signing, so the same triple yields the identical signature. That is
-/// what makes an idempotent re-sign harmless — and why the watermark refuses *equality*
-/// rather than relying on it.
+/// what makes an idempotent re-sign harmless: the prohibition is two *different* messages at
+/// one `(key, slot)`, never a retry of the same one.
 #[test]
 fn should_produce_identical_bytes_when_the_same_message_is_signed_twice_at_one_slot() {
     let Some(key) = test_key() else {

--- a/docs/design/concurrency.md
+++ b/docs/design/concurrency.md
@@ -1,6 +1,6 @@
 ---
 title: Verity Concurrency Model
-last_updated: 2026-08-26
+last_updated: 2026-08-30
 tags:
   - concurrency
   - runtime
@@ -222,8 +222,15 @@ verification stage.
   by the **same slot clock** that feeds ① — one clock in the `verity` binary, two consumers —
   and never by callbacks from the chain task. At its duty interval a validator task reads the
   current `ChainView` snapshot (proposal head, attestation target), produces and signs, and
-  sends the product into ②; the chain task's sole involvement in production is the interval-2
-  aggregation handoff below. Aggregate-proof *production* — seconds of zk proving — follows
+  sends the product into ②. **Which interval that is follows leanSpec's duty loop**: block
+  production at interval 0 only, attestation at interval ≥ 1 so a proposal that outruns
+  interval 0 does not cost that slot's attestation. That shape is why signing needs no durable
+  state — interval 0 is reached once per slot, and the attestation branch, reachable on
+  intervals 1 through 4, is collapsed to one signature by an in-memory already-attested slot
+  set with 4-slot retention. Nothing about signing is persisted; see
+  [key-management.md](key-management.md#decision-1--no-persisted-signing-state-once-per-slot-duty-dedup).
+  The chain task's sole involvement in production is the interval-2 aggregation handoff
+  below. Aggregate-proof *production* — seconds of zk proving — follows
   the ethlambda pattern with the wiring explicit: the interval-2 tick action in the chain task
   determines that aggregation is due and hands the signature-pool snapshot to
   `verity-validator`'s aggregation worker; the worker runs on `spawn_blocking`, and the chain

--- a/docs/design/key-management.md
+++ b/docs/design/key-management.md
@@ -1,6 +1,6 @@
 ---
 title: Validator Key Management — XMSS Signing State
-last_updated: 2026-08-27
+last_updated: 2026-08-30
 tags:
   - xmss
   - key-management
@@ -9,21 +9,36 @@ tags:
 
 # Validator Key Management — XMSS Signing State
 
-> Status: pre-implementation. Decisions ratified 2026-08-16. This document settles how Verity
-> manages its validators' XMSS keys: the crash-safe no-reuse guarantee, key material loading,
-> and preparation scheduling. It extends [storage.md](storage.md) with one column family and
-> plugs into the runtime model of [concurrency.md](concurrency.md).
+> Status: pre-implementation. Decisions ratified 2026-08-16; Decision 1 re-decided 2026-08-30.
+> This document settles how Verity manages its validators' XMSS keys: the no-reuse guarantee,
+> key material loading, and preparation scheduling. It adds no column family to
+> [storage.md](storage.md) and plugs into the runtime model of
+> [concurrency.md](concurrency.md).
 
-The stake is unusual and worth stating first. XMSS is a **stateful one-time signature
-scheme**: signing two *different* messages with the same key at the same epoch does not incur
-a protocol penalty — the lean protocol has no slashing at all — it **breaks the key
-cryptographically**, exposing enough one-time-chain state that signatures can be forged. The
-asset being protected is the secret key's soundness itself. Everything below is sized against
-that, not against a fine.
+The stake is unusual and worth sizing precisely first, because an earlier revision of this
+document oversized it and reached a heavier decision as a result. XMSS is a **stateful
+one-time signature scheme**: signing two *different* messages with the same key at the same
+epoch does not incur a protocol penalty — the lean protocol has no slashing at all — it
+degrades the *key material itself*, which no penalty schedule can undo.
+
+**The blast radius is one epoch, not the key.** leanSig derives each epoch's one-time chain
+start values from the PRF applied to that epoch:
+`PRF::get_domain_element(&sk.prf_key, epoch, index)` in `sign`
+(`src/signature/generalized_xmss.rs`). Epochs are therefore independent, and the Merkle tree
+above them authenticates per-epoch public keys. Two different messages at one epoch expose
+that epoch's chain values and nothing else: the top tree, the PRF seed, and every other epoch
+stay intact. At `LOG_LIFETIME = 32` the key remains usable for its other ~4.29 billion slots.
+
+What an attacker gains is therefore bounded: the ability to forge **one validator's message at
+one slot**, subject to finding a message whose incomparable encoding is dominated by the
+revealed chain positions. The protocol already tolerates equivocation — fork choice accepts
+two blocks from one proposer at one slot, and no slashing container exists — so the forged
+message is worth one validator's weight at one already-past slot. Everything below is sized
+against that, and not against a whole-key compromise.
 
 ## What the spec and the library fix
 
-Read at leanSpec `main` = `cce7955`, leanSig `main` = `c08a3ba`.
+Read at leanSpec `main` = `0588c2d2`, leanSig `main` = `c08a3ba`.
 
 **leanSpec** (`src/lean_spec/spec/crypto/xmss/`, `.../lstar/containers/validator.py`):
 
@@ -39,8 +54,14 @@ Read at leanSpec `main` = `cce7955`, leanSig `main` = `c08a3ba`.
 - **Key lifetime is a non-issue**: production `LOG_LIFETIME = 32` → 2³² slots ≈ 544 years at
   4-second slots. There is no key-rotation mechanism in the spec, and none is needed.
 - **The protocol tolerates equivocation**: fork choice accepts two blocks from one proposer at
-  one slot; no slashing container exists. The reference node keeps signing state in memory
-  only and persists nothing across restarts.
+  one slot; no slashing container exists.
+- **The reference node is not state-free — it persists, and deliberately excludes signing
+  state.** `src/lean_spec/node/storage/` is a real SQLite backend whose tables are `blocks`,
+  `states`, `checkpoints` (justified, finalized, head, and `genesis_time`, the last one
+  commented "Persisted so the node can restart without external genesis config"),
+  `slot_index`, and `state_root_index`. Restart is a designed-for scenario there. No table
+  holds signing state. The absence is a choice made *with* a durability layer present, not the
+  by-product of not having one.
 
 **leanSig** (Rust, the library `verity-crypto` wraps):
 
@@ -60,75 +81,144 @@ Read at leanSpec `main` = `cce7955`, leanSig `main` = `c08a3ba`.
   `leansig-test-keys` is data only (8 production-scheme keypairs, attestation role only,
   JSON-hex envelopes produced by leanSpec's Python tooling).
 
-## Survey — what other clients do
+## Survey — what the reference node and other clients do
 
-Read at ethlambda `e16f477`, ream `842a709`, zeam `6495beb`, qlean-mini `55b6eb3`.
+Read at leanSpec `0588c2d2`, ethlambda `e16f477`, ream `842a709`, zeam `6495beb`,
+qlean-mini `55b6eb3`.
 
 | Client | Persisted signing state | Anti-double-sign guard | `advance_preparation` |
 |---|---|---|---|
+| leanSpec (reference) | none (its SQLite backend has no such table) | in-memory `_attested_slots` set, 4-slot retention, attestations only | inline in `_sign_with_key`, advancing until the slot is prepared |
 | ethlambda | none | none | per-slot pre-advance on the chain actor + startup catch-up |
 | ream | none | in-memory block-prebuild flag only | **never called in production code** |
 | zeam | none | none; **falls back to one key for both roles** when only one file is present | lazily, inline inside `sign`, under the signing mutex |
 | qlean-mini | none | none | none |
 
-Every client derives the signing epoch from the wall clock at the moment of signing and
-persists nothing. The entire ecosystem's no-reuse guarantee is an implicit bet on clock
-monotonicity. The survey also produced two live counterexamples of what unmanaged key state
-looks like: ream will panic at the prepared-window boundary because nothing ever advances it,
-and zeam's single-key fallback reproduces exactly the dual-role reuse the spec's reference
-loader rejects.
+No implementation in the ecosystem, the reference node included, persists signing state. The
+survey also produced two live counterexamples of what unmanaged key state looks like: ream will
+panic at the prepared-window boundary because nothing ever advances it, and zeam's single-key
+fallback reproduces exactly the dual-role reuse the reference loader rejects
+(`node/validator/registry.py`: "Sharing one key across both roles reuses one-time state and
+breaks it").
 
-Three scenarios break the clock-monotonicity bet:
+### What `_attested_slots` actually is
 
-1. **Intra-slot crash-restart.** The process restarts within one 4-second slot; the node's
-   view (head) has changed; the validator re-attests the same slot with different data — two
-   different messages under one `(key, slot)`. A restarted proposer rebuilding its block hits
-   the same trap.
-2. **Clock step-back** (NTP correction, VM resume) — the derived slot rewinds into
-   already-signed territory.
-3. **Operational error** — restoring a datadir from backup, or accidentally running two
-   instances with the same keys.
+It is duty-loop idempotence, not a key-safety mechanism, and the duty loop's own branch
+conditions show why (`node/validator/service.py`):
 
-## Decision 1 — signing watermark, persist-before-sign
+```python
+if interval == Interval(0):                 # block production: structurally reached once per slot
+    ...
+if interval >= Interval(1) and slot not in self._attested_slots:   # attestation: reachable at 1,2,3,4
+    ...
+```
 
-Verity persists a **signing watermark**: the last slot signed, per `(validator, role)`, in a
-dedicated `verity-db` column family (`signing_watermarks`, defined in
-[storage.md](storage.md#column-families)). The signing path enforces, in this order:
+Block production sits behind `interval == 0`, so one slot admits one attempt and no set is
+needed. Attestation sits behind `interval >= 1`, so one slot admits up to four passes — the set
+collapses them to one. `ATTESTED_SLOT_RETENTION = 4` is documented as "Slots of attestation
+dedup history to keep; older slots can no longer be attested", which is a statement about what
+the duty loop will ever revisit, not about key lifetime.
 
-1. derive the message for slot `s`;
-2. require `s > watermark(validator, role)` — **equality is refused**, even for a
-   byte-identical message;
-3. durably write `watermark := s` (write-ahead log + fsync);
-4. only then sign and release the signature to the rest of the process.
+### The reference node's actual answer to a rewinding clock
 
-A signature therefore cannot exist — not in channel ②, not on the wire — unless a watermark
-at or above its slot is already on disk. A crash between steps 3 and 4 costs exactly one
-duty (one vote or one proposal in the crash slot), which carries no protocol penalty; the
-alternative it buys off is key compromise. Refusing equality (rather than allowing the
-idempotent re-sign leanSig's determinism would permit) is deliberate: the rescue value of one
-duty in a 4-second-slot protocol is negligible, and slot-only state keeps the mechanism two
-`u64`s per validator instead of a message-root log.
+leanSpec does not assume the wall clock moves forward. It says so, names the causes, and
+defends the consensus side (`node/chain/service.py`):
 
-- **Ownership.** The validator signing path is the sole writer of `signing_watermarks` — the
-  one documented exception to the chain task's write ownership (see storage.md). This keeps
-  the check-write-sign sequence synchronous inside the signing path; routing it through the
-  chain task would add a query channel that [concurrency.md](concurrency.md) deliberately
-  does not have. One keyspace, one writer still holds — per family, not per database.
-- **Write cost.** At most two fsynced single-row writes per slot per validator; negligible
-  against the storage engine's proof workload.
-- **Startup.** Watermarks are read before validator readiness. An **absent row is the normal
-  first-run state** — the validator has never signed; signing is permitted and the first
-  signature creates the row. A **present row with `watermark ≥ current_slot`** means the
-  clock has rewound relative to a signature that already exists (scenario 2 or 3): the node
-  fails closed — duties for that validator stay disabled until `current_slot > watermark`,
-  and the condition is logged loudly. (`≥`, not `>`: at equality the sign path would refuse
-  anyway, so readiness gates on the same comparison the sign path enforces.) It is never
-  treated as corruption to repair automatically.
-- **Scenario coverage.** (1) is covered by the equality refusal, (2) by the startup check plus
-  the per-sign comparison, (3) partially: a restored backup restores an old watermark, but the
-  per-sign comparison still refuses any slot at or below it *if the restored node's clock is
-  honest*; two concurrent instances sharing keys are out of scope of any local mechanism and
-  remain an operator responsibility, stated in the operator documentation.
+```python
+# The target comes from the wall clock, which can step backward.
+# NTP slew, a leap second, or a VM migration can move it before the store time.
+# A backward target would tick nothing, so return early.
+if target_interval <= store.time:
+    return []
+```
+
+The defence is that **`store.time` is monotone**: a rewound wall clock cannot rewind consensus
+processing. That monotonicity is not extended to the validator duty path, which reads
+`self.clock.current_slot()` directly off a plain wall clock (`node/chain/clock.py` imports
+`from time import time as wall_time`; there is no monotonic source anywhere). The rewind
+magnitude the reference node is sized for can be read off the causes it names: an NTP
+correction and a leap second are sub-second to a few seconds, and the 4-slot (16-second)
+attestation window covers exactly that band. Only "a VM migration" can exceed it, and that case
+is named but not sized for.
+
+### Scenarios, restated at their real weight
+
+1. **Intra-slot crash-restart** — the process restarts inside one 4-second slot and re-signs it
+   with a changed view. **Unreachable in Verity.** Startup loads 33.5 MB × 2 roles ≈ 67 MB of
+   key material per validator (Decision 2) before any duty runs, and may owe preparation
+   advances on top (Decision 3). A restart does not complete inside one slot.
+2. **In-process clock step-back** — the derived slot rewinds while the process runs. Real, but
+   **bounded small in normal operation**: a backward step requires the OS clock to have been
+   *ahead* of true time, and a continuously running NTP daemon slews rather than steps once the
+   offset is small, so the offset never grows to slot scale. Exceeding 4 slots takes a
+   precondition — NTP absent for a long period, an RTC set ahead, or a manual `date -s`.
+3. **State restored underneath a running or restarting node** — a datadir or VM snapshot
+   restored from an earlier point, or two instances started on one key set. A snapshot restore
+   rolls process memory back too, so no in-memory mechanism can observe it; two instances share
+   nothing to coordinate through. **Out of scope of any local mechanism; operator
+   responsibility**, stated in the operator documentation.
+
+## Decision 1 — no persisted signing state; once-per-slot duty dedup
+
+Verity persists **nothing** about signing. The no-reuse guarantee is the same shape the
+reference node uses: an **in-memory, once-per-slot duty dedup**, and a duty loop whose
+structure is what makes that dedup sufficient.
+
+- **Duty loop structure, mirroring leanSpec.** Block production runs only at interval 0.
+  Attestation runs at interval ≥ 1 and may be reached on any later interval of the same slot,
+  so a slow proposal does not cost that slot's attestation. This is leanSpec's structure and
+  Verity adopts it unchanged; `verity-chain`'s `SlotClock::current_slot(&self,
+  now_milliseconds: u64)` already takes its time as an argument rather than reading an ambient
+  wall clock, matching the reference node's injectable `time_fn`.
+- **The dedup follows from that structure.** Attestation carries an in-memory set of
+  already-attested slots with 4-slot retention, because interval ≥ 1 admits up to four passes
+  per slot. Block production carries none, because interval 0 admits one. This is a
+  consequence of the loop shape, not an independent judgement about the two roles — if the
+  loop shape changes, this changes with it.
+- **Nothing is written, so nothing is fsynced.** The signing path performs no I/O.
+- **Startup has no signing-state gate.** Duties are gated by key preparation, the first
+  `ChainView`, and sync state (Decision 3), never by signing history.
+
+### Why not persist a watermark
+
+An earlier revision of this document specified a persisted per-`(validator, role)` watermark in
+a `signing_watermarks` column family, fsynced before each signature was released. It is
+withdrawn. Three findings, in the order they bind:
+
+1. **The threat it priced does not exist at that size.** The decision was sized against
+   whole-key compromise. The blast radius is one epoch (see the opening section) — one
+   validator's forgeable message at one slot, in a protocol with no slashing that already
+   tolerates equivocation.
+2. **Its runtime cost lands in the worst possible place.** A durable write before signature
+   release puts an fsync on the signing path, sharing the storage engine's WAL with the
+   aggregate-proof workload — 155–236 KB per proof, median 190 KB, ~4.1 GB/day
+   ([storage.md](storage.md)). Signature-release latency then becomes a function of compaction
+   and flush tail behavior, inside the interval budget the attestation must meet. It converts
+   a stable, I/O-free path into one coupled to the least predictable component in the node.
+3. **Its failure mode is unrecoverable by the operator's natural action.** The design failed
+   closed at startup whenever `watermark ≥ current_slot`, disabling that validator's duties
+   until the clock passed the watermark. Because the state was durable, a restart did not clear
+   it. That trades a *certain* availability loss, of unbounded duration, against the
+   probability of a *bounded* one-slot forgeability — and it does so in the scenario class
+   (scenario 3 above) it cannot actually cover, since a snapshot restore rolls the watermark back with
+   everything else.
+
+The residual exposure is stated plainly: an in-process clock step-back exceeding 4 slots would
+let a validator re-sign a slot it has already signed. Scenario 2 above bounds how that arises;
+the reference node accepts the same exposure with the same 4-slot window. Verity accepts it,
+and does not buy it off with an fsync on the signing path.
+
+### What carries the guarantee instead
+
+- **Role separation**, enforced at load time: distinct attestation and proposal keys, identical
+  keys rejected (Decision 2). This is what keeps a proposer's block signature and its
+  attestation in the same slot from colliding.
+- **Duty-loop structure plus the dedup set**, above: one signature per `(validator, role,
+  slot)`, forward only.
+- **Determinism as a backstop.** leanSig's randomness comes from
+  `PRF::get_randomness(&sk.prf_key, epoch, message, attempts)`, so re-signing the *same*
+  message at the same slot reproduces the identical signature and is harmless. The prohibition
+  is precisely two *different* messages at one `(key, slot)`; an idempotent retry is not one.
 
 ## Decision 2 — key material: follow the de-facto standard, harden the loader
 
@@ -178,14 +268,14 @@ window boundary) mark the two failure modes to design out.
   advance produces a window of that same second tree plus the next one. Old and new windows
   therefore share ≈ 3 days of coverage around the current slot — there is no moment at which
   either key object is unable to sign for "now", however long the rebuild takes within that
-  margin. Both key objects are the same key; no-reuse is enforced by the watermark on the
-  signing path, independent of which copy signs.
+  margin. Both key objects are the same key; no-reuse is enforced by the duty loop's
+  once-per-slot dedup, independent of which copy signs.
 - **Persist the advanced key.** The `spawn_blocking` worker itself, as the final step of the
   advance job and *before* returning the advanced clone, rewrites the key file atomically
   (temp file + rename; public key verified against the manifest on load) — so a key the
   validator task swaps in is already durable. A failed file write is logged and is
-  **non-fatal**: the swap still proceeds, because persistence only bounds restart cost while
-  the watermark, not the key file, carries the no-reuse guarantee; a stale file costs extra
+  **non-fatal**: the swap still proceeds, because persisting the advanced key only bounds
+  restart cost — it carries no part of the no-reuse guarantee; a stale file costs extra
   catch-up and nothing else. No surveyed client persists advanced keys, and the omission is
   why a year-old node would owe ~120 consecutive rebuilds (minutes to hours) at startup: the
   on-disk key never moves off its activation window. With periodic persistence, startup
@@ -196,9 +286,8 @@ window boundary) mark the two failure modes to design out.
   unreachability.
 - **Startup order — who runs it, and when.** Key preparation is `verity-validator`'s own
   initialization: the `verity` binary **spawns the validator task at process start, alongside
-  the chain task**, handing it the key directory and the `signing_watermarks` handle at
-  construction. The task then loads keys, reads watermarks (clock-rewind check), and advances
-  each key on `spawn_blocking` until the current slot is inside its prepared interval (which
+  the chain task**, handing it the key directory at construction. The task then loads keys and
+  advances each key on `spawn_blocking` until the current slot is inside its prepared interval (which
   may take a while after long downtime — progress is logged). None of this needs consensus
   state, so it runs in parallel with the chain task's own startup — per
   [concurrency.md](concurrency.md#lifecycle), what the first `ChainView` gates is *serving*,
@@ -214,16 +303,22 @@ window boundary) mark the two failure modes to design out.
 - **Key generation ceremony / tooling** — devnet keys come from lean-quickstart's generator;
   Verity ships no keygen.
 - **Hot key reload** — key set changes require a restart.
-- **A separate slashing-protection database** — the protocol has no slashing; the watermark
-  *is* the double-sign protection, and an eth2-style interchange format has no counterpart
-  here yet.
+- **A separate slashing-protection database** — the protocol has no slashing, and an
+  eth2-style interchange format has no counterpart here. More generally, **no signing state is
+  persisted at all** (Decision 1).
+- **Defending state restored underneath the node** — a datadir or VM snapshot rolled back to an
+  earlier point, or two instances sharing one key set (scenario 3). No local mechanism can
+  observe either: a snapshot restore rolls back process memory along with everything else, and
+  two instances share nothing to coordinate through. This is an operator responsibility and
+  belongs in the operator documentation, not in the node.
 
 ## Verification obligations introduced by this model
 
-- **The watermark ordering property** is the consensus-critical invariant of this document:
-  *no signature is released whose slot is not durably watermarked*. It is a
-  sequential-ordering property of the signing path, targeted with property tests
-  (crash-injection between write and release) rather than Loom — no concurrency is involved.
+- **The once-per-slot property** is the invariant of this document: *the duty loop releases at
+  most one signature per `(validator, role, slot)`, and slots are visited in increasing order*.
+  It is a sequential property of a single task's loop, targeted with property tests over
+  interval sequences — no crash injection, because nothing is written, and no Loom, because no
+  concurrency is involved.
 - **Kani / bolero:** the loader (no-panic-on-any-input over manifest and key bytes; reject ⇒
   no partial registry) and the sign wrapper (leanSig's asserts unreachable given the
   wrapper's pre-checks).

--- a/docs/design/storage.md
+++ b/docs/design/storage.md
@@ -1,6 +1,6 @@
 ---
 title: Storage Schema
-last_updated: 2026-08-26
+last_updated: 2026-08-30
 tags:
   - storage
   - rocksdb
@@ -63,12 +63,11 @@ corruption, not an absent value.
 | `fork_choice_blocks` | `slot_be ‖ block_root` | `parent_root` | Processed fork-choice tree; retained |
 | `known_votes` | `validator_index_be` | `SSZ(AttestationData)` | Latest counted vote per validator |
 | `pending_votes` | `validator_index_be` | `SSZ(AttestationData)` | Latest not-yet-counted vote per validator |
-| `signing_watermarks` | `validator_index_be ‖ role` | `SSZ(uint64)` last-signed slot | Local XMSS no-reuse state; retained; see [Key Management](key-management.md) |
 | `metadata` | fixed ASCII key | typed scalar or SSZ value | Database identity and current view pointers |
 
-`role` is one byte: `0x00` attestation, `0x01` proposal. `signing_watermarks` rows exist only
-for validators this node operates; they are never pruned and never touched by any range
-tombstone.
+No column family holds validator signing state. XMSS no-reuse is carried by the duty loop in
+memory and nothing about it is written — see
+[Key Management](key-management.md#decision-1--no-persisted-signing-state-once-per-slot-duty-dedup).
 
 Blocks are stored unsigned: header and body are separate rows, while the signed envelope's aggregate
 proof is the `block_proofs` row. `MultiMessageAggregate` is persisted as the entire SSZ container,
@@ -142,12 +141,11 @@ automatically: an operator must select a new directory and explicitly checkpoint
 ## Writer, batches, and restart
 
 `verity-chain` — initially the chain module inside the single `verity-consensus` crate — owns the
-only write capability, with **one documented exception**: `signing_watermarks` is written solely by
-the validator signing path, because its persist-before-sign ordering must stay synchronous inside
-that path (see [Key Management](key-management.md#decision-1--signing-watermark-persist-before-sign)).
-The discipline is one writer per column family, not one writer per database. Watermark writes always
-fsync. P2P, RPC, validator duties, and maintenance otherwise submit requests to the chain writer
-rather than writing the backend directly. Read-only snapshot views may run concurrently.
+only write capability, with **no exceptions**: the discipline is one writer per database, not one
+writer per column family. P2P, RPC, validator duties, and maintenance submit requests to the chain
+writer rather than writing the backend directly. Read-only snapshot views may run concurrently.
+The rule is strong enough to express in the type system — the chain task holds the backend's only
+mutable handle — so it is enforced by ownership before any model checker is pointed at it.
 
 A processed block commits in one cross-column-family `WriteBatch`:
 


### PR DESCRIPTION
## What

Retires Decision 1 of `docs/design/key-management.md` — a per-`(validator, role)` signing watermark, persisted in its own column family and fsynced before every signature was released — and replaces it with leanSpec's own shape: an **in-memory, once-per-slot duty dedup**, with nothing about signing written to disk.

No Rust behavior changes: `verity-validator` does not exist yet, so the watermark lived only in design docs and `verity-crypto` doc comments.

## Why

**The threat was oversized.** The old text said reuse "breaks the key cryptographically". leanSig derives each epoch's one-time chain start values from the PRF applied to that epoch (`PRF::get_domain_element(&sk.prf_key, epoch, index)` in `sign`), so epochs are independent. Two different messages at one epoch expose that epoch and nothing else — the top tree, the PRF seed and every other epoch stay intact. The real blast radius is one validator's forgeable message at one slot, in a protocol with no slashing that already tolerates equivocation.

**The runtime cost landed in the worst place.** A durable write before signature release puts an fsync on the signing path, sharing the storage engine's WAL with the aggregate-proof workload (155–236 KB per proof, median 190 KB, ~4.1 GB/day). Signature-release latency then tracks compaction and flush tail behavior, inside the interval budget the attestation has to meet.

**The failure mode was unrecoverable by restart.** Failing closed at startup on `watermark ≥ current_slot` disabled a validator's duties for an unbounded period, and because the state was durable a restart did not clear it — while the scenario it targeted (state restored underneath the node) rolls the watermark back along with everything else.

## Survey corrections

The old survey section was wrong about the reference node in three ways:

- **It does persist.** `src/lean_spec/node/storage/` is a SQLite backend with `blocks`, `states`, `checkpoints` (incl. `genesis_time`, "Persisted so the node can restart without external genesis config"), `slot_index`, `state_root_index`. Excluding signing state is a choice made *with* a durability layer present.
- **It does have a guard**, `_attested_slots` (4-slot retention) — but it is duty-loop idempotence, not key safety. Attestation sits behind `interval >= 1` so one slot admits four passes; block production sits behind `interval == 0` so it admits one and needs no set.
- **It does not assume a monotone clock.** `node/chain/service.py` names NTP, leap seconds and VM migration, and defends by keeping `store.time` monotone. `concurrency.md:206` already requires the same of Verity's chain task, so no gap is introduced here.

## Also

Removing the column family removes `storage.md`'s only writer exception, so the invariant returns to **one writer per database** — expressible through ownership rather than convention.

Residual exposure is stated in the doc: an in-process clock step-back beyond 4 slots could let a validator re-sign a slot. The reference node accepts the same exposure with the same window; scenario 2 in the doc bounds how it arises.

## Verification

- `cargo clippy --workspace --locked --all-targets -- -D warnings` — clean
- `cargo test --workspace --locked` — pass
- `mdbook build` — clean