### PR TITLE
feat(db): implement the consensus repository over a swappable backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,30 @@ The `Quality / pre-commit` job runs `pre-commit run --all-files` with `SKIP=fmt,
 the Rust hooks need the toolchain, so they run in the `Rust` workflow where the
 toolchain and build cache live.
 
+## Host build requirements
+
+Beyond the Rust toolchain, which `rust-toolchain.toml` pins and `rustup` installs on its own,
+a Rust build needs two things from the host. Both come from `verity-db`'s RocksDB dependency,
+which is compiled from source rather than linked against a system library:
+
+- **A C++ toolchain.** `librocksdb-sys` builds RocksDB itself, plus `lz4-sys`.
+- **libclang.** `librocksdb-sys` generates its FFI bindings with bindgen on every build, in
+  `bindgen-runtime` mode, which loads `libclang` dynamically. On Debian and Ubuntu this is
+  `libclang-dev`; CI runner images already carry it.
+
+The first Rust build after a clean checkout therefore takes several minutes longer than the
+crate count suggests, and is cached afterwards.
+
+If bindgen reports `couldn't find any valid shared libraries matching: ['libclang.so',
+'libclang-*.so']` while `libclang` is plainly installed, the library is present only under a
+versioned name that bindgen's search does not match. Point it at one it does:
+
+```bash
+mkdir -p ~/.local/lib/libclang
+ln -sf /usr/lib/llvm-19/lib/libclang-19.so.1 ~/.local/lib/libclang/libclang.so
+export LIBCLANG_PATH=~/.local/lib/libclang
+```
+
 ## Tooling versions
 
 Hook versions are pinned by `rev` in `.pre-commit-config.yaml` and kept current by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,13 +548,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "jobserver",
+ "libc",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -566,6 +605,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1141,6 +1191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,10 +1661,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+]
 
 [[package]]
 name = "libssz"
@@ -1642,6 +1732,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1762,16 @@ name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "lz4_flex"
@@ -1685,6 +1796,12 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mt-air"
@@ -1805,6 +1922,16 @@ dependencies = [
  "system-info",
  "tracing",
  "zk-alloc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2164,6 +2291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2590,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2636,16 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -2808,6 +2963,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -3226,6 +3387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "verity-chain"
 version = "0.0.0"
 dependencies = [
@@ -3252,6 +3419,21 @@ dependencies = [
  "serde_json",
  "serde_norway",
  "tempfile",
+ "verity-types",
+]
+
+[[package]]
+name = "verity-db"
+version = "0.0.0"
+dependencies = [
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
+ "rocksdb",
+ "sha2",
+ "tempfile",
+ "verity-chain",
  "verity-types",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,31 @@ libp2p = { version = "0.56", default-features = false, features = [
 
 # --- Storage -------------------------------------------------------------------------------
 # See docs/src/reference/architecture.md "Storage engine and retention" for why an LSM engine and not a B-tree one.
-rocksdb = "0.24"
+#
+# `default-features = false` drops snappy, zstd, zlib, and bzip2. `verity-db` writes exactly two
+# compression settings — LZ4 for every table, and none for `block_proofs`, whose values are
+# high-entropy cryptographic blobs that compress to nothing. The other codecs would be four more
+# C libraries built into every image to support a setting nothing may select. Adding one back is a
+# change here and in `column.rs` together, which is the point.
+#
+# `bindgen-runtime` is in rocksdb's default set, so it has to be named again here or dropping the
+# defaults drops it too. It is not optional in practice: `librocksdb-sys` generates its FFI
+# bindings with bindgen on every build, and with neither `bindgen-runtime` nor `bindgen-static`
+# selected the build resolves bindgen's own defaults instead of the mode this manifest chose.
+# Runtime, not static: it loads the host's `libclang` dynamically, which is what CI images and
+# distribution `libclang-dev` packages provide. A build host therefore needs libclang available —
+# on a machine where the library is installed only under a versioned name (`libclang-19.so.1`),
+# point `LIBCLANG_PATH` at a directory holding a `libclang.so` symlink to it.
+rocksdb = { version = "0.24", default-features = false, features = [
+    "lz4",
+    "bindgen-runtime",
+] }
+
+# --- Hashing -------------------------------------------------------------------------------
+# Not the SSZ hasher — that is `libssz-merkle`, and nothing may route a consensus root around
+# it. This is for `verity-db`'s stored-type manifest digest, which hashes a description of the
+# schema rather than any consensus value.
+sha2 = "0.10"
 
 # --- Workspace members ---------------------------------------------------------------------
 # Declared here so a member's path appears in one place, like every external dependency.
@@ -112,7 +136,9 @@ rocksdb = "0.24"
 # wildcard requirement, which `deny.toml` bans for the same reason it bans one on a git
 # dependency: nothing in the manifest then states what the dependent was built against.
 verity-types = { path = "crates/verity-types", version = "0.0.0" }
+verity-chain = { path = "crates/verity-chain", version = "0.0.0" }
 verity-crypto = { path = "crates/verity-crypto", version = "0.0.0" }
+verity-db = { path = "crates/verity-db", version = "0.0.0" }
 
 # --- Test-only -----------------------------------------------------------------------------
 # Scoped to SSZ round-trip properties in `verity-types`. This is a deliberate, narrow exception

--- a/crates/verity-db/Cargo.toml
+++ b/crates/verity-db/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "verity-db"
+description = "The consensus repository: what is persisted, how it is keyed, and which transitions commit together, over a swappable byte-level backend."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+
+# The Runtime Shell's storage layer. It depends on `verity-types` for the shapes it stores and
+# on the SSZ family to encode them, and on nothing else from the workspace: a repository that
+# depended on `verity-chain` would be a repository that could make a consensus decision, and
+# the write discipline of `docs/design/storage.md` rests on it not being able to.
+#
+# `libssz-merkle` is here for the integrity checks — a batch is refused unless the header roots
+# to the block root and the state roots to the header — not to compute anything new.
+#
+# `sha2` hashes exactly one thing: the stored-type manifest of `schema.rs`. It is not the SSZ
+# hasher; that stays behind `libssz-merkle`.
+[dependencies]
+libssz.workspace = true
+libssz-derive.workspace = true
+libssz-merkle.workspace = true
+libssz-types.workspace = true
+rocksdb.workspace = true
+sha2.workspace = true
+verity-types.workspace = true
+
+# `verity-chain` is a *test* dependency only, and the direction matters: the repository must
+# not be able to reach a consensus decision, but a test of the repository is worth nothing
+# unless the states it stores are ones the real state transition produced.
+[dev-dependencies]
+tempfile.workspace = true
+verity-chain.workspace = true
+
+[lints]
+workspace = true

--- a/crates/verity-db/src/backend/memory.rs
+++ b/crates/verity-db/src/backend/memory.rs
@@ -75,7 +75,7 @@ impl StorageBackend for MemoryBackend {
     }
 
     fn range(&self, table: ColumnFamily, start: &[u8], end: &[u8]) -> Result<Rows, StorageError> {
-        // A reversed interval is empty, not an error, matching a RocksDB iterator seeked past
+        // A reversed interval is empty, not an error, matching a RocksDB iterator positioned past
         // its upper bound.
         if start >= end {
             return Ok(Vec::new());

--- a/crates/verity-db/src/backend/memory.rs
+++ b/crates/verity-db/src/backend/memory.rs
@@ -105,7 +105,7 @@ mod tests {
         let mut backend = MemoryBackend::new();
         let mut batch = WriteBatch::new();
         for slot in 0u64..8 {
-            batch.put(
+            batch.queue_put(
                 ColumnFamily::CanonicalBlocks,
                 slot.to_be_bytes().to_vec(),
                 vec![u8::try_from(slot).unwrap()],
@@ -146,7 +146,7 @@ mod tests {
     fn should_apply_a_range_delete_to_exactly_the_half_open_interval() {
         let mut backend = seeded();
         let mut batch = WriteBatch::new();
-        batch.delete_range(
+        batch.queue_delete_range(
             ColumnFamily::CanonicalBlocks,
             0u64.to_be_bytes().to_vec(),
             3u64.to_be_bytes().to_vec(),
@@ -167,8 +167,8 @@ mod tests {
     fn should_let_a_later_op_in_a_batch_win_over_an_earlier_one() {
         let mut backend = MemoryBackend::new();
         let mut batch = WriteBatch::new();
-        batch.put(ColumnFamily::Metadata, b"head".to_vec(), vec![1]);
-        batch.put(ColumnFamily::Metadata, b"head".to_vec(), vec![2]);
+        batch.queue_put(ColumnFamily::Metadata, b"head".to_vec(), vec![1]);
+        batch.queue_put(ColumnFamily::Metadata, b"head".to_vec(), vec![2]);
         backend.write(batch, Durability::Synced).unwrap();
         assert_eq!(
             backend.get(ColumnFamily::Metadata, b"head").unwrap(),

--- a/crates/verity-db/src/backend/memory.rs
+++ b/crates/verity-db/src/backend/memory.rs
@@ -1,0 +1,188 @@
+//! The in-memory sibling of the RocksDB backend.
+//!
+//! Used by tests and by ephemeral nodes. It is a `BTreeMap` per table precisely because
+//! `BTreeMap<Vec<u8>, _>` iterates in the same lexicographic byte order RocksDB does: a range
+//! scan written against this backend returns the rows, in the order, production returns.
+//!
+//! Durability is meaningless here — nothing survives the process — so [`Durability`] is
+//! accepted and ignored rather than being absent from the contract.
+
+use std::collections::BTreeMap;
+
+use crate::column::ColumnFamily;
+use crate::error::StorageError;
+
+use super::{Durability, Op, Rows, StorageBackend, WriteBatch};
+
+/// A volatile backend holding every table in a sorted map.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryBackend {
+    tables: BTreeMap<ColumnFamily, BTreeMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl MemoryBackend {
+    /// An empty database with every column family present.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            tables: ColumnFamily::ALL
+                .into_iter()
+                .map(|table| (table, BTreeMap::new()))
+                .collect(),
+        }
+    }
+
+    /// How many rows a table holds. Test affordance; the repository does not count rows.
+    #[must_use]
+    pub fn row_count(&self, table: ColumnFamily) -> usize {
+        self.tables.get(&table).map_or(0, BTreeMap::len)
+    }
+
+    fn table_mut(&mut self, table: ColumnFamily) -> &mut BTreeMap<Vec<u8>, Vec<u8>> {
+        self.tables.entry(table).or_default()
+    }
+
+    fn apply(&mut self, op: Op) {
+        match op {
+            Op::Put { table, key, value } => {
+                self.table_mut(table).insert(key, value);
+            }
+            Op::Delete { table, key } => {
+                self.table_mut(table).remove(&key);
+            }
+            Op::DeleteRange { table, start, end } => {
+                let doomed: Vec<Vec<u8>> = self
+                    .table_mut(table)
+                    .range(start..end)
+                    .map(|(key, _)| key.clone())
+                    .collect();
+                let rows = self.table_mut(table);
+                for key in doomed {
+                    rows.remove(&key);
+                }
+            }
+        }
+    }
+}
+
+impl StorageBackend for MemoryBackend {
+    fn get(&self, table: ColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
+        Ok(self
+            .tables
+            .get(&table)
+            .and_then(|rows| rows.get(key))
+            .cloned())
+    }
+
+    fn range(&self, table: ColumnFamily, start: &[u8], end: &[u8]) -> Result<Rows, StorageError> {
+        // A reversed interval is empty, not an error, matching a RocksDB iterator seeked past
+        // its upper bound.
+        if start >= end {
+            return Ok(Vec::new());
+        }
+        Ok(self.tables.get(&table).map_or_else(Vec::new, |rows| {
+            rows.range(start.to_vec()..end.to_vec())
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect()
+        }))
+    }
+
+    fn write(&mut self, batch: WriteBatch, _durability: Durability) -> Result<(), StorageError> {
+        // Atomicity is free: nothing observes the map between two ops of one `write` call,
+        // because the writer holds the only mutable handle.
+        for op in batch.ops().iter().cloned() {
+            self.apply(op);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnFamily, Durability, MemoryBackend, StorageBackend, WriteBatch};
+
+    fn seeded() -> MemoryBackend {
+        let mut backend = MemoryBackend::new();
+        let mut batch = WriteBatch::new();
+        for slot in 0u64..8 {
+            batch.put(
+                ColumnFamily::CanonicalBlocks,
+                slot.to_be_bytes().to_vec(),
+                vec![u8::try_from(slot).unwrap()],
+            );
+        }
+        backend.write(batch, Durability::Buffered).unwrap();
+        backend
+    }
+
+    #[test]
+    fn should_return_a_range_in_ascending_key_order() {
+        let backend = seeded();
+        let rows = backend
+            .range(
+                ColumnFamily::CanonicalBlocks,
+                &2u64.to_be_bytes(),
+                &5u64.to_be_bytes(),
+            )
+            .unwrap();
+        let values: Vec<u8> = rows.iter().map(|(_, value)| value[0]).collect();
+        assert_eq!(values, vec![2, 3, 4], "half-open, and sorted");
+    }
+
+    #[test]
+    fn should_treat_a_reversed_interval_as_empty() {
+        let backend = seeded();
+        let rows = backend
+            .range(
+                ColumnFamily::CanonicalBlocks,
+                &5u64.to_be_bytes(),
+                &2u64.to_be_bytes(),
+            )
+            .unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn should_apply_a_range_delete_to_exactly_the_half_open_interval() {
+        let mut backend = seeded();
+        let mut batch = WriteBatch::new();
+        batch.delete_range(
+            ColumnFamily::CanonicalBlocks,
+            0u64.to_be_bytes().to_vec(),
+            3u64.to_be_bytes().to_vec(),
+        );
+        backend.write(batch, Durability::Buffered).unwrap();
+
+        assert_eq!(backend.row_count(ColumnFamily::CanonicalBlocks), 5);
+        assert!(
+            backend
+                .get(ColumnFamily::CanonicalBlocks, &3u64.to_be_bytes())
+                .unwrap()
+                .is_some(),
+            "the exclusive upper bound survives"
+        );
+    }
+
+    #[test]
+    fn should_let_a_later_op_in_a_batch_win_over_an_earlier_one() {
+        let mut backend = MemoryBackend::new();
+        let mut batch = WriteBatch::new();
+        batch.put(ColumnFamily::Metadata, b"head".to_vec(), vec![1]);
+        batch.put(ColumnFamily::Metadata, b"head".to_vec(), vec![2]);
+        backend.write(batch, Durability::Synced).unwrap();
+        assert_eq!(
+            backend.get(ColumnFamily::Metadata, b"head").unwrap(),
+            Some(vec![2])
+        );
+    }
+
+    #[test]
+    fn should_report_no_value_for_an_absent_key() {
+        assert_eq!(
+            MemoryBackend::new()
+                .get(ColumnFamily::Metadata, b"head")
+                .unwrap(),
+            None
+        );
+    }
+}

--- a/crates/verity-db/src/backend/mod.rs
+++ b/crates/verity-db/src/backend/mod.rs
@@ -78,8 +78,14 @@ pub enum Op {
 
 /// A set of mutations that apply all or none.
 ///
+/// The `queue_` prefix on every method is the point: they mutate this batch and nothing else,
+/// and no key moves until the batch is handed to [`StorageBackend::write`]. A commit is one
+/// batch, so a crash between two of these calls cannot leave half a block on disk.
+///
 /// Ops are applied in insertion order, so a later put over an earlier key in the same batch
-/// wins, and a range delete does not remove a put issued after it.
+/// wins, and a range delete does not remove a put issued after it. A reorg to a block at a
+/// slot the old branch also occupied relies on exactly that: the delete is queued first and
+/// the new root's put lands after it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WriteBatch {
     ops: Vec<Op>,
@@ -92,8 +98,12 @@ impl WriteBatch {
         Self { ops: Vec::new() }
     }
 
-    /// Queues a value write.
-    pub fn put(&mut self, table: ColumnFamily, key: impl Into<Vec<u8>>, value: Vec<u8>) {
+    /// Writes `value` at `key`, replacing whatever the key already held.
+    ///
+    /// `key` is generic because callers build one from a root, a slot, a validator index, or
+    /// a fixed ASCII name; `value` is not, because every value in this crate is already the
+    /// `Vec<u8>` that `to_ssz` returned.
+    pub fn queue_put(&mut self, table: ColumnFamily, key: impl Into<Vec<u8>>, value: Vec<u8>) {
         self.ops.push(Op::Put {
             table,
             key: key.into(),
@@ -101,16 +111,16 @@ impl WriteBatch {
         });
     }
 
-    /// Queues a single-key removal.
-    pub fn delete(&mut self, table: ColumnFamily, key: impl Into<Vec<u8>>) {
+    /// Removes `key`. A key that is not present is not an error.
+    pub fn queue_delete(&mut self, table: ColumnFamily, key: impl Into<Vec<u8>>) {
         self.ops.push(Op::Delete {
             table,
             key: key.into(),
         });
     }
 
-    /// Queues a half-open range removal.
-    pub fn delete_range(
+    /// Removes every key in `[start, end)`, leaving `end` itself in place.
+    pub fn queue_delete_range(
         &mut self,
         table: ColumnFamily,
         start: impl Into<Vec<u8>>,

--- a/crates/verity-db/src/backend/mod.rs
+++ b/crates/verity-db/src/backend/mod.rs
@@ -1,0 +1,175 @@
+//! The byte-level contract every storage engine satisfies, and nothing above it.
+//!
+//! The trait exposes exactly four operations: point reads, lexicographically ordered
+//! half-open range reads, atomic write batches spanning column families, and half-open range
+//! deletes. Range deletes are an operation *inside* a batch rather than a method beside it,
+//! which is what lets a proof expiry and the metadata that records it commit together.
+//!
+//! No RocksDB behavior may leak past this contract without being named in it. The in-memory
+//! sibling preserves lexicographic iteration order for exactly that reason: a test that
+//! passes against it is a test that describes the ordering RocksDB will give in production.
+//!
+//! # Why writes take `&mut self`
+//!
+//! `docs/design/storage.md` requires one writer per database, with no exceptions — P2P, RPC,
+//! validator duties, and maintenance submit requests to the chain writer rather than writing
+//! here. That rule is expressible in the type system, so it is enforced by ownership: reads
+//! borrow shared, writes borrow unique, and a second writer cannot be constructed without
+//! moving the backend out of the first.
+
+pub mod memory;
+pub mod rocks;
+
+use crate::column::ColumnFamily;
+use crate::error::StorageError;
+
+pub use memory::MemoryBackend;
+pub use rocks::RocksBackend;
+
+/// Key-value pairs read from one table, in ascending key order.
+///
+/// Named rather than spelled out because the trait returns it and the repository forwards it
+/// unchanged: two identical anonymous tuple-vector types in two signatures say less about
+/// what they hold than one alias does.
+pub type Rows = Vec<(Vec<u8>, Vec<u8>)>;
+
+/// Whether a batch must reach the disk before the call returns.
+///
+/// Write-ahead logging is always on, so every batch is atomic either way. This chooses only
+/// whether the log is fsynced: routine block imports and interval updates are not, while
+/// anchors and commits that advance finalization are.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Durability {
+    /// Atomic, logged, but not fsynced. The default for routine progress.
+    Buffered,
+    /// Atomic and fsynced before returning.
+    Synced,
+}
+
+/// One mutation inside a batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Op {
+    /// Write a value, replacing any value already at the key.
+    Put {
+        /// Table to write into.
+        table: ColumnFamily,
+        /// Key to write at.
+        key: Vec<u8>,
+        /// Value to write.
+        value: Vec<u8>,
+    },
+    /// Remove a single key.
+    Delete {
+        /// Table to delete from.
+        table: ColumnFamily,
+        /// Key to remove.
+        key: Vec<u8>,
+    },
+    /// Remove every key in the half-open interval `[start, end)`.
+    DeleteRange {
+        /// Table to delete from.
+        table: ColumnFamily,
+        /// Inclusive lower bound.
+        start: Vec<u8>,
+        /// Exclusive upper bound.
+        end: Vec<u8>,
+    },
+}
+
+/// A set of mutations that apply all or none.
+///
+/// Ops are applied in insertion order, so a later put over an earlier key in the same batch
+/// wins, and a range delete does not remove a put issued after it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WriteBatch {
+    ops: Vec<Op>,
+}
+
+impl WriteBatch {
+    /// An empty batch.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { ops: Vec::new() }
+    }
+
+    /// Queues a value write.
+    pub fn put(&mut self, table: ColumnFamily, key: impl Into<Vec<u8>>, value: Vec<u8>) {
+        self.ops.push(Op::Put {
+            table,
+            key: key.into(),
+            value,
+        });
+    }
+
+    /// Queues a single-key removal.
+    pub fn delete(&mut self, table: ColumnFamily, key: impl Into<Vec<u8>>) {
+        self.ops.push(Op::Delete {
+            table,
+            key: key.into(),
+        });
+    }
+
+    /// Queues a half-open range removal.
+    pub fn delete_range(
+        &mut self,
+        table: ColumnFamily,
+        start: impl Into<Vec<u8>>,
+        end: impl Into<Vec<u8>>,
+    ) {
+        self.ops.push(Op::DeleteRange {
+            table,
+            start: start.into(),
+            end: end.into(),
+        });
+    }
+
+    /// The queued mutations, in the order they will be applied.
+    #[must_use]
+    pub fn ops(&self) -> &[Op] {
+        &self.ops
+    }
+
+    /// Whether the batch would change anything.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+
+    /// How many mutations are queued.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.ops.len()
+    }
+}
+
+/// A key-value engine the repository can be built on.
+///
+/// Implementors own no consensus meaning: keys and values are opaque bytes, and the ordering
+/// guarantee below is the only structure the repository is allowed to rely on.
+pub trait StorageBackend {
+    /// Reads the value at `key`, or `None` when the table holds no such key.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Backend`] when the engine fails.
+    fn get(&self, table: ColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError>;
+
+    /// Reads every pair in `[start, end)`, in ascending lexicographic key order.
+    ///
+    /// The result is materialized rather than streamed. Every caller in the repository scans
+    /// a slot-bounded window — a range-sync response, a fork-choice rebuild from the justified
+    /// slot, the two validator-indexed vote maps — so the bound is the caller's, not the
+    /// engine's, and a borrowed iterator would only push RocksDB's lifetimes into the trait.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Backend`] when the engine fails.
+    fn range(&self, table: ColumnFamily, start: &[u8], end: &[u8]) -> Result<Rows, StorageError>;
+
+    /// Applies every op in `batch` atomically, or none of them.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Backend`] when the engine fails. The batch is not partially applied.
+    fn write(&mut self, batch: WriteBatch, durability: Durability) -> Result<(), StorageError>;
+}

--- a/crates/verity-db/src/backend/rocks.rs
+++ b/crates/verity-db/src/backend/rocks.rs
@@ -1,0 +1,146 @@
+//! The RocksDB backend.
+//!
+//! The engine choice is settled in `docs/src/reference/architecture.md`: aggregate block
+//! proofs are 155–236 KB each and expire in slot order, so the dominant workload is large
+//! appends followed by bulk range deletion, which is what an LSM tree with range tombstones
+//! is for. Everything this module adds on top of the trait is physical tuning — column
+//! families, compression, sync flags — and none of it is visible to the repository.
+//!
+//! Write-ahead logging is left at its default, which is on. [`Durability`] chooses only
+//! whether that log is fsynced before the call returns.
+
+use std::path::{Path, PathBuf};
+
+use rocksdb::{
+    ColumnFamilyDescriptor, DB, DBCompressionType, IteratorMode, Options, ReadOptions,
+    WriteBatch as RocksBatch, WriteOptions,
+};
+
+use crate::column::ColumnFamily;
+use crate::error::StorageError;
+
+use super::{Durability, Op, Rows, StorageBackend, WriteBatch};
+
+/// A RocksDB database with one column family per logical table.
+#[derive(Debug)]
+pub struct RocksBackend {
+    db: DB,
+    path: PathBuf,
+}
+
+impl RocksBackend {
+    /// Opens, creating the database and any missing column family.
+    ///
+    /// Creating missing column families is safe here and is not a way of tolerating a
+    /// damaged database: identity checking happens a layer up, in
+    /// [`crate::Repository::open`], which refuses a populated database whose metadata does
+    /// not match. An empty new table in an otherwise populated directory would fail that
+    /// check on its missing metadata rather than being silently adopted.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Backend`] when RocksDB cannot open the directory.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, StorageError> {
+        let path = path.as_ref().to_path_buf();
+
+        let mut db_options = Options::default();
+        db_options.create_if_missing(true);
+        db_options.create_missing_column_families(true);
+
+        let descriptors = ColumnFamily::ALL
+            .map(|table| ColumnFamilyDescriptor::new(table.name(), table_options(table)));
+
+        let db = DB::open_cf_descriptors(&db_options, &path, descriptors).map_err(backend)?;
+        Ok(Self { db, path })
+    }
+
+    /// The directory this database lives in.
+    ///
+    /// A failure preserves the directory for diagnosis rather than repairing it, so the
+    /// operator has to be told where to look.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn handle(&self, table: ColumnFamily) -> Result<&rocksdb::ColumnFamily, StorageError> {
+        self.db.cf_handle(table.name()).ok_or_else(|| {
+            StorageError::Backend(format!(
+                "column family {table} is absent from {}",
+                self.path.display()
+            ))
+        })
+    }
+}
+
+/// Per-table physical options.
+///
+/// Compression is the only setting fixed here, because it follows from what the table holds
+/// rather than from the machine. Cache size, memtable size, and compaction parallelism are
+/// operational tunables and are deliberately left at RocksDB's defaults until production
+/// fixtures say otherwise; none of them is a consensus constant.
+fn table_options(table: ColumnFamily) -> Options {
+    let mut options = Options::default();
+    options.set_compression_type(if table.compressed() {
+        DBCompressionType::Lz4
+    } else {
+        DBCompressionType::None
+    });
+    options
+}
+
+fn backend(error: rocksdb::Error) -> StorageError {
+    StorageError::Backend(error.to_string())
+}
+
+impl StorageBackend for RocksBackend {
+    fn get(&self, table: ColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
+        self.db.get_cf(self.handle(table)?, key).map_err(backend)
+    }
+
+    fn range(&self, table: ColumnFamily, start: &[u8], end: &[u8]) -> Result<Rows, StorageError> {
+        if start >= end {
+            return Ok(Vec::new());
+        }
+        let handle = self.handle(table)?;
+
+        // Bounds are set on the iterator rather than checked per row, so RocksDB can skip
+        // whole SST files instead of handing them up to be discarded.
+        let mut read_options = ReadOptions::default();
+        read_options.set_iterate_lower_bound(start.to_vec());
+        read_options.set_iterate_upper_bound(end.to_vec());
+
+        let mut rows = Vec::new();
+        for row in self
+            .db
+            .iterator_cf_opt(handle, read_options, IteratorMode::Start)
+        {
+            let (key, value) = row.map_err(backend)?;
+            rows.push((key.into_vec(), value.into_vec()));
+        }
+        Ok(rows)
+    }
+
+    fn write(&mut self, batch: WriteBatch, durability: Durability) -> Result<(), StorageError> {
+        let mut rocks_batch = RocksBatch::default();
+        for op in batch.ops() {
+            match op {
+                Op::Put { table, key, value } => {
+                    rocks_batch.put_cf(self.handle(*table)?, key, value);
+                }
+                Op::Delete { table, key } => {
+                    rocks_batch.delete_cf(self.handle(*table)?, key);
+                }
+                Op::DeleteRange { table, start, end } => {
+                    rocks_batch.delete_range_cf(self.handle(*table)?, start, end);
+                }
+            }
+        }
+
+        let mut write_options = WriteOptions::default();
+        write_options.set_sync(durability == Durability::Synced);
+        self.db
+            .write_opt(rocks_batch, &write_options)
+            .map_err(backend)
+    }
+}

--- a/crates/verity-db/src/column.rs
+++ b/crates/verity-db/src/column.rs
@@ -1,0 +1,140 @@
+//! The logical tables the repository is split into.
+//!
+//! One column family per logical table, so a range tombstone issued for one keyspace cannot
+//! reach another. RocksDB's own default column family is reserved and never named here.
+//!
+//! Transcribed from `docs/design/storage.md`, "Column families".
+
+use core::fmt;
+
+/// A logical table in the repository.
+///
+/// The `name` of a variant is the on-disk column-family name. It is part of the stored
+/// format: renaming one makes an existing database unreadable, so a rename is a schema
+/// migration, not a refactor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ColumnFamily {
+    /// `block_root` -> `SSZ(BlockHeader)`. Every processed block; retained.
+    BlockHeaders,
+    /// `block_root` -> `SSZ(BlockBody)`. Every processed block, empty bodies included.
+    BlockBodies,
+    /// `slot_be ‖ block_root` -> `SSZ(MultiMessageAggregate)`. Range-pruned.
+    BlockProofs,
+    /// `block_root` -> `SSZ(State)`. Anchors and periodic bases; retained.
+    StateSnapshots,
+    /// `block_root` -> `SSZ(StateDiff)`. One per processed non-anchor block; retained.
+    StateDiffs,
+    /// `slot_be` -> `block_root`. The canonical root at each non-empty slot.
+    CanonicalBlocks,
+    /// `state_root` -> `block_root`. Reverse lookup for checkpoint sync.
+    StateRoots,
+    /// `slot_be ‖ block_root` -> `parent_root`. The all-branch fork-choice tree.
+    ForkChoiceBlocks,
+    /// `validator_index_be` -> `SSZ(AttestationData)`. Latest counted vote.
+    KnownVotes,
+    /// `validator_index_be` -> `SSZ(AttestationData)`. Latest not-yet-counted vote.
+    PendingVotes,
+    /// Fixed ASCII key -> typed scalar or SSZ value. Identity and view pointers.
+    Metadata,
+}
+
+impl ColumnFamily {
+    /// Every column family, in the order `docs/design/storage.md` lists them.
+    ///
+    /// Opening a database creates exactly these, so a variant added without appearing here
+    /// would be a table nothing ever creates.
+    pub const ALL: [Self; 11] = [
+        Self::BlockHeaders,
+        Self::BlockBodies,
+        Self::BlockProofs,
+        Self::StateSnapshots,
+        Self::StateDiffs,
+        Self::CanonicalBlocks,
+        Self::StateRoots,
+        Self::ForkChoiceBlocks,
+        Self::KnownVotes,
+        Self::PendingVotes,
+        Self::Metadata,
+    ];
+
+    /// The on-disk column-family name.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::BlockHeaders => "block_headers",
+            Self::BlockBodies => "block_bodies",
+            Self::BlockProofs => "block_proofs",
+            Self::StateSnapshots => "state_snapshots",
+            Self::StateDiffs => "state_diffs",
+            Self::CanonicalBlocks => "canonical_blocks",
+            Self::StateRoots => "state_roots",
+            Self::ForkChoiceBlocks => "fork_choice_blocks",
+            Self::KnownVotes => "known_votes",
+            Self::PendingVotes => "pending_votes",
+            Self::Metadata => "metadata",
+        }
+    }
+
+    /// Whether values in this table are worth compressing.
+    ///
+    /// Aggregate proofs are high-entropy cryptographic blobs: compressing them spends CPU on
+    /// every write and compaction to save almost nothing. Everything else is small, repetitive
+    /// SSZ and takes LZ4 well.
+    #[must_use]
+    pub const fn compressed(self) -> bool {
+        !matches!(self, Self::BlockProofs)
+    }
+
+    /// The fixed key width of this table, or `None` where keys are variable-width.
+    ///
+    /// Only [`ColumnFamily::Metadata`] is variable: its keys are fixed ASCII strings of
+    /// differing length. Everywhere else a key of the wrong width is a caller bug, and
+    /// [`crate::key`] rejects it rather than silently producing a row nothing can find.
+    #[must_use]
+    pub const fn key_width(self) -> Option<usize> {
+        match self {
+            Self::BlockHeaders
+            | Self::BlockBodies
+            | Self::StateSnapshots
+            | Self::StateDiffs
+            | Self::StateRoots => Some(32),
+            Self::BlockProofs | Self::ForkChoiceBlocks => Some(40),
+            Self::CanonicalBlocks | Self::KnownVotes | Self::PendingVotes => Some(8),
+            Self::Metadata => None,
+        }
+    }
+}
+
+impl fmt::Display for ColumnFamily {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnFamily;
+
+    #[test]
+    fn should_give_every_column_family_a_distinct_name() {
+        let mut names: Vec<_> = ColumnFamily::ALL.iter().map(|cf| cf.name()).collect();
+        names.sort_unstable();
+        let count = names.len();
+        names.dedup();
+        assert_eq!(names.len(), count);
+    }
+
+    #[test]
+    fn should_never_use_the_reserved_default_column_family() {
+        assert!(ColumnFamily::ALL.iter().all(|cf| cf.name() != "default"));
+    }
+
+    #[test]
+    fn should_leave_only_the_proof_table_uncompressed() {
+        let uncompressed: Vec<_> = ColumnFamily::ALL
+            .iter()
+            .filter(|cf| !cf.compressed())
+            .collect();
+        assert_eq!(uncompressed, vec![&ColumnFamily::BlockProofs]);
+    }
+}

--- a/crates/verity-db/src/diff.rs
+++ b/crates/verity-db/src/diff.rs
@@ -1,0 +1,120 @@
+//! The per-block state delta, and the snapshot rule that bounds how many of them a replay
+//! ever walks.
+//!
+//! A full state per block is not affordable. `process_slots` appends to
+//! `historical_block_hashes` every slot and the lstar state never trims it, so a state is
+//! roughly `300 B + 32 B × slot`: about 691 KB at one day of slots and 8.4 MB at
+//! `HISTORICAL_ROOTS_LIMIT`. Writing one per block would grow quadratically — around 7.5 GB
+//! over the first day alone.
+//!
+//! So a full snapshot is written at anchors and at 1,024-slot boundaries, and every other
+//! processed block writes a [`StateDiff`]. The diff carries only the fields a block can move
+//! that nothing else can rederive: the snapshot supplies `config` and the validator registry,
+//! and `reconstruct` derives the latest header and the historical roots from the stored
+//! blocks and the parent link.
+//!
+//! Transcribed from `docs/design/storage.md`, "State storage: snapshots and diffs".
+
+use libssz_derive::{HashTreeRoot, SszDecode, SszEncode};
+use verity_types::primitives::{Bytes32, Slot};
+use verity_types::state::{JustificationRoots, JustificationValidators, JustifiedSlots};
+use verity_types::{Checkpoint, State};
+
+/// How often a full snapshot is written, in slots.
+///
+/// A block writes a snapshot when its edge from its parent crosses a multiple of this. The
+/// rule is stated on the *edge*, not on the block's own slot, so a run of empty slots cannot
+/// skip a boundary and lengthen a replay past 1,023 diffs.
+pub const SNAPSHOT_INTERVAL_SLOTS: u64 = 1_024;
+
+/// The fields of a state that a block moves and nothing else can rederive.
+///
+/// Field order is the stored format. It follows `docs/design/storage.md` exactly; reordering
+/// it makes every existing `state_diffs` row decode into a different state, which is why the
+/// stored-type manifest in [`crate::schema`] hashes this shape.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, SszEncode, SszDecode, HashTreeRoot)]
+pub struct StateDiff {
+    /// Root of the block this diff is applied on top of — the child's parent.
+    pub base_block_root: Bytes32,
+    /// The slot of the state this diff produces.
+    pub slot: Slot,
+    /// The highest justified checkpoint after the block.
+    pub latest_justified: Checkpoint,
+    /// The highest finalized checkpoint after the block.
+    pub latest_finalized: Checkpoint,
+    /// Justification status per tracked slot after the block.
+    pub justified_slots: JustifiedSlots,
+    /// Block roots of the slots with justification votes in flight.
+    pub justifications_roots: JustificationRoots,
+    /// Justification votes, flattened over slots and validators.
+    pub justifications_validators: JustificationValidators,
+}
+
+impl StateDiff {
+    /// The diff that reproduces `post` from the state of its parent block.
+    ///
+    /// The base is taken from `post.latest_block_header.parent_root` rather than being passed
+    /// in, so a diff cannot be built claiming a base the state does not actually descend from.
+    #[must_use = "this builds the row; it does not store it"]
+    pub fn of(post: &State) -> Self {
+        Self {
+            base_block_root: post.latest_block_header.parent_root,
+            slot: post.slot,
+            latest_justified: post.latest_justified,
+            latest_finalized: post.latest_finalized,
+            justified_slots: post.justified_slots.clone(),
+            justifications_roots: post.justifications_roots.clone(),
+            justifications_validators: post.justifications_validators.clone(),
+        }
+    }
+}
+
+/// Whether the edge from `parent_slot` to `block_slot` crosses a snapshot boundary.
+///
+/// # Panics
+///
+/// Never. A `block_slot` at or below `parent_slot` cannot cross a boundary and returns
+/// `false`; the state transition has already refused such a block long before this is asked.
+#[must_use]
+pub fn crosses_snapshot_boundary(parent_slot: Slot, block_slot: Slot) -> bool {
+    parent_slot.0 / SNAPSHOT_INTERVAL_SLOTS < block_slot.0 / SNAPSHOT_INTERVAL_SLOTS
+}
+
+#[cfg(test)]
+mod tests {
+    use libssz::{SszDecode, SszEncode};
+    use verity_types::primitives::Slot;
+
+    use super::{SNAPSHOT_INTERVAL_SLOTS, StateDiff, crosses_snapshot_boundary};
+
+    #[test]
+    fn should_take_a_snapshot_when_the_edge_crosses_a_boundary() {
+        assert!(crosses_snapshot_boundary(
+            Slot(SNAPSHOT_INTERVAL_SLOTS - 1),
+            Slot(SNAPSHOT_INTERVAL_SLOTS)
+        ));
+    }
+
+    #[test]
+    fn should_not_take_a_snapshot_inside_one_interval() {
+        assert!(!crosses_snapshot_boundary(Slot(1), Slot(1_023)));
+    }
+
+    #[test]
+    fn should_take_a_snapshot_when_empty_slots_jump_over_a_boundary() {
+        assert!(
+            crosses_snapshot_boundary(Slot(1_000), Slot(3_000)),
+            "the rule is on the edge, so a gap cannot skip a boundary"
+        );
+    }
+
+    #[test]
+    fn should_round_trip_a_diff_through_its_stored_encoding() {
+        let diff = StateDiff {
+            base_block_root: [7u8; 32],
+            slot: Slot(9),
+            ..StateDiff::default()
+        };
+        assert_eq!(StateDiff::from_ssz_bytes(&diff.to_ssz()).unwrap(), diff);
+    }
+}

--- a/crates/verity-db/src/diff.rs
+++ b/crates/verity-db/src/diff.rs
@@ -53,10 +53,15 @@ pub struct StateDiff {
 impl StateDiff {
     /// The diff that reproduces `post` from the state of its parent block.
     ///
+    /// This drops most of a state rather than converting one, which is why it is a named
+    /// constructor and not a `From` implementation: `config`, the validator registry, the
+    /// latest header, and the historical roots are all left behind for the snapshot and for
+    /// `reconstruct` to supply.
+    ///
     /// The base is taken from `post.latest_block_header.parent_root` rather than being passed
     /// in, so a diff cannot be built claiming a base the state does not actually descend from.
     #[must_use = "this builds the row; it does not store it"]
-    pub fn of(post: &State) -> Self {
+    pub fn from_post_state(post: &State) -> Self {
         Self {
             base_block_root: post.latest_block_header.parent_root,
             slot: post.slot,

--- a/crates/verity-db/src/error.rs
+++ b/crates/verity-db/src/error.rs
@@ -1,0 +1,236 @@
+//! What can go wrong between a consensus value and the bytes that hold it.
+//!
+//! Every variant here is fatal to the node. `docs/design/storage.md` is explicit that a
+//! decode failure, a missing required row, an identity mismatch, or a root-integrity failure
+//! stops the node and preserves the directory for diagnosis — none of them is ever treated as
+//! an absent value, and none is recovered from by overwriting. There is deliberately no
+//! "not found" variant: an absent row that is legitimately absent is `Ok(None)`.
+
+use core::fmt;
+
+use verity_types::Bytes32;
+
+use crate::column::ColumnFamily;
+use crate::metadata::MetadataKey;
+
+/// A failure of the repository or of the database underneath it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StorageError {
+    /// The backend engine itself failed. Carries the engine's own message.
+    Backend(String),
+    /// A stored value did not decode as the SSZ type its table declares.
+    Decode {
+        /// The table the value came from.
+        table: ColumnFamily,
+        /// The key it was stored under.
+        key: Vec<u8>,
+    },
+    /// A key of the wrong width was offered for a fixed-width table.
+    KeyWidth {
+        /// The table that rejected it.
+        table: ColumnFamily,
+        /// The width the table requires.
+        expected: usize,
+        /// The width supplied.
+        found: usize,
+    },
+    /// A row the repository requires in order to make progress is absent.
+    MissingRow {
+        /// The table the row was expected in.
+        table: ColumnFamily,
+        /// The key it was expected under.
+        key: Vec<u8>,
+    },
+    /// A `metadata` value a populated database must carry is absent.
+    MissingMetadata(MetadataKey),
+    /// The database on disk describes a different chain, fork, or schema.
+    Identity(IdentityMismatch),
+    /// A value does not hash to the root that was committed for it.
+    RootMismatch {
+        /// The root the committed data claims.
+        expected: Bytes32,
+        /// The root the stored value actually produces.
+        computed: Bytes32,
+    },
+    /// A stored parent link disagrees with the child that points at it.
+    ParentMismatch {
+        /// The parent the child header names.
+        expected: Bytes32,
+        /// The parent the stored row names.
+        found: Bytes32,
+    },
+    /// A batch was refused before it reached the backend.
+    ///
+    /// The writer checks a commit's internal consistency first, so an inconsistent batch is
+    /// never made durable and never partially applied.
+    RejectedBatch(&'static str),
+    /// Rebuilding a state ran longer than the snapshot interval allows.
+    ///
+    /// The snapshot rule bounds any replay at 1,023 diffs. Exceeding it means the snapshot
+    /// that should have terminated the walk is missing, which is corruption, not a long chain.
+    ReplayTooLong {
+        /// The block the walk started from.
+        from: Bytes32,
+        /// The number of diffs walked before giving up.
+        walked: usize,
+    },
+    /// A reconstructed collection overran the SSZ limit that bounds it.
+    CapacityExceeded(&'static str),
+}
+
+/// Which identity value disagrees with the node's configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityMismatch {
+    /// The database was written by a different repository schema version.
+    SchemaVersion {
+        /// The version this build writes.
+        expected: u32,
+        /// The version found on disk.
+        found: u32,
+    },
+    /// The database holds a different chain.
+    ChainFingerprint {
+        /// The configured genesis state root.
+        expected: Bytes32,
+        /// The genesis state root found on disk.
+        found: Bytes32,
+    },
+    /// The database was written under a different protocol fork.
+    ForkVersion {
+        /// The configured fork version.
+        expected: u64,
+        /// The fork version found on disk.
+        found: u64,
+    },
+    /// A stored SSZ container has changed shape since the database was written.
+    SszSchemaDigest {
+        /// The digest of this build's stored-type manifest.
+        expected: Bytes32,
+        /// The digest found on disk.
+        found: Bytes32,
+    },
+}
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(message) => write!(f, "storage backend failed: {message}"),
+            Self::Decode { table, key } => {
+                write!(f, "value in {table} at {} did not decode", Hex(key))
+            }
+            Self::KeyWidth {
+                table,
+                expected,
+                found,
+            } => write!(f, "{table} keys are {expected} bytes wide, got {found}"),
+            Self::MissingRow { table, key } => {
+                write!(f, "required row {} is absent from {table}", Hex(key))
+            }
+            Self::MissingMetadata(key) => write!(f, "required metadata value {key} is absent"),
+            Self::Identity(mismatch) => write!(f, "{mismatch}"),
+            Self::RootMismatch { expected, computed } => write!(
+                f,
+                "committed root {} but the value hashes to {}",
+                Hex(expected),
+                Hex(computed)
+            ),
+            Self::ParentMismatch { expected, found } => write!(
+                f,
+                "child names parent {} but the stored link names {}",
+                Hex(expected),
+                Hex(found)
+            ),
+            Self::RejectedBatch(reason) => write!(f, "batch refused: {reason}"),
+            Self::ReplayTooLong { from, walked } => write!(
+                f,
+                "no snapshot found within {walked} diffs of {}",
+                Hex(from)
+            ),
+            Self::CapacityExceeded(what) => write!(f, "{what} overran its SSZ limit"),
+        }
+    }
+}
+
+impl fmt::Display for IdentityMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SchemaVersion { expected, found } => write!(
+                f,
+                "database schema version is {found}, this build writes {expected}"
+            ),
+            Self::ChainFingerprint { expected, found } => write!(
+                f,
+                "database holds chain {}, configured for {}",
+                Hex(found),
+                Hex(expected)
+            ),
+            Self::ForkVersion { expected, found } => write!(
+                f,
+                "database was written at fork version {found}, configured for {expected}"
+            ),
+            Self::SszSchemaDigest { expected, found } => write!(
+                f,
+                "database stored-type manifest is {}, this build's is {}",
+                Hex(found),
+                Hex(expected)
+            ),
+        }
+    }
+}
+
+impl core::error::Error for StorageError {}
+impl core::error::Error for IdentityMismatch {}
+
+impl From<IdentityMismatch> for StorageError {
+    fn from(mismatch: IdentityMismatch) -> Self {
+        Self::Identity(mismatch)
+    }
+}
+
+/// Renders bytes as lowercase hex, so a key or root in a message is greppable against the
+/// database rather than being printed as a decimal array.
+struct Hex<'a>(&'a [u8]);
+
+impl fmt::Display for Hex<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("0x")?;
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnFamily, Hex, IdentityMismatch, StorageError};
+
+    #[test]
+    fn should_render_keys_as_hex_so_a_message_is_greppable() {
+        assert_eq!(Hex(&[0x0a, 0xff]).to_string(), "0x0aff");
+    }
+
+    #[test]
+    fn should_name_the_table_and_key_when_a_value_fails_to_decode() {
+        let error = StorageError::Decode {
+            table: ColumnFamily::StateDiffs,
+            key: vec![0x01],
+        };
+        assert_eq!(
+            error.to_string(),
+            "value in state_diffs at 0x01 did not decode"
+        );
+    }
+
+    #[test]
+    fn should_report_the_stored_side_and_the_configured_side_of_a_fork_mismatch() {
+        let error = StorageError::from(IdentityMismatch::ForkVersion {
+            expected: 2,
+            found: 1,
+        });
+        assert_eq!(
+            error.to_string(),
+            "database was written at fork version 1, configured for 2"
+        );
+    }
+}

--- a/crates/verity-db/src/key.rs
+++ b/crates/verity-db/src/key.rs
@@ -1,0 +1,172 @@
+//! How a consensus identifier becomes a database key.
+//!
+//! Two rules hold everywhere. Roots are stored raw, as their 32 SSZ bytes. Integers are
+//! stored fixed-width **big-endian**, so lexicographic key order — the only order a
+//! byte-level backend has — is numeric order. That equality is what makes a slot range a
+//! contiguous scan and a proof expiry a single range tombstone.
+//!
+//! Transcribed from `docs/design/storage.md`, "Column families".
+
+use verity_types::primitives::{Bytes32, Slot, ValidatorIndex};
+
+use crate::column::ColumnFamily;
+use crate::error::StorageError;
+
+/// Width of a big-endian `u64` key component.
+pub const SLOT_WIDTH: usize = 8;
+
+/// Width of a raw 32-byte root key component.
+pub const ROOT_WIDTH: usize = 32;
+
+/// Width of a `slot_be ‖ root` composite key.
+pub const SLOT_ROOT_WIDTH: usize = SLOT_WIDTH + ROOT_WIDTH;
+
+/// A root, as its own key.
+#[must_use]
+pub const fn root(root: Bytes32) -> [u8; ROOT_WIDTH] {
+    root
+}
+
+/// A slot, as a big-endian key.
+#[must_use]
+pub fn slot(slot: Slot) -> [u8; SLOT_WIDTH] {
+    slot.0.to_be_bytes()
+}
+
+/// A validator index, as a big-endian key.
+#[must_use]
+pub fn validator(index: ValidatorIndex) -> [u8; SLOT_WIDTH] {
+    index.0.to_be_bytes()
+}
+
+/// The `slot_be ‖ root` key that orders a table by slot first.
+#[must_use]
+pub fn slot_and_root(at: Slot, block_root: Bytes32) -> [u8; SLOT_ROOT_WIDTH] {
+    let mut key = [0u8; SLOT_ROOT_WIDTH];
+    key[..SLOT_WIDTH].copy_from_slice(&slot(at));
+    key[SLOT_WIDTH..].copy_from_slice(&block_root);
+    key
+}
+
+/// The half-open key bounds covering slots `[start, end)` in a slot-keyed table.
+#[must_use]
+pub fn slot_bounds(start: Slot, end: Slot) -> ([u8; SLOT_WIDTH], [u8; SLOT_WIDTH]) {
+    (slot(start), slot(end))
+}
+
+/// The half-open key bounds covering slots `[start, end)` in a `slot_be ‖ root` table.
+///
+/// The zero root is the smallest 32-byte suffix, so a bound of `slot ‖ 0` sits at or before
+/// every key at that slot and strictly after every key below it. The range therefore covers
+/// exactly the slots asked for, whatever roots happen to be present.
+#[must_use]
+pub fn slot_and_root_bounds(
+    start: Slot,
+    end: Slot,
+) -> ([u8; SLOT_ROOT_WIDTH], [u8; SLOT_ROOT_WIDTH]) {
+    (
+        slot_and_root(start, [0u8; ROOT_WIDTH]),
+        slot_and_root(end, [0u8; ROOT_WIDTH]),
+    )
+}
+
+/// Reads back a big-endian slot key.
+///
+/// # Errors
+///
+/// [`StorageError::KeyWidth`] when the stored key is not eight bytes wide, which means the
+/// table holds a key nothing in this module could have written.
+pub fn decode_slot(table: ColumnFamily, key: &[u8]) -> Result<Slot, StorageError> {
+    let bytes: [u8; SLOT_WIDTH] = key.try_into().map_err(|_| StorageError::KeyWidth {
+        table,
+        expected: SLOT_WIDTH,
+        found: key.len(),
+    })?;
+    Ok(Slot(u64::from_be_bytes(bytes)))
+}
+
+/// Reads back a big-endian validator-index key.
+///
+/// # Errors
+///
+/// [`StorageError::KeyWidth`] when the stored key is not eight bytes wide.
+pub fn decode_validator(table: ColumnFamily, key: &[u8]) -> Result<ValidatorIndex, StorageError> {
+    let bytes: [u8; SLOT_WIDTH] = key.try_into().map_err(|_| StorageError::KeyWidth {
+        table,
+        expected: SLOT_WIDTH,
+        found: key.len(),
+    })?;
+    Ok(ValidatorIndex(u64::from_be_bytes(bytes)))
+}
+
+/// Reads back a raw root key.
+///
+/// # Errors
+///
+/// [`StorageError::KeyWidth`] when the stored key is not 32 bytes wide.
+pub fn decode_root(table: ColumnFamily, key: &[u8]) -> Result<Bytes32, StorageError> {
+    key.try_into().map_err(|_| StorageError::KeyWidth {
+        table,
+        expected: ROOT_WIDTH,
+        found: key.len(),
+    })
+}
+
+/// Reads back a `slot_be ‖ root` composite key.
+///
+/// # Errors
+///
+/// [`StorageError::KeyWidth`] when the stored key is not 40 bytes wide.
+pub fn decode_slot_and_root(
+    table: ColumnFamily,
+    key: &[u8],
+) -> Result<(Slot, Bytes32), StorageError> {
+    if key.len() != SLOT_ROOT_WIDTH {
+        return Err(StorageError::KeyWidth {
+            table,
+            expected: SLOT_ROOT_WIDTH,
+            found: key.len(),
+        });
+    }
+    let at = decode_slot(table, &key[..SLOT_WIDTH])?;
+    let block_root = decode_root(table, &key[SLOT_WIDTH..])?;
+    Ok((at, block_root))
+}
+
+#[cfg(test)]
+mod tests {
+    use verity_types::primitives::Slot;
+
+    use super::{ColumnFamily, decode_slot_and_root, slot, slot_and_root, slot_and_root_bounds};
+
+    #[test]
+    fn should_order_slot_keys_numerically_when_compared_as_bytes() {
+        assert!(slot(Slot(255)) < slot(Slot(256)), "big-endian, not little");
+        assert!(slot(Slot(0)) < slot(Slot(u64::MAX)));
+    }
+
+    #[test]
+    fn should_group_every_root_at_a_slot_inside_that_slot_bounds() {
+        let (start, end) = slot_and_root_bounds(Slot(7), Slot(8));
+        for byte in [0x00u8, 0x7f, 0xff] {
+            let key = slot_and_root(Slot(7), [byte; 32]);
+            assert!(key >= start && key < end, "root {byte:#x} left slot 7");
+        }
+        assert!(slot_and_root(Slot(8), [0u8; 32]) >= end);
+        assert!(slot_and_root(Slot(6), [0xffu8; 32]) < start);
+    }
+
+    #[test]
+    fn should_round_trip_a_composite_key() {
+        let key = slot_and_root(Slot(4_096), [3u8; 32]);
+        assert_eq!(
+            decode_slot_and_root(ColumnFamily::BlockProofs, &key).unwrap(),
+            (Slot(4_096), [3u8; 32])
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_composite_key_of_the_wrong_width() {
+        assert!(decode_slot_and_root(ColumnFamily::BlockProofs, &[0u8; 39]).is_err());
+    }
+}

--- a/crates/verity-db/src/lib.rs
+++ b/crates/verity-db/src/lib.rs
@@ -1,0 +1,69 @@
+//! The consensus repository: what Verity persists, and the only way it is written.
+//!
+//! # What belongs here
+//!
+//! A Runtime Shell concern, not a consensus object. Nothing in this crate decides whether a
+//! block is valid, which fork is the head, or whether a vote should count — it records what
+//! the chain already decided, and refuses to record something self-contradictory. That is why
+//! it depends on `verity-types` and not on `verity-chain`: a repository able to reach a
+//! consensus decision would be a second place where one could be made.
+//!
+//! Consensus values are stored as their exact SSZ types, so a row never invents an
+//! alternative encoding for a protocol container. The one type defined here that leanSpec
+//! does not have is [`StateDiff`], and it exists for a size reason set out in [`diff`].
+//!
+//! # The layers
+//!
+//! - [`backend`] — four byte-level operations, with a RocksDB implementation and an in-memory
+//!   sibling that preserves its iteration order.
+//! - [`column`] and [`key`] — which table a value lives in and how its identifier is encoded.
+//!   Integer keys are big-endian so that lexicographic order is numeric order, which is what
+//!   makes a slot range a scan and a proof expiry a single range tombstone.
+//! - [`Repository`] — consensus values over the backend, plus the identity check that refuses
+//!   a database belonging to another chain, fork, or schema.
+//! - [`writer`] — the four commits, each one batch, each checked before it can become durable.
+//! - [`retention`] — the only two things ever deleted, and what a peer may therefore request.
+//!
+//! # One writer
+//!
+//! `docs/design/storage.md` requires one writer per database, with no exceptions: P2P, RPC,
+//! validator duties, and maintenance submit requests to the chain writer rather than writing
+//! here. The rule is carried by ownership rather than by convention — [`Repository`] owns its
+//! backend by value, reads take `&self`, and commits take `&mut self` — so a second writer
+//! cannot be constructed without moving the repository out of the first.
+//!
+//! Within a process that is the whole enforcement. Across processes it is RocksDB's: opening
+//! a directory takes an exclusive lock on it, so a second node aimed at the same path fails
+//! to open rather than interleaving writes. Nothing here needs to detect that case, because
+//! [`RocksBackend::open`] cannot succeed in it.
+//!
+//! # No signing state
+//!
+//! No table holds validator signing state. XMSS no-reuse is a property of the duty loop's
+//! structure and nothing about it is written; see `docs/design/key-management.md`.
+
+pub mod backend;
+pub mod column;
+pub mod diff;
+pub mod error;
+pub mod key;
+mod merkle;
+pub mod metadata;
+pub mod read;
+pub mod reconstruct;
+pub mod repository;
+pub mod retention;
+pub mod schema;
+pub mod votes;
+pub mod writer;
+
+pub use backend::{Durability, MemoryBackend, RocksBackend, StorageBackend, WriteBatch};
+pub use column::ColumnFamily;
+pub use diff::{SNAPSHOT_INTERVAL_SLOTS, StateDiff};
+pub use error::{IdentityMismatch, StorageError};
+pub use metadata::MetadataKey;
+pub use read::ForkChoiceEntry;
+pub use repository::Repository;
+pub use retention::{MIN_SLOTS_FOR_BLOCK_REQUESTS, PROOF_RETENTION_SLOTS};
+pub use schema::{Identity, SCHEMA_VERSION, ssz_schema_digest};
+pub use writer::{AnchorCommit, BlockCommit, TickCommit, stored_header};

--- a/crates/verity-db/src/merkle.rs
+++ b/crates/verity-db/src/merkle.rs
@@ -1,0 +1,14 @@
+//! The one place this crate chooses a hash tree root hasher.
+//!
+//! `verity-chain` keeps the same single-function discipline for the same reason: routing
+//! every call through one place makes a change of Serialization supplier a one-file change.
+//! Nothing else in `verity-db` may name a hasher.
+
+use libssz_merkle::{HashTreeRoot, Sha2Hasher};
+use verity_types::Bytes32;
+
+/// The SSZ hash tree root of a stored value.
+#[must_use]
+pub(crate) fn hash_tree_root<T: HashTreeRoot>(value: &T) -> Bytes32 {
+    value.hash_tree_root(&Sha2Hasher)
+}

--- a/crates/verity-db/src/metadata.rs
+++ b/crates/verity-db/src/metadata.rs
@@ -1,0 +1,120 @@
+//! The fixed key set of the `metadata` table.
+//!
+//! `metadata` is the one table without a structural key, so the set of keys it accepts is
+//! closed here instead. Four of them identify the database; the rest are the current view the
+//! node restarts from.
+//!
+//! Transcribed from `docs/design/storage.md`, "Metadata and identity".
+
+use core::fmt;
+
+/// A key the `metadata` table accepts. No other key may be written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MetadataKey {
+    /// `SSZ(uint32)` repository schema version.
+    SchemaVersion,
+    /// The genesis state's `hash_tree_root`, as `Bytes32`.
+    ChainFingerprint,
+    /// The canonical protocol fork-version scalar, as `SSZ(uint64)`.
+    ForkVersion,
+    /// SHA-256 of the versioned stored-type manifest, as `Bytes32`.
+    SszSchemaDigest,
+    /// The current head block root, as `Bytes32`.
+    Head,
+    /// The current safe target block root, as `Bytes32`.
+    SafeTarget,
+    /// `SSZ(Checkpoint)`.
+    LatestJustified,
+    /// `SSZ(Checkpoint)`.
+    LatestFinalized,
+    /// `SSZ(uint64)`: the first slot range sync may be served from.
+    ServedFromSlot,
+    /// `SSZ(Interval)`: the last interval whose events fully committed.
+    LastProcessedInterval,
+}
+
+impl MetadataKey {
+    /// The four values that identify which chain, fork, and schema this database holds.
+    ///
+    /// They are written once, by the anchor commit, and are never updated afterwards. A
+    /// populated database must carry all four or it does not open.
+    pub const IDENTITY: [Self; 4] = [
+        Self::SchemaVersion,
+        Self::ChainFingerprint,
+        Self::ForkVersion,
+        Self::SszSchemaDigest,
+    ];
+
+    /// The view pointers a restart reconstructs and re-checks.
+    pub const VIEW: [Self; 6] = [
+        Self::Head,
+        Self::SafeTarget,
+        Self::LatestJustified,
+        Self::LatestFinalized,
+        Self::ServedFromSlot,
+        Self::LastProcessedInterval,
+    ];
+
+    /// The literal bytes of the key as stored.
+    ///
+    /// These strings are part of the on-disk format; changing one is a schema migration.
+    #[must_use]
+    pub const fn as_bytes(self) -> &'static [u8] {
+        match self {
+            Self::SchemaVersion => b"schema_version",
+            Self::ChainFingerprint => b"chain_fingerprint",
+            Self::ForkVersion => b"fork_version",
+            Self::SszSchemaDigest => b"ssz_schema_digest",
+            Self::Head => b"head",
+            Self::SafeTarget => b"safe_target",
+            Self::LatestJustified => b"latest_justified",
+            Self::LatestFinalized => b"latest_finalized",
+            Self::ServedFromSlot => b"served_from_slot",
+            Self::LastProcessedInterval => b"last_processed_interval",
+        }
+    }
+}
+
+impl fmt::Display for MetadataKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Every key is ASCII by construction, so this cannot lose information.
+        f.write_str(core::str::from_utf8(self.as_bytes()).unwrap_or("<non-utf8 metadata key>"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MetadataKey;
+
+    const ALL: [MetadataKey; 10] = [
+        MetadataKey::SchemaVersion,
+        MetadataKey::ChainFingerprint,
+        MetadataKey::ForkVersion,
+        MetadataKey::SszSchemaDigest,
+        MetadataKey::Head,
+        MetadataKey::SafeTarget,
+        MetadataKey::LatestJustified,
+        MetadataKey::LatestFinalized,
+        MetadataKey::ServedFromSlot,
+        MetadataKey::LastProcessedInterval,
+    ];
+
+    #[test]
+    fn should_partition_every_key_into_identity_or_view() {
+        for key in ALL {
+            let identity = MetadataKey::IDENTITY.contains(&key);
+            let view = MetadataKey::VIEW.contains(&key);
+            assert!(identity ^ view, "{key} belongs to exactly one group");
+        }
+    }
+
+    #[test]
+    fn should_give_every_key_a_distinct_ascii_name() {
+        let mut names: Vec<_> = ALL.iter().map(|key| key.as_bytes()).collect();
+        assert!(names.iter().all(|name| name.is_ascii()));
+        names.sort_unstable();
+        let count = names.len();
+        names.dedup();
+        assert_eq!(names.len(), count);
+    }
+}

--- a/crates/verity-db/src/read.rs
+++ b/crates/verity-db/src/read.rs
@@ -1,0 +1,259 @@
+//! Reading consensus values back out of the repository.
+//!
+//! Every method here answers with `Option` where absence is legitimate — a slot with no
+//! block, a validator that has not voted, a block whose proof has been pruned — and with an
+//! error where absence is not. The distinction is the whole point: inside the advertised
+//! range-sync window a missing proof for a canonical block is corruption, and a reader that
+//! collapsed it to "empty slot" would serve a hole to a peer instead of failing.
+
+use libssz::SszDecode;
+use verity_types::primitives::{Bytes32, Slot, ValidatorIndex};
+use verity_types::{AttestationData, BlockBody, BlockHeader, MultiMessageAggregate, State};
+
+use crate::backend::StorageBackend;
+use crate::column::ColumnFamily;
+use crate::diff::StateDiff;
+use crate::error::StorageError;
+use crate::key;
+use crate::repository::Repository;
+
+/// One edge of the stored fork-choice tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ForkChoiceEntry {
+    /// The slot the block was proposed in.
+    pub slot: Slot,
+    /// The block's own root.
+    pub root: Bytes32,
+    /// The root of the block's parent.
+    pub parent_root: Bytes32,
+}
+
+impl<B: StorageBackend> Repository<B> {
+    /// The header of a processed block.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored header does not decode.
+    pub fn block_header(&self, root: Bytes32) -> Result<Option<BlockHeader>, StorageError> {
+        self.read(ColumnFamily::BlockHeaders, &key::root(root))
+    }
+
+    /// The body of a processed block. An empty body is stored, so this is `None` only when
+    /// the block itself is unknown.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored body does not decode.
+    pub fn block_body(&self, root: Bytes32) -> Result<Option<BlockBody>, StorageError> {
+        self.read(ColumnFamily::BlockBodies, &key::root(root))
+    }
+
+    /// The aggregate proof of a block, if it is still inside the retention window.
+    ///
+    /// The slot is required because proofs are keyed `slot ‖ root`: that ordering is what
+    /// makes expiry a single range tombstone rather than a scan.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored proof does not decode.
+    pub fn block_proof(
+        &self,
+        slot: Slot,
+        root: Bytes32,
+    ) -> Result<Option<MultiMessageAggregate>, StorageError> {
+        self.read(ColumnFamily::BlockProofs, &key::slot_and_root(slot, root))
+    }
+
+    /// The full state snapshot anchored at a block, when that block is a snapshot base.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored state does not decode.
+    pub fn state_snapshot(&self, root: Bytes32) -> Result<Option<State>, StorageError> {
+        self.read(ColumnFamily::StateSnapshots, &key::root(root))
+    }
+
+    /// The state delta a processed non-anchor block wrote.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored diff does not decode.
+    pub fn state_diff(&self, root: Bytes32) -> Result<Option<StateDiff>, StorageError> {
+        self.read(ColumnFamily::StateDiffs, &key::root(root))
+    }
+
+    /// The canonical block root at a slot, or `None` for a slot with no canonical block.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored root does not decode.
+    pub fn canonical_root(&self, slot: Slot) -> Result<Option<Bytes32>, StorageError> {
+        self.read(ColumnFamily::CanonicalBlocks, &key::slot(slot))
+    }
+
+    /// The canonical roots in `[start, end)`, ascending by slot.
+    ///
+    /// Empty slots are absent rather than zero-filled, so the result is the response body a
+    /// `BlocksByRange` reply is built from: partial responses are legal, and a gap here is a
+    /// gap there.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::KeyWidth`] or [`StorageError::Decode`] on a damaged row.
+    pub fn canonical_range(
+        &self,
+        start: Slot,
+        end: Slot,
+    ) -> Result<Vec<(Slot, Bytes32)>, StorageError> {
+        let (low, high) = key::slot_bounds(start, end);
+        self.scan(ColumnFamily::CanonicalBlocks, &low, &high)?
+            .into_iter()
+            .map(|(raw_key, value)| {
+                let slot = key::decode_slot(ColumnFamily::CanonicalBlocks, &raw_key)?;
+                let root = decode_root_value(ColumnFamily::CanonicalBlocks, &raw_key, &value)?;
+                Ok((slot, root))
+            })
+            .collect()
+    }
+
+    /// The block that produced a given state root.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored root does not decode.
+    pub fn block_root_for_state_root(
+        &self,
+        state_root: Bytes32,
+    ) -> Result<Option<Bytes32>, StorageError> {
+        self.read(ColumnFamily::StateRoots, &key::root(state_root))
+    }
+
+    /// The parent of a block in the all-branch fork-choice index.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored root does not decode.
+    pub fn fork_choice_parent(
+        &self,
+        slot: Slot,
+        root: Bytes32,
+    ) -> Result<Option<Bytes32>, StorageError> {
+        self.read(
+            ColumnFamily::ForkChoiceBlocks,
+            &key::slot_and_root(slot, root),
+        )
+    }
+
+    /// Every fork-choice edge in `[start, end)`, ascending by slot then root.
+    ///
+    /// This is what a restart rebuilds the fork-choice tree from: the scan begins at
+    /// `latest_justified.slot`, because nothing below it can still be reorganized.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::KeyWidth`] or [`StorageError::Decode`] on a damaged row.
+    pub fn fork_choice_range(
+        &self,
+        start: Slot,
+        end: Slot,
+    ) -> Result<Vec<ForkChoiceEntry>, StorageError> {
+        let (low, high) = key::slot_and_root_bounds(start, end);
+        self.scan(ColumnFamily::ForkChoiceBlocks, &low, &high)?
+            .into_iter()
+            .map(|(raw_key, value)| {
+                let (slot, root) =
+                    key::decode_slot_and_root(ColumnFamily::ForkChoiceBlocks, &raw_key)?;
+                let parent_root =
+                    decode_root_value(ColumnFamily::ForkChoiceBlocks, &raw_key, &value)?;
+                Ok(ForkChoiceEntry {
+                    slot,
+                    root,
+                    parent_root,
+                })
+            })
+            .collect()
+    }
+
+    /// A validator's latest counted vote.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored vote does not decode.
+    pub fn known_vote(
+        &self,
+        validator: ValidatorIndex,
+    ) -> Result<Option<AttestationData>, StorageError> {
+        self.read(ColumnFamily::KnownVotes, &key::validator(validator))
+    }
+
+    /// A validator's latest not-yet-counted vote.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the stored vote does not decode.
+    pub fn pending_vote(
+        &self,
+        validator: ValidatorIndex,
+    ) -> Result<Option<AttestationData>, StorageError> {
+        self.read(ColumnFamily::PendingVotes, &key::validator(validator))
+    }
+
+    /// Every counted vote, ascending by validator index.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::KeyWidth`] or [`StorageError::Decode`] on a damaged row.
+    pub fn known_votes(&self) -> Result<Vec<(ValidatorIndex, AttestationData)>, StorageError> {
+        self.all_votes(ColumnFamily::KnownVotes)
+    }
+
+    /// Every not-yet-counted vote, ascending by validator index.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::KeyWidth`] or [`StorageError::Decode`] on a damaged row.
+    pub fn pending_votes(&self) -> Result<Vec<(ValidatorIndex, AttestationData)>, StorageError> {
+        self.all_votes(ColumnFamily::PendingVotes)
+    }
+
+    fn all_votes(
+        &self,
+        table: ColumnFamily,
+    ) -> Result<Vec<(ValidatorIndex, AttestationData)>, StorageError> {
+        // The registry is bounded by `VALIDATOR_REGISTRY_LIMIT`, so scanning the whole
+        // index-keyed table is bounded by the same constant, not by chain length.
+        let (low, high) = key::slot_bounds(Slot(0), Slot(u64::MAX));
+        let mut rows = self.scan(table, &low, &high)?;
+
+        // `u64::MAX` is exclusive as a bound, so the last possible index is fetched on its
+        // own rather than by widening the key space past what `key` can encode.
+        let last = key::validator(ValidatorIndex(u64::MAX));
+        if let Some(value) = self.backend().get(table, &last)? {
+            rows.push((last.to_vec(), value));
+        }
+
+        rows.into_iter()
+            .map(|(raw_key, value)| {
+                let validator = key::decode_validator(table, &raw_key)?;
+                let vote =
+                    AttestationData::from_ssz_bytes(&value).map_err(|_| StorageError::Decode {
+                        table,
+                        key: raw_key.clone(),
+                    })?;
+                Ok((validator, vote))
+            })
+            .collect()
+    }
+}
+
+/// Decodes a 32-byte root stored as a bare value.
+fn decode_root_value(
+    table: ColumnFamily,
+    raw_key: &[u8],
+    value: &[u8],
+) -> Result<Bytes32, StorageError> {
+    value.try_into().map_err(|_| StorageError::Decode {
+        table,
+        key: raw_key.to_vec(),
+    })
+}

--- a/crates/verity-db/src/reconstruct.rs
+++ b/crates/verity-db/src/reconstruct.rs
@@ -1,0 +1,147 @@
+//! Rebuilding a state from the snapshot it descends from and the diffs in between.
+//!
+//! The walk goes backwards to the nearest snapshot, then forwards applying diffs. It is
+//! bounded at [`SNAPSHOT_INTERVAL_SLOTS`] steps by the snapshot rule of [`crate::diff`]: a
+//! longer walk means the snapshot that should have terminated it is missing, which is
+//! corruption rather than a long chain, and is reported as such instead of being followed to
+//! genesis.
+//!
+//! Two things are checked on every step, because a diff on its own cannot be wrong in a way
+//! that shows up later: the diff's base must be the child header's parent, and the state the
+//! step produces must hash to the `state_root` the child header committed to.
+//!
+//! Transcribed from `docs/design/storage.md`, "State storage: snapshots and diffs".
+
+use verity_types::primitives::{Bytes32, ZERO_HASH};
+use verity_types::state::HistoricalBlockHashes;
+use verity_types::{BlockHeader, State};
+
+use crate::backend::StorageBackend;
+use crate::column::ColumnFamily;
+use crate::diff::{SNAPSHOT_INTERVAL_SLOTS, StateDiff};
+use crate::error::StorageError;
+use crate::key;
+use crate::merkle::hash_tree_root;
+use crate::repository::Repository;
+
+impl<B: StorageBackend> Repository<B> {
+    /// The state a block produced, rebuilt from stored data.
+    ///
+    /// Returns the snapshot directly when the block is a snapshot base; otherwise walks back
+    /// to the nearest one and replays the diffs forward.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::MissingRow`] when a header or diff on the path is absent.
+    /// - [`StorageError::ReplayTooLong`] when no snapshot is reached within the snapshot
+    ///   interval.
+    /// - [`StorageError::ParentMismatch`] when a diff claims a base its block does not have.
+    /// - [`StorageError::RootMismatch`] when a rebuilt state does not hash to the root its
+    ///   header committed to.
+    pub fn state_at(&self, block_root: Bytes32) -> Result<State, StorageError> {
+        let (base, path) = self.path_to_snapshot(block_root)?;
+
+        let mut state = base;
+        for (header, diff) in path.into_iter().rev() {
+            state = apply(&state, &header, &diff)?;
+            let root = hash_tree_root(&state);
+            if root != header.state_root {
+                return Err(StorageError::RootMismatch {
+                    expected: header.state_root,
+                    computed: root,
+                });
+            }
+        }
+        Ok(state)
+    }
+
+    /// Walks back from `block_root` to the nearest snapshot.
+    ///
+    /// The returned path is ordered child-first, so replaying it means iterating in reverse.
+    fn path_to_snapshot(
+        &self,
+        block_root: Bytes32,
+    ) -> Result<(State, Vec<(BlockHeader, StateDiff)>), StorageError> {
+        let mut path = Vec::new();
+        let mut cursor = block_root;
+
+        loop {
+            if let Some(snapshot) = self.state_snapshot(cursor)? {
+                return Ok((snapshot, path));
+            }
+            if path.len() >= SNAPSHOT_INTERVAL_SLOTS as usize {
+                return Err(StorageError::ReplayTooLong {
+                    from: block_root,
+                    walked: path.len(),
+                });
+            }
+            let header: BlockHeader =
+                self.read_required(ColumnFamily::BlockHeaders, &key::root(cursor))?;
+            let diff: StateDiff =
+                self.read_required(ColumnFamily::StateDiffs, &key::root(cursor))?;
+            path.push((header, diff));
+            cursor = header.parent_root;
+        }
+    }
+}
+
+/// Applies one block's diff on top of the state of its parent.
+///
+/// `config` and the validator registry come from `base` — they are static across the fork and
+/// the snapshot is their only source. The latest header is the child's own, with its state
+/// root cleared, exactly as `process_block_header` leaves it. The historical roots are
+/// extended the way that function extends them: the parent's root, then one zero hash per
+/// slot missed since the parent.
+fn apply(base: &State, header: &BlockHeader, diff: &StateDiff) -> Result<State, StorageError> {
+    if diff.base_block_root != header.parent_root {
+        return Err(StorageError::ParentMismatch {
+            expected: header.parent_root,
+            found: diff.base_block_root,
+        });
+    }
+    if diff.slot != header.slot {
+        return Err(StorageError::RejectedBatch(
+            "stored diff and header disagree on the slot",
+        ));
+    }
+
+    Ok(State {
+        config: base.config,
+        slot: header.slot,
+        latest_block_header: BlockHeader {
+            state_root: ZERO_HASH,
+            ..*header
+        },
+        latest_justified: diff.latest_justified,
+        latest_finalized: diff.latest_finalized,
+        historical_block_hashes: extend_history(base, header)?,
+        justified_slots: diff.justified_slots.clone(),
+        validators: base.validators.clone(),
+        justifications_roots: diff.justifications_roots.clone(),
+        justifications_validators: diff.justifications_validators.clone(),
+    })
+}
+
+/// The chain view after `header`, given the view its parent left.
+fn extend_history(
+    base: &State,
+    header: &BlockHeader,
+) -> Result<HistoricalBlockHashes, StorageError> {
+    let parent_slot = base.latest_block_header.slot;
+    if header.slot.0 <= parent_slot.0 {
+        return Err(StorageError::RejectedBatch(
+            "stored block does not advance past its parent's slot",
+        ));
+    }
+
+    let mut hashes = base.historical_block_hashes.clone();
+    hashes
+        .push(header.parent_root)
+        .map_err(|_| StorageError::CapacityExceeded("historical_block_hashes"))?;
+    for _ in 0..(header.slot.0 - parent_slot.0 - 1) {
+        hashes
+            .push(ZERO_HASH)
+            .map_err(|_| StorageError::CapacityExceeded("historical_block_hashes"))?;
+    }
+    Ok(hashes)
+}

--- a/crates/verity-db/src/repository.rs
+++ b/crates/verity-db/src/repository.rs
@@ -269,5 +269,5 @@ impl<B: StorageBackend> Repository<B> {
 /// Free function rather than a method so a caller assembling one cross-table batch does not
 /// need a second mutable borrow of the repository while holding the batch.
 pub(crate) fn put_metadata<T: SszEncode>(batch: &mut WriteBatch, key: MetadataKey, value: &T) {
-    batch.put(ColumnFamily::Metadata, key.as_bytes(), value.to_ssz());
+    batch.queue_put(ColumnFamily::Metadata, key.as_bytes(), value.to_ssz());
 }

--- a/crates/verity-db/src/repository.rs
+++ b/crates/verity-db/src/repository.rs
@@ -1,0 +1,273 @@
+//! The repository: consensus values over a byte-level backend.
+//!
+//! Everything above [`crate::backend`] lives here. The backend knows keys and values; the
+//! repository knows which table a container belongs in, which key encodes its identifier, and
+//! which values must agree before a batch is allowed to become durable.
+//!
+//! Opening is where a wrong database is caught. `docs/design/storage.md` is explicit that a
+//! populated database opens only when every identity value matches, and that a mismatch,
+//! missing row, decode failure, or integrity failure stops the node and preserves the
+//! directory: it is never treated as an empty database and never overwritten automatically.
+
+use libssz::{SszDecode, SszEncode};
+use verity_types::Checkpoint;
+use verity_types::primitives::{Bytes32, Interval, Slot};
+
+use crate::backend::{Durability, Rows, StorageBackend, WriteBatch};
+use crate::column::ColumnFamily;
+use crate::error::{IdentityMismatch, StorageError};
+use crate::metadata::MetadataKey;
+use crate::schema::{Identity, SCHEMA_VERSION, ssz_schema_digest};
+
+/// A consensus repository over one backend.
+///
+/// Reads borrow shared and writes borrow unique, so the one-writer-per-database rule of
+/// `docs/design/storage.md` is carried by ownership: P2P, RPC, and validator duties can hold
+/// a `&Repository` and read, and only the chain writer can hold the `&mut` that commits.
+#[derive(Debug)]
+pub struct Repository<B: StorageBackend> {
+    backend: B,
+    identity: Identity,
+}
+
+impl<B: StorageBackend> Repository<B> {
+    /// Opens `backend` as the repository of the chain described by `identity`.
+    ///
+    /// An empty database — one carrying none of the four identity values — opens and waits
+    /// for an anchor commit to write them. A database carrying any of them must carry all
+    /// four and must agree with `identity` and with this build's schema.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Identity`] when a stored identity value disagrees.
+    /// - [`StorageError::MissingMetadata`] when a populated database is missing one of the
+    ///   four. This is corruption, not an empty database, and is never repaired here.
+    /// - [`StorageError::Decode`] when an identity value does not decode.
+    pub fn open(backend: B, identity: Identity) -> Result<Self, StorageError> {
+        let repository = Self { backend, identity };
+        if repository.is_populated()? {
+            repository.check_identity()?;
+        }
+        Ok(repository)
+    }
+
+    /// The chain and fork this repository was opened for.
+    #[must_use]
+    pub const fn identity(&self) -> Identity {
+        self.identity
+    }
+
+    /// The backend underneath, for tests and for operational inspection.
+    #[must_use]
+    pub const fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    /// Whether the database has been anchored yet.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Backend`] when the engine fails.
+    pub fn is_populated(&self) -> Result<bool, StorageError> {
+        for key in MetadataKey::IDENTITY {
+            if self.raw_metadata(key)?.is_some() {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn check_identity(&self) -> Result<(), StorageError> {
+        let stored_version: u32 = self.required_metadata(MetadataKey::SchemaVersion)?;
+        if stored_version != SCHEMA_VERSION {
+            return Err(IdentityMismatch::SchemaVersion {
+                expected: SCHEMA_VERSION,
+                found: stored_version,
+            }
+            .into());
+        }
+
+        let fingerprint: Bytes32 = self.required_metadata(MetadataKey::ChainFingerprint)?;
+        if fingerprint != self.identity.chain_fingerprint {
+            return Err(IdentityMismatch::ChainFingerprint {
+                expected: self.identity.chain_fingerprint,
+                found: fingerprint,
+            }
+            .into());
+        }
+
+        let fork: u64 = self.required_metadata(MetadataKey::ForkVersion)?;
+        if fork != self.identity.fork_version {
+            return Err(IdentityMismatch::ForkVersion {
+                expected: self.identity.fork_version,
+                found: fork,
+            }
+            .into());
+        }
+
+        let digest: Bytes32 = self.required_metadata(MetadataKey::SszSchemaDigest)?;
+        let expected = ssz_schema_digest();
+        if digest != expected {
+            return Err(IdentityMismatch::SszSchemaDigest {
+                expected,
+                found: digest,
+            }
+            .into());
+        }
+        Ok(())
+    }
+
+    // --- Low-level typed access -----------------------------------------------------------
+
+    /// Decodes the value at `key`, or `None` when the row is absent.
+    ///
+    /// An absent row is `None`; a row that fails to decode is an error. The two are never
+    /// collapsed: a decode failure is storage corruption, and treating it as an empty slot
+    /// would let a damaged database look like a shorter chain.
+    pub(crate) fn read<T: SszDecode>(
+        &self,
+        table: ColumnFamily,
+        key: &[u8],
+    ) -> Result<Option<T>, StorageError> {
+        let Some(bytes) = self.backend.get(table, key)? else {
+            return Ok(None);
+        };
+        T::from_ssz_bytes(&bytes)
+            .map(Some)
+            .map_err(|_| StorageError::Decode {
+                table,
+                key: key.to_vec(),
+            })
+    }
+
+    /// Decodes a row the caller cannot proceed without.
+    pub(crate) fn read_required<T: SszDecode>(
+        &self,
+        table: ColumnFamily,
+        key: &[u8],
+    ) -> Result<T, StorageError> {
+        self.read(table, key)?
+            .ok_or_else(|| StorageError::MissingRow {
+                table,
+                key: key.to_vec(),
+            })
+    }
+
+    /// Reads a half-open key range, in ascending key order.
+    pub(crate) fn scan(
+        &self,
+        table: ColumnFamily,
+        start: &[u8],
+        end: &[u8],
+    ) -> Result<Rows, StorageError> {
+        self.backend.range(table, start, end)
+    }
+
+    /// Applies a batch. The only path by which anything becomes durable.
+    pub(crate) fn commit(
+        &mut self,
+        batch: WriteBatch,
+        durability: Durability,
+    ) -> Result<(), StorageError> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+        self.backend.write(batch, durability)
+    }
+
+    // --- Metadata -------------------------------------------------------------------------
+
+    fn raw_metadata(&self, key: MetadataKey) -> Result<Option<Vec<u8>>, StorageError> {
+        self.backend.get(ColumnFamily::Metadata, key.as_bytes())
+    }
+
+    /// Decodes a metadata value, or `None` when it has never been written.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] when the value does not decode as `T`.
+    pub fn metadata<T: SszDecode>(&self, key: MetadataKey) -> Result<Option<T>, StorageError> {
+        self.read(ColumnFamily::Metadata, key.as_bytes())
+    }
+
+    /// Decodes a metadata value a populated database must carry.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::MissingMetadata`] when absent, [`StorageError::Decode`] when it does
+    /// not decode as `T`.
+    pub fn required_metadata<T: SszDecode>(&self, key: MetadataKey) -> Result<T, StorageError> {
+        self.metadata(key)?
+            .ok_or(StorageError::MissingMetadata(key))
+    }
+
+    /// The current head block root.
+    ///
+    /// # Errors
+    ///
+    /// As [`Repository::metadata`].
+    pub fn head(&self) -> Result<Option<Bytes32>, StorageError> {
+        self.metadata(MetadataKey::Head)
+    }
+
+    /// The current safe target block root.
+    ///
+    /// # Errors
+    ///
+    /// As [`Repository::metadata`].
+    pub fn safe_target(&self) -> Result<Option<Bytes32>, StorageError> {
+        self.metadata(MetadataKey::SafeTarget)
+    }
+
+    /// The highest justified checkpoint committed.
+    ///
+    /// # Errors
+    ///
+    /// As [`Repository::metadata`].
+    pub fn latest_justified(&self) -> Result<Option<Checkpoint>, StorageError> {
+        self.metadata(MetadataKey::LatestJustified)
+    }
+
+    /// The highest finalized checkpoint committed.
+    ///
+    /// # Errors
+    ///
+    /// As [`Repository::metadata`].
+    pub fn latest_finalized(&self) -> Result<Option<Checkpoint>, StorageError> {
+        self.metadata(MetadataKey::LatestFinalized)
+    }
+
+    /// The first slot this node can serve proof-bearing history from.
+    ///
+    /// A checkpoint-sync node starts above genesis and must not advertise range service below
+    /// this; see [`crate::retention`].
+    ///
+    /// # Errors
+    ///
+    /// As [`Repository::metadata`].
+    pub fn served_from_slot(&self) -> Result<Option<Slot>, StorageError> {
+        Ok(self.metadata::<u64>(MetadataKey::ServedFromSlot)?.map(Slot))
+    }
+
+    /// The last interval whose events fully committed.
+    ///
+    /// Wall-clock time alone cannot say which interval finished before a crash, which is why
+    /// this is persisted rather than recomputed from the clock at startup.
+    ///
+    /// # Errors
+    ///
+    /// As [`Repository::metadata`].
+    pub fn last_processed_interval(&self) -> Result<Option<Interval>, StorageError> {
+        Ok(self
+            .metadata::<u64>(MetadataKey::LastProcessedInterval)?
+            .map(Interval))
+    }
+}
+
+/// Queues a metadata write into `batch`.
+///
+/// Free function rather than a method so a caller assembling one cross-table batch does not
+/// need a second mutable borrow of the repository while holding the batch.
+pub(crate) fn put_metadata<T: SszEncode>(batch: &mut WriteBatch, key: MetadataKey, value: &T) {
+    batch.put(ColumnFamily::Metadata, key.as_bytes(), value.to_ssz());
+}

--- a/crates/verity-db/src/retention.rs
+++ b/crates/verity-db/src/retention.rs
@@ -1,0 +1,174 @@
+//! What gets deleted, and what a peer may therefore ask for.
+//!
+//! Only two things are ever deleted: aggregate block proofs older than the retention window,
+//! and votes current fork-choice rules have declared irrelevant. Headers, bodies, snapshots,
+//! diffs, state-root mappings, and fork-choice entries are retained, so all processed state
+//! history stays reconstructible.
+//!
+//! The proof window is what makes the deletion worth doing at all. Measured against
+//! leanSpec's production-scheme fixtures, an aggregate block proof is 155–236 KB against
+//! ~100–800 B for everything else — about 4.1 GB/day of proofs versus ~5 MB/day of blocks and
+//! states at four-second slots.
+//!
+//! Transcribed from `docs/design/storage.md`, "Retention and range sync".
+
+use verity_types::Checkpoint;
+use verity_types::primitives::{Bytes32, Slot};
+
+use crate::backend::{Durability, StorageBackend, WriteBatch};
+use crate::column::ColumnFamily;
+use crate::error::StorageError;
+use crate::key;
+use crate::repository::Repository;
+
+/// How long aggregate block proofs are kept, in slots.
+///
+/// At `SECONDS_PER_SLOT = 4` this is about one day. It is an operational choice six times
+/// above leanSpec's [`MIN_SLOTS_FOR_BLOCK_REQUESTS`] floor: it is how far a peer can fall
+/// behind and still catch up over P2P instead of needing a checkpoint.
+pub const PROOF_RETENTION_SLOTS: u64 = 21_600;
+
+/// The sliding window a `BlocksByRange` responder must serve, in slots.
+///
+/// leanSpec's one MUST for the ReqResp suite: four hours at four-second slots. Below it, a
+/// request is answered `RESOURCE_UNAVAILABLE` rather than with a short response.
+pub const MIN_SLOTS_FOR_BLOCK_REQUESTS: u64 = 3_600;
+
+impl<B: StorageBackend> Repository<B> {
+    /// Deletes expired aggregate proofs, returning the exclusive cutoff when anything was
+    /// deleted.
+    ///
+    /// Two conditions gate the delete, and both matter. The cutoff is
+    /// `tip_slot − PROOF_RETENTION_SLOTS`, saturating at zero, so a young chain prunes
+    /// nothing. And the delete happens only when the cutoff is at or below the finalized
+    /// slot, which is what guarantees a proof inside the current non-finalized range is never
+    /// removed — a reorg into that range would otherwise need a proof that had already gone.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Backend`] when the engine fails, or [`StorageError::Decode`] when the
+    /// finalized checkpoint does not decode.
+    pub fn prune_block_proofs(&mut self, tip_slot: Slot) -> Result<Option<Slot>, StorageError> {
+        let cutoff = Slot(tip_slot.0.saturating_sub(PROOF_RETENTION_SLOTS));
+        if cutoff.0 == 0 {
+            return Ok(None);
+        }
+        let finalized = self.latest_finalized()?.unwrap_or_default();
+        if cutoff.0 > finalized.slot.0 {
+            return Ok(None);
+        }
+
+        let (low, high) = key::slot_and_root_bounds(Slot(0), cutoff);
+        let mut batch = WriteBatch::new();
+        batch.delete_range(ColumnFamily::BlockProofs, low.to_vec(), high.to_vec());
+        self.commit(batch, Durability::Buffered)?;
+        Ok(Some(cutoff))
+    }
+
+    /// Deletes votes the fork choice can no longer be moved by, returning how many went.
+    ///
+    /// A vote is irrelevant when its head is at or below the finalized slot, or when its head
+    /// is not a descendant of the finalized block. The blocks themselves stay: losing a vote's
+    /// relevance says nothing about whether the block it names is still worth serving.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] on a damaged vote row, [`StorageError::Backend`] on engine
+    /// failure.
+    pub fn prune_stale_votes(&mut self) -> Result<usize, StorageError> {
+        let Some(finalized) = self.latest_finalized()? else {
+            return Ok(0);
+        };
+
+        let mut batch = WriteBatch::new();
+        let mut pruned = 0;
+        for table in [ColumnFamily::KnownVotes, ColumnFamily::PendingVotes] {
+            let votes = if table == ColumnFamily::KnownVotes {
+                self.known_votes()?
+            } else {
+                self.pending_votes()?
+            };
+            for (validator, vote) in votes {
+                if self.vote_is_relevant(vote.head, finalized)? {
+                    continue;
+                }
+                batch.delete(table, key::validator(validator));
+                pruned += 1;
+            }
+        }
+        self.commit(batch, Durability::Buffered)?;
+        Ok(pruned)
+    }
+
+    /// Whether a vote for `head` can still influence a fork choice finalized at `finalized`.
+    fn vote_is_relevant(
+        &self,
+        head: Checkpoint,
+        finalized: Checkpoint,
+    ) -> Result<bool, StorageError> {
+        if head.slot.0 <= finalized.slot.0 {
+            return Ok(false);
+        }
+        self.descends_from(head.root, finalized)
+    }
+
+    /// Whether `root` is a descendant of `ancestor`, by walking the stored headers back.
+    ///
+    /// An unknown block answers `false`: descent that cannot be shown is not descent, and a
+    /// vote for a block this node never processed is not one it can count.
+    fn descends_from(&self, root: Bytes32, ancestor: Checkpoint) -> Result<bool, StorageError> {
+        let mut cursor = root;
+        loop {
+            if cursor == ancestor.root {
+                return Ok(true);
+            }
+            let Some(header) = self.block_header(cursor)? else {
+                return Ok(false);
+            };
+            if header.slot.0 <= ancestor.slot.0 {
+                return Ok(false);
+            }
+            cursor = header.parent_root;
+        }
+    }
+
+    /// The lowest slot this node will answer a `BlocksByRange` request from.
+    ///
+    /// It is the higher of the spec's sliding four-hour floor and the first slot this node
+    /// actually holds proved history for. A checkpoint-sync node starts above genesis, and
+    /// advertising down to the spec floor before backfilling would promise history it does
+    /// not have.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::MissingMetadata`] when `served_from_slot` has never been written,
+    /// which means the database was never anchored.
+    pub fn range_service_floor(&self, current_slot: Slot) -> Result<Slot, StorageError> {
+        let served_from = self
+            .served_from_slot()?
+            .ok_or(StorageError::MissingMetadata(
+                crate::metadata::MetadataKey::ServedFromSlot,
+            ))?;
+        Ok(Slot(
+            current_slot
+                .0
+                .saturating_sub(MIN_SLOTS_FOR_BLOCK_REQUESTS)
+                .max(served_from.0),
+        ))
+    }
+
+    /// Whether a `BlocksByRange` request starting at `requested_slot` may be served.
+    ///
+    /// A `false` here is a `RESOURCE_UNAVAILABLE` response, not an empty one.
+    ///
+    /// # Errors
+    ///
+    /// As [`Repository::range_service_floor`].
+    pub fn can_serve_range(
+        &self,
+        current_slot: Slot,
+        requested_slot: Slot,
+    ) -> Result<bool, StorageError> {
+        Ok(requested_slot.0 >= self.range_service_floor(current_slot)?.0)
+    }
+}

--- a/crates/verity-db/src/retention.rs
+++ b/crates/verity-db/src/retention.rs
@@ -60,7 +60,7 @@ impl<B: StorageBackend> Repository<B> {
 
         let (low, high) = key::slot_and_root_bounds(Slot(0), cutoff);
         let mut batch = WriteBatch::new();
-        batch.delete_range(ColumnFamily::BlockProofs, low.to_vec(), high.to_vec());
+        batch.queue_delete_range(ColumnFamily::BlockProofs, low.to_vec(), high.to_vec());
         self.commit(batch, Durability::Buffered)?;
         Ok(Some(cutoff))
     }
@@ -92,7 +92,7 @@ impl<B: StorageBackend> Repository<B> {
                 if self.vote_is_relevant(vote.head, finalized)? {
                     continue;
                 }
-                batch.delete(table, key::validator(validator));
+                batch.queue_delete(table, key::validator(validator));
                 pruned += 1;
             }
         }

--- a/crates/verity-db/src/schema.rs
+++ b/crates/verity-db/src/schema.rs
@@ -1,0 +1,160 @@
+//! What this build of the repository writes, and how a database says what it holds.
+//!
+//! Four values identify a database: the repository schema version, the chain, the protocol
+//! fork, and the shape of the SSZ containers stored inside it. All four are written once by
+//! the anchor commit and checked on every subsequent open.
+//!
+//! The last of them is the interesting one. A stored value is raw SSZ, so a field added to
+//! `State` or a reordered `StateDiff` does not fail to decode — it decodes into a *different*
+//! value. Hashing a description of every stored container turns that silent reinterpretation
+//! into a refusal to open, and the digest constant in this module's test into a review
+//! artifact: a shape change that does not move the digest is a shape change that was not
+//! actually made.
+//!
+//! Transcribed from `docs/design/storage.md`, "Metadata and identity".
+
+use sha2::{Digest, Sha256};
+use verity_types::Bytes32;
+use verity_types::config::{
+    BYTE_LIST_512_KIB_LIMIT, HISTORICAL_ROOTS_LIMIT, JUSTIFICATION_VALIDATORS_LIMIT,
+    VALIDATOR_REGISTRY_LIMIT,
+};
+
+/// The repository schema version this build writes.
+///
+/// Bump it whenever the key layout, the table set, or the metadata key set changes. A
+/// container *shape* change does not need a bump — the manifest digest already catches it —
+/// but bumping is harmless and the two are checked independently.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// The stored container types, in the fixed order `docs/design/storage.md` lists them.
+///
+/// Order is part of the digest. It is the doc's order, not alphabetical and not dependency
+/// order, so the two can be diffed against each other by eye.
+pub const STORED_TYPES: [&str; 7] = [
+    "BlockHeader",
+    "BlockBody",
+    "MultiMessageAggregate",
+    "State",
+    "StateDiff",
+    "Checkpoint",
+    "AttestationData",
+];
+
+/// The field list of each stored type, paired with [`STORED_TYPES`] by position.
+///
+/// Written out rather than derived. The SSZ traits expose an encoding, not a description of
+/// the shape that produced it, so there is nothing to reflect over: two containers with the
+/// same field types in a different order are indistinguishable at the trait level and would
+/// hash identically. Transcribing the fields is what makes the reorder visible.
+///
+/// Collection limits are interpolated from the constants rather than typed as literals, so a
+/// limit change moves the digest on its own — it changes merkle depth, hence every root, and
+/// must not be able to slip past this check just because nobody edited this file.
+fn field_lists() -> [String; STORED_TYPES.len()] {
+    let registry = VALIDATOR_REGISTRY_LIMIT;
+    let roots = HISTORICAL_ROOTS_LIMIT;
+    let votes = JUSTIFICATION_VALIDATORS_LIMIT;
+    let proof = BYTE_LIST_512_KIB_LIMIT;
+
+    [
+        "slot:uint64,proposer_index:uint64,parent_root:Bytes32,state_root:Bytes32,\
+         body_root:Bytes32"
+            .to_owned(),
+        format!(
+            "attestations:List[AggregatedAttestation{{aggregation_bits:Bitlist[{registry}],\
+             data:AttestationData}},{registry}]"
+        ),
+        format!("proof:List[uint8,{proof}]"),
+        format!(
+            "config:GenesisConfig{{genesis_time:uint64}},slot:uint64,\
+             latest_block_header:BlockHeader,latest_justified:Checkpoint,\
+             latest_finalized:Checkpoint,historical_block_hashes:List[Bytes32,{roots}],\
+             justified_slots:Bitlist[{roots}],\
+             validators:List[Validator{{attestation_public_key:Bytes52,\
+             proposal_public_key:Bytes52,index:uint64}},{registry}],\
+             justifications_roots:List[Bytes32,{roots}],\
+             justifications_validators:Bitlist[{votes}]"
+        ),
+        format!(
+            "base_block_root:Bytes32,slot:uint64,latest_justified:Checkpoint,\
+             latest_finalized:Checkpoint,justified_slots:Bitlist[{roots}],\
+             justifications_roots:List[Bytes32,{roots}],\
+             justifications_validators:Bitlist[{votes}]"
+        ),
+        "root:Bytes32,slot:uint64".to_owned(),
+        "slot:uint64,head:Checkpoint,target:Checkpoint,source:Checkpoint".to_owned(),
+    ]
+}
+
+/// SHA-256 over the versioned stored-type manifest.
+///
+/// The version is hashed in as well, so a key-layout bump and a shape change are not able to
+/// cancel each other out.
+#[must_use]
+pub fn ssz_schema_digest() -> Bytes32 {
+    let mut hasher = Sha256::new();
+    hasher.update(b"verity-db stored-type manifest v");
+    hasher.update(SCHEMA_VERSION.to_le_bytes());
+    for (name, fields) in STORED_TYPES.iter().zip(field_lists()) {
+        hasher.update(name.as_bytes());
+        hasher.update(b"(");
+        hasher.update(fields.as_bytes());
+        hasher.update(b")");
+    }
+    hasher.finalize().into()
+}
+
+/// What a node expects the database it opens to hold.
+///
+/// `chain_fingerprint` is the genesis state's `hash_tree_root`, which already commits to the
+/// genesis time, the configuration, and the validator registry — so it identifies the chain
+/// without introducing a second chain-identity format beside the state root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Identity {
+    /// The genesis state root of the chain this node is configured for.
+    pub chain_fingerprint: Bytes32,
+    /// The canonical protocol fork version.
+    pub fork_version: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{STORED_TYPES, field_lists, ssz_schema_digest};
+
+    /// The digest this build produces.
+    ///
+    /// This constant is the review artifact. Any change to a stored container's shape, or to
+    /// a collection limit, moves it — and a diff that touches a container without touching
+    /// this line is a diff that did not change the shape it appears to change.
+    const EXPECTED: &str = "6f93f71bb43fcd15cb541ef5f10ceb49863521aa2f9553f5f4fd1da5685d3084";
+
+    #[test]
+    fn should_pair_every_stored_type_with_a_field_list() {
+        assert_eq!(field_lists().len(), STORED_TYPES.len());
+    }
+
+    #[test]
+    fn should_be_deterministic_across_calls() {
+        assert_eq!(ssz_schema_digest(), ssz_schema_digest());
+    }
+
+    #[test]
+    fn should_describe_every_field_of_every_stored_type() {
+        // The digest can only catch a reordered container if the description it hashes names
+        // the fields in order. A field list that lost its names would still hash, and would
+        // still look like it was doing its job.
+        for fields in field_lists() {
+            assert!(fields.contains(':'), "a field list must name field types");
+        }
+    }
+
+    #[test]
+    fn should_match_the_digest_recorded_for_this_build() {
+        let digest: String = ssz_schema_digest()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert_eq!(digest, EXPECTED);
+    }
+}

--- a/crates/verity-db/src/votes.rs
+++ b/crates/verity-db/src/votes.rs
@@ -1,0 +1,72 @@
+//! The reduction that turns a stream of verified aggregates into two small vote maps.
+//!
+//! Raw XMSS signatures and reusable proof pools are bounded in-memory inputs and are
+//! discarded on restart. What survives is one latest vote per validator, in
+//! `pending_votes` and `known_votes`.
+//!
+//! Reducing a set to one element needs a total order, or the surviving element depends on
+//! insertion order and a restart reconstructs a different fork choice than the one that was
+//! running. The order here is: newer attestation slot wins; on a tie, the lexicographically
+//! larger `AttestationData` root wins. The tiebreak is arbitrary but total, which is the
+//! whole requirement.
+//!
+//! Transcribed from `docs/design/storage.md`, "Fork-choice votes and time".
+
+use core::cmp::Ordering;
+
+use verity_types::AttestationData;
+
+use crate::merkle::hash_tree_root;
+
+/// Whether `candidate` replaces `stored` in a vote map.
+///
+/// Equal votes do not supersede: re-observing the same vote must not rewrite the row, so a
+/// duplicate aggregate produces an empty batch rather than a redundant write.
+#[must_use]
+pub fn supersedes(candidate: &AttestationData, stored: &AttestationData) -> bool {
+    match candidate.slot.0.cmp(&stored.slot.0) {
+        Ordering::Greater => true,
+        Ordering::Less => false,
+        Ordering::Equal => hash_tree_root(candidate) > hash_tree_root(stored),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use verity_types::primitives::Slot;
+    use verity_types::{AttestationData, Checkpoint};
+
+    use super::supersedes;
+
+    fn vote(slot: u64, head: u8) -> AttestationData {
+        AttestationData {
+            slot: Slot(slot),
+            head: Checkpoint {
+                root: [head; 32],
+                slot: Slot(slot),
+            },
+            ..AttestationData::default()
+        }
+    }
+
+    #[test]
+    fn should_prefer_the_newer_attestation_slot() {
+        assert!(supersedes(&vote(5, 1), &vote(4, 9)));
+        assert!(!supersedes(&vote(4, 9), &vote(5, 1)));
+    }
+
+    #[test]
+    fn should_not_replace_a_vote_with_itself() {
+        assert!(!supersedes(&vote(5, 1), &vote(5, 1)));
+    }
+
+    #[test]
+    fn should_break_a_slot_tie_the_same_way_whichever_arrives_first() {
+        let (a, b) = (vote(5, 1), vote(5, 2));
+        assert_ne!(
+            supersedes(&a, &b),
+            supersedes(&b, &a),
+            "exactly one direction wins, so insertion order cannot change the survivor"
+        );
+    }
+}

--- a/crates/verity-db/src/votes.rs
+++ b/crates/verity-db/src/votes.rs
@@ -18,12 +18,20 @@ use verity_types::AttestationData;
 
 use crate::merkle::hash_tree_root;
 
-/// Whether `candidate` replaces `stored` in a vote map.
+/// Whether `candidate` replaces what a vote map holds for its validator.
 ///
-/// Equal votes do not supersede: re-observing the same vote must not rewrite the row, so a
+/// `stored` is an `Option` because the rule covers the empty row too, and both callers need
+/// that case: a validator votes for the first time at interval 1, and a pending vote is
+/// merged into an empty `known_votes` row at interval 4. Folding it in here is what keeps one
+/// rule from being written twice, once per caller, in two shapes that can drift apart.
+///
+/// A vote does not replace itself. Re-observing the same vote must not rewrite the row, so a
 /// duplicate aggregate produces an empty batch rather than a redundant write.
 #[must_use]
-pub fn supersedes(candidate: &AttestationData, stored: &AttestationData) -> bool {
+pub fn replaces(candidate: &AttestationData, stored: Option<&AttestationData>) -> bool {
+    let Some(stored) = stored else {
+        return true;
+    };
     match candidate.slot.0.cmp(&stored.slot.0) {
         Ordering::Greater => true,
         Ordering::Less => false,
@@ -36,7 +44,7 @@ mod tests {
     use verity_types::primitives::Slot;
     use verity_types::{AttestationData, Checkpoint};
 
-    use super::supersedes;
+    use super::replaces;
 
     fn vote(slot: u64, head: u8) -> AttestationData {
         AttestationData {
@@ -51,21 +59,26 @@ mod tests {
 
     #[test]
     fn should_prefer_the_newer_attestation_slot() {
-        assert!(supersedes(&vote(5, 1), &vote(4, 9)));
-        assert!(!supersedes(&vote(4, 9), &vote(5, 1)));
+        assert!(replaces(&vote(5, 1), Some(&vote(4, 9))));
+        assert!(!replaces(&vote(4, 9), Some(&vote(5, 1))));
     }
 
     #[test]
     fn should_not_replace_a_vote_with_itself() {
-        assert!(!supersedes(&vote(5, 1), &vote(5, 1)));
+        assert!(!replaces(&vote(5, 1), Some(&vote(5, 1))));
+    }
+
+    #[test]
+    fn should_fill_an_empty_row_with_any_vote() {
+        assert!(replaces(&vote(0, 0), None));
     }
 
     #[test]
     fn should_break_a_slot_tie_the_same_way_whichever_arrives_first() {
         let (a, b) = (vote(5, 1), vote(5, 2));
         assert_ne!(
-            supersedes(&a, &b),
-            supersedes(&b, &a),
+            replaces(&a, Some(&b)),
+            replaces(&b, Some(&a)),
             "exactly one direction wins, so insertion order cannot change the survivor"
         );
     }

--- a/crates/verity-db/src/writer.rs
+++ b/crates/verity-db/src/writer.rs
@@ -27,7 +27,7 @@ use crate::merkle::hash_tree_root;
 use crate::metadata::MetadataKey;
 use crate::repository::{Repository, put_metadata};
 use crate::schema::{SCHEMA_VERSION, ssz_schema_digest};
-use crate::votes::replaces;
+use crate::votes;
 
 use libssz::SszEncode;
 
@@ -292,7 +292,7 @@ impl<B: StorageBackend> Repository<B> {
         let mut batch = WriteBatch::new();
         for (validator, vote) in votes {
             let stored = self.pending_vote(*validator)?;
-            if !replaces(vote, stored.as_ref()) {
+            if !votes::replaces(vote, stored.as_ref()) {
                 continue;
             }
             batch.queue_put(
@@ -458,7 +458,7 @@ impl<B: StorageBackend> Repository<B> {
     fn queue_vote_merge(&self, batch: &mut WriteBatch) -> Result<(), StorageError> {
         for (validator, vote) in self.pending_votes()? {
             let stored = self.known_vote(validator)?;
-            if replaces(&vote, stored.as_ref()) {
+            if votes::replaces(&vote, stored.as_ref()) {
                 batch.queue_put(
                     ColumnFamily::KnownVotes,
                     key::validator(validator),

--- a/crates/verity-db/src/writer.rs
+++ b/crates/verity-db/src/writer.rs
@@ -388,7 +388,7 @@ impl<B: StorageBackend> Repository<B> {
         new_head: Bytes32,
     ) -> Result<(), StorageError> {
         let switch = match previous {
-            Some(previous) => self.divergence(previous, new_head)?,
+            Some(previous) => self.canonical_switch(previous, new_head)?,
             // No previous head: nothing to unwind, and the anchor already wrote its own slot.
             None => CanonicalSwitch {
                 leaving: Vec::new(),
@@ -408,11 +408,12 @@ impl<B: StorageBackend> Repository<B> {
         Ok(())
     }
 
-    /// Walks both heads back to their common ancestor.
+    /// The edits moving the head from `previous` to `new_head` implies, found by walking both
+    /// back to their common ancestor.
     ///
     /// The walk is bounded by the chain itself: each step moves one of the two pointers
     /// strictly backwards, and a missing header stops it as corruption rather than looping.
-    fn divergence(
+    fn canonical_switch(
         &self,
         previous: Bytes32,
         new_head: Bytes32,

--- a/crates/verity-db/src/writer.rs
+++ b/crates/verity-db/src/writer.rs
@@ -1,0 +1,522 @@
+//! The only path by which anything becomes durable.
+//!
+//! There are four commits, and each one is a single cross-table batch that applies whole or
+//! not at all: the anchor a chain starts from, a processed block, an interval-3 safe target,
+//! and the interval tick that moves the head. Nothing else writes.
+//!
+//! Every commit checks its own internal consistency **before** the batch is handed to the
+//! backend, so an inconsistent commit is refused rather than made durable and repaired later.
+//! The checks are the ones `docs/design/storage.md` names: the header roots to the block
+//! root, the body roots to the header, the state roots to the header, and the parent links
+//! agree.
+//!
+//! Transcribed from `docs/design/storage.md`, "Writer, batches, and restart".
+
+use verity_types::config::INTERVALS_PER_SLOT;
+use verity_types::primitives::{Bytes32, Interval, Slot, ValidatorIndex};
+use verity_types::{
+    AttestationData, BlockBody, BlockHeader, Checkpoint, MultiMessageAggregate, State,
+};
+
+use crate::backend::{Durability, StorageBackend, WriteBatch};
+use crate::column::ColumnFamily;
+use crate::diff::{StateDiff, crosses_snapshot_boundary};
+use crate::error::StorageError;
+use crate::key;
+use crate::merkle::hash_tree_root;
+use crate::metadata::MetadataKey;
+use crate::repository::{Repository, put_metadata};
+use crate::schema::{SCHEMA_VERSION, ssz_schema_digest};
+use crate::votes::supersedes;
+
+use libssz::SszEncode;
+
+/// The state a chain is started or restarted from.
+///
+/// The anchor block's header is not passed in, because it is not free to differ from the
+/// state: [`stored_header`] derives it, and `block_root` is checked against what that
+/// derivation produces. Genesis and a checkpoint-sync anchor take the same path. Only the
+/// body is genuinely extra, and only when the operator fetched one — an anchor without its
+/// body is serviceable, it is simply not servable over `BlocksByRange`.
+#[derive(Debug, Clone, Copy)]
+pub struct AnchorCommit<'a> {
+    /// Root of the anchor block.
+    pub block_root: Bytes32,
+    /// The state the anchor pins.
+    pub state: &'a State,
+    /// The anchor block's body, when the operator supplied one.
+    pub body: Option<&'a BlockBody>,
+    /// First slot this node may serve proof-bearing history from.
+    ///
+    /// An anchor above genesis has no history below itself, so range service starts here and
+    /// not at slot zero.
+    pub served_from_slot: Slot,
+}
+
+/// A block that has passed the state transition, with the state it produced.
+///
+/// As with [`AnchorCommit`], the header is derived rather than supplied: every one of its
+/// fields is already fixed by the post-state, so accepting one would only create a way for a
+/// caller to store a header that disagrees with the state beside it.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockCommit<'a> {
+    /// Root of the block.
+    pub block_root: Bytes32,
+    /// The block's body.
+    pub body: &'a BlockBody,
+    /// The single proof covering the block's attestations and its proposer signature.
+    pub proof: &'a MultiMessageAggregate,
+    /// The state the block produced.
+    pub post_state: &'a State,
+    /// The slot of the block's parent, which decides whether a snapshot is due.
+    pub parent_slot: Slot,
+}
+
+/// The header a block is stored under, derived from the state it produced.
+///
+/// A post-state carries the block's header with its `state_root` still empty —
+/// `process_block_header` leaves it for the next slot to fill, and `process_slots` fills it
+/// with the root of the state as of that block. Filling it here reproduces the header the
+/// chain itself roots, which is the root the block's children name as their parent. Deriving
+/// it is therefore not a convenience: it is the definition.
+#[must_use]
+pub fn stored_header(post_state: &State) -> BlockHeader {
+    BlockHeader {
+        state_root: hash_tree_root(post_state),
+        ..post_state.latest_block_header
+    }
+}
+
+/// The canonical-index edits a head move implies.
+///
+/// Two lists rather than one, because they are applied in order and the order matters: a slot
+/// can both leave and rejoin — the same height on a different branch — and the upsert has to
+/// land after the delete.
+#[derive(Debug, Clone, Default)]
+struct CanonicalSwitch {
+    /// Slots leaving the canonical chain.
+    leaving: Vec<Slot>,
+    /// Slots joining it, with the root that now occupies each.
+    joining: Vec<(Slot, Bytes32)>,
+}
+
+/// The interval tick that moves the node's view forward.
+///
+/// Interval 4 is the one that merges votes; the others carry only the head recomputation and
+/// the interval marker. Both go through here so that a vote-table change, the metadata it
+/// affects, and `last_processed_interval` are always one batch — which is what makes a
+/// restart able to tell which interval finished.
+#[derive(Debug, Clone, Copy)]
+pub struct TickCommit {
+    /// The recomputed head block root.
+    pub head: Bytes32,
+    /// The head-derived justified checkpoint.
+    pub latest_justified: Checkpoint,
+    /// The head-derived finalized checkpoint.
+    pub latest_finalized: Checkpoint,
+    /// The interval whose events this batch completes.
+    pub interval: Interval,
+    /// Whether pending votes merge into the counted map and the pending map is cleared.
+    pub merge_pending_votes: bool,
+}
+
+impl<B: StorageBackend> Repository<B> {
+    /// Writes the anchor a chain starts from, identity included.
+    ///
+    /// Fsynced: everything after this is interpreted relative to it, so it must not be the
+    /// commit that a power cut leaves half-written.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::RejectedBatch`] when the anchor block, its body, and the anchor
+    ///   state do not agree with each other or with `block_root`.
+    /// - [`StorageError::Backend`] when the engine fails.
+    pub fn commit_anchor(&mut self, anchor: &AnchorCommit<'_>) -> Result<(), StorageError> {
+        let header = stored_header(anchor.state);
+        check_anchor(anchor, &header)?;
+        let state_root = header.state_root;
+        let slot = header.slot;
+
+        let mut batch = WriteBatch::new();
+
+        put_metadata(&mut batch, MetadataKey::SchemaVersion, &SCHEMA_VERSION);
+        put_metadata(
+            &mut batch,
+            MetadataKey::ChainFingerprint,
+            &self.identity().chain_fingerprint,
+        );
+        put_metadata(
+            &mut batch,
+            MetadataKey::ForkVersion,
+            &self.identity().fork_version,
+        );
+        put_metadata(
+            &mut batch,
+            MetadataKey::SszSchemaDigest,
+            &ssz_schema_digest(),
+        );
+
+        put_metadata(&mut batch, MetadataKey::Head, &anchor.block_root);
+        put_metadata(&mut batch, MetadataKey::SafeTarget, &anchor.block_root);
+        put_metadata(
+            &mut batch,
+            MetadataKey::LatestJustified,
+            &anchor.state.latest_justified,
+        );
+        put_metadata(
+            &mut batch,
+            MetadataKey::LatestFinalized,
+            &anchor.state.latest_finalized,
+        );
+        put_metadata(
+            &mut batch,
+            MetadataKey::ServedFromSlot,
+            &anchor.served_from_slot.0,
+        );
+        // The anchor is complete at the first interval of its own slot; nothing later has run.
+        put_metadata(
+            &mut batch,
+            MetadataKey::LastProcessedInterval,
+            &(slot.0 * INTERVALS_PER_SLOT),
+        );
+
+        batch.put(
+            ColumnFamily::BlockHeaders,
+            key::root(anchor.block_root),
+            header.to_ssz(),
+        );
+        if let Some(body) = anchor.body {
+            batch.put(
+                ColumnFamily::BlockBodies,
+                key::root(anchor.block_root),
+                body.to_ssz(),
+            );
+        }
+        batch.put(
+            ColumnFamily::StateSnapshots,
+            key::root(anchor.block_root),
+            anchor.state.to_ssz(),
+        );
+        batch.put(
+            ColumnFamily::StateRoots,
+            key::root(state_root),
+            anchor.block_root.to_vec(),
+        );
+        batch.put(
+            ColumnFamily::CanonicalBlocks,
+            key::slot(slot),
+            anchor.block_root.to_vec(),
+        );
+        batch.put(
+            ColumnFamily::ForkChoiceBlocks,
+            key::slot_and_root(slot, anchor.block_root),
+            header.parent_root.to_vec(),
+        );
+
+        self.commit(batch, Durability::Synced)
+    }
+
+    /// Writes a processed block: its data, its state delta, and its index entries.
+    ///
+    /// The node's view — head, canonical index, checkpoints — is deliberately untouched. A
+    /// block on a side branch is processed exactly like one on the canonical chain, and only
+    /// [`Repository::commit_tick`] decides which of them the node is following.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::RejectedBatch`] when the block, its body, and its post-state do not
+    ///   agree with each other or with `block_root`.
+    /// - [`StorageError::Backend`] when the engine fails.
+    pub fn commit_block(&mut self, commit: &BlockCommit<'_>) -> Result<(), StorageError> {
+        let header = stored_header(commit.post_state);
+        check_block(commit, &header)?;
+        let slot = header.slot;
+        let root = commit.block_root;
+
+        let mut batch = WriteBatch::new();
+        batch.put(ColumnFamily::BlockHeaders, key::root(root), header.to_ssz());
+        batch.put(
+            ColumnFamily::BlockBodies,
+            key::root(root),
+            commit.body.to_ssz(),
+        );
+        batch.put(
+            ColumnFamily::BlockProofs,
+            key::slot_and_root(slot, root),
+            commit.proof.to_ssz(),
+        );
+        batch.put(
+            ColumnFamily::StateDiffs,
+            key::root(root),
+            StateDiff::of(commit.post_state).to_ssz(),
+        );
+        if crosses_snapshot_boundary(commit.parent_slot, slot) {
+            batch.put(
+                ColumnFamily::StateSnapshots,
+                key::root(root),
+                commit.post_state.to_ssz(),
+            );
+        }
+        batch.put(
+            ColumnFamily::StateRoots,
+            key::root(header.state_root),
+            root.to_vec(),
+        );
+        batch.put(
+            ColumnFamily::ForkChoiceBlocks,
+            key::slot_and_root(slot, root),
+            header.parent_root.to_vec(),
+        );
+
+        // Not fsynced. A block lost to a power cut is reacquired over the network; a block
+        // wrongly reported as durable is not recoverable at all, and the batch's atomicity is
+        // what rules that out, not the fsync.
+        self.commit(batch, Durability::Buffered)
+    }
+
+    /// Records verified block-external aggregate votes as pending.
+    ///
+    /// A vote only replaces the stored one under the total order of [`crate::votes`], so the
+    /// surviving vote does not depend on the order proofs happened to arrive in — which is
+    /// what makes the reduction survive a restart unchanged.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Decode`] on a damaged vote row, [`StorageError::Backend`] on engine
+    /// failure.
+    pub fn record_pending_votes(
+        &mut self,
+        votes: &[(ValidatorIndex, AttestationData)],
+        interval: Interval,
+    ) -> Result<(), StorageError> {
+        let mut batch = WriteBatch::new();
+        for (validator, vote) in votes {
+            let stored = self.pending_vote(*validator)?;
+            if stored.is_some_and(|stored| !supersedes(vote, &stored)) {
+                continue;
+            }
+            batch.put(
+                ColumnFamily::PendingVotes,
+                key::validator(*validator),
+                vote.to_ssz(),
+            );
+        }
+        if batch.is_empty() {
+            return Ok(());
+        }
+        put_metadata(&mut batch, MetadataKey::LastProcessedInterval, &interval.0);
+        self.commit(batch, Durability::Buffered)
+    }
+
+    /// Commits the interval-3 safe target.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Backend`] when the engine fails.
+    pub fn commit_safe_target(
+        &mut self,
+        root: Bytes32,
+        interval: Interval,
+    ) -> Result<(), StorageError> {
+        let mut batch = WriteBatch::new();
+        put_metadata(&mut batch, MetadataKey::SafeTarget, &root);
+        put_metadata(&mut batch, MetadataKey::LastProcessedInterval, &interval.0);
+        self.commit(batch, Durability::Buffered)
+    }
+
+    /// Commits an interval tick: the head, the canonical index it implies, and — at interval
+    /// 4 — the vote merge.
+    ///
+    /// Fsynced when finalization advances. That is the one commit whose loss would let the
+    /// node re-derive a *different* finalized checkpoint after a restart, so it is the one
+    /// that pays for the disk flush.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::MissingRow`] when walking to the common ancestor reaches a block
+    ///   whose header is absent, which means the fork-choice index and the block store
+    ///   disagree.
+    /// - [`StorageError::Backend`] when the engine fails.
+    pub fn commit_tick(&mut self, tick: &TickCommit) -> Result<(), StorageError> {
+        let mut batch = WriteBatch::new();
+
+        let previous_head = self.head()?;
+        if previous_head != Some(tick.head) {
+            self.queue_canonical_switch(&mut batch, previous_head, tick.head)?;
+        }
+        if tick.merge_pending_votes {
+            self.queue_vote_merge(&mut batch)?;
+        }
+
+        put_metadata(&mut batch, MetadataKey::Head, &tick.head);
+        put_metadata(
+            &mut batch,
+            MetadataKey::LatestJustified,
+            &tick.latest_justified,
+        );
+        put_metadata(
+            &mut batch,
+            MetadataKey::LatestFinalized,
+            &tick.latest_finalized,
+        );
+        put_metadata(
+            &mut batch,
+            MetadataKey::LastProcessedInterval,
+            &tick.interval.0,
+        );
+
+        let advances_finalization = self
+            .latest_finalized()?
+            .is_none_or(|stored| tick.latest_finalized.slot.0 > stored.slot.0);
+        let durability = if advances_finalization {
+            Durability::Synced
+        } else {
+            Durability::Buffered
+        };
+        self.commit(batch, durability)
+    }
+
+    /// Queues the canonical-index edits that move the head from `previous` to `new_head`.
+    ///
+    /// Deletes are queued before upserts, so a slot that both leaves and rejoins the
+    /// canonical chain — the same height on a different branch — ends up holding the new
+    /// root rather than nothing.
+    fn queue_canonical_switch(
+        &self,
+        batch: &mut WriteBatch,
+        previous: Option<Bytes32>,
+        new_head: Bytes32,
+    ) -> Result<(), StorageError> {
+        let switch = match previous {
+            Some(previous) => self.divergence(previous, new_head)?,
+            // No previous head: nothing to unwind, and the anchor already wrote its own slot.
+            None => CanonicalSwitch {
+                leaving: Vec::new(),
+                joining: self.ancestry_to_canonical(new_head)?,
+            },
+        };
+        for slot in switch.leaving {
+            batch.delete(ColumnFamily::CanonicalBlocks, key::slot(slot));
+        }
+        for (slot, root) in switch.joining {
+            batch.put(
+                ColumnFamily::CanonicalBlocks,
+                key::slot(slot),
+                root.to_vec(),
+            );
+        }
+        Ok(())
+    }
+
+    /// Walks both heads back to their common ancestor.
+    ///
+    /// The walk is bounded by the chain itself: each step moves one of the two pointers
+    /// strictly backwards, and a missing header stops it as corruption rather than looping.
+    fn divergence(
+        &self,
+        previous: Bytes32,
+        new_head: Bytes32,
+    ) -> Result<CanonicalSwitch, StorageError> {
+        let (mut old, mut new) = (previous, new_head);
+        let mut switch = CanonicalSwitch::default();
+
+        while old != new {
+            let old_header = self.required_header(old)?;
+            let new_header = self.required_header(new)?;
+            if old_header.slot.0 >= new_header.slot.0 {
+                switch.leaving.push(old_header.slot);
+                old = old_header.parent_root;
+            } else {
+                switch.joining.push((new_header.slot, new));
+                new = new_header.parent_root;
+            }
+        }
+        Ok(switch)
+    }
+
+    /// Every `(slot, root)` from `head` back to the first block already recorded as canonical
+    /// at its own slot.
+    fn ancestry_to_canonical(&self, head: Bytes32) -> Result<Vec<(Slot, Bytes32)>, StorageError> {
+        let mut joining = Vec::new();
+        let mut cursor = head;
+        loop {
+            let header = self.required_header(cursor)?;
+            if self.canonical_root(header.slot)? == Some(cursor) {
+                return Ok(joining);
+            }
+            joining.push((header.slot, cursor));
+            cursor = header.parent_root;
+        }
+    }
+
+    fn required_header(&self, root: Bytes32) -> Result<BlockHeader, StorageError> {
+        self.read_required(ColumnFamily::BlockHeaders, &key::root(root))
+    }
+
+    /// Queues the interval-4 merge: every pending vote is offered to the counted map under
+    /// the same total order, and the pending map is emptied whether or not it won.
+    fn queue_vote_merge(&self, batch: &mut WriteBatch) -> Result<(), StorageError> {
+        for (validator, vote) in self.pending_votes()? {
+            let stored = self.known_vote(validator)?;
+            if stored.is_none_or(|stored| supersedes(&vote, &stored)) {
+                batch.put(
+                    ColumnFamily::KnownVotes,
+                    key::validator(validator),
+                    vote.to_ssz(),
+                );
+            }
+            batch.delete(ColumnFamily::PendingVotes, key::validator(validator));
+        }
+        Ok(())
+    }
+}
+
+/// Checks an anchor commit against the header derived from its state.
+fn check_anchor(anchor: &AnchorCommit<'_>, header: &BlockHeader) -> Result<(), StorageError> {
+    // The anchor state must be a block's post-state, not one advanced through empty slots.
+    // An advanced state hashes to something the anchor block never committed to, so the
+    // derived header would carry a `state_root` no child could ever agree with.
+    if anchor.state.slot != anchor.state.latest_block_header.slot {
+        return Err(StorageError::RejectedBatch(
+            "anchor state has been advanced past its own block's slot",
+        ));
+    }
+    if hash_tree_root(header) != anchor.block_root {
+        return Err(StorageError::RejectedBatch(
+            "anchor block does not commit to the anchor state it was handed with",
+        ));
+    }
+    if let Some(body) = anchor.body
+        && hash_tree_root(body) != header.body_root
+    {
+        return Err(StorageError::RejectedBatch(
+            "anchor body does not root to the anchor header's body root",
+        ));
+    }
+    Ok(())
+}
+
+/// Checks a block commit against the header derived from its post-state.
+fn check_block(commit: &BlockCommit<'_>, header: &BlockHeader) -> Result<(), StorageError> {
+    if hash_tree_root(header) != commit.block_root {
+        return Err(StorageError::RejectedBatch(
+            "post-state does not produce the block root it was committed under",
+        ));
+    }
+    if hash_tree_root(commit.body) != header.body_root {
+        return Err(StorageError::RejectedBatch(
+            "body does not root to the header's body root",
+        ));
+    }
+    if commit.post_state.slot != header.slot {
+        return Err(StorageError::RejectedBatch(
+            "post-state and header disagree on the slot",
+        ));
+    }
+    if commit.parent_slot.0 >= header.slot.0 {
+        return Err(StorageError::RejectedBatch(
+            "parent slot is not below the block's slot",
+        ));
+    }
+    Ok(())
+}

--- a/crates/verity-db/src/writer.rs
+++ b/crates/verity-db/src/writer.rs
@@ -27,7 +27,7 @@ use crate::merkle::hash_tree_root;
 use crate::metadata::MetadataKey;
 use crate::repository::{Repository, put_metadata};
 use crate::schema::{SCHEMA_VERSION, ssz_schema_digest};
-use crate::votes::supersedes;
+use crate::votes::replaces;
 
 use libssz::SszEncode;
 
@@ -292,7 +292,7 @@ impl<B: StorageBackend> Repository<B> {
         let mut batch = WriteBatch::new();
         for (validator, vote) in votes {
             let stored = self.pending_vote(*validator)?;
-            if stored.is_some_and(|stored| !supersedes(vote, &stored)) {
+            if !replaces(vote, stored.as_ref()) {
                 continue;
             }
             batch.queue_put(
@@ -458,7 +458,7 @@ impl<B: StorageBackend> Repository<B> {
     fn queue_vote_merge(&self, batch: &mut WriteBatch) -> Result<(), StorageError> {
         for (validator, vote) in self.pending_votes()? {
             let stored = self.known_vote(validator)?;
-            if stored.is_none_or(|stored| supersedes(&vote, &stored)) {
+            if replaces(&vote, stored.as_ref()) {
                 batch.queue_put(
                     ColumnFamily::KnownVotes,
                     key::validator(validator),

--- a/crates/verity-db/src/writer.rs
+++ b/crates/verity-db/src/writer.rs
@@ -248,7 +248,7 @@ impl<B: StorageBackend> Repository<B> {
         batch.queue_put(
             ColumnFamily::StateDiffs,
             key::root(root),
-            StateDiff::of(commit.post_state).to_ssz(),
+            StateDiff::from_post_state(commit.post_state).to_ssz(),
         );
         if crosses_snapshot_boundary(commit.parent_slot, slot) {
             batch.queue_put(

--- a/crates/verity-db/src/writer.rs
+++ b/crates/verity-db/src/writer.rs
@@ -180,34 +180,34 @@ impl<B: StorageBackend> Repository<B> {
             &(slot.0 * INTERVALS_PER_SLOT),
         );
 
-        batch.put(
+        batch.queue_put(
             ColumnFamily::BlockHeaders,
             key::root(anchor.block_root),
             header.to_ssz(),
         );
         if let Some(body) = anchor.body {
-            batch.put(
+            batch.queue_put(
                 ColumnFamily::BlockBodies,
                 key::root(anchor.block_root),
                 body.to_ssz(),
             );
         }
-        batch.put(
+        batch.queue_put(
             ColumnFamily::StateSnapshots,
             key::root(anchor.block_root),
             anchor.state.to_ssz(),
         );
-        batch.put(
+        batch.queue_put(
             ColumnFamily::StateRoots,
             key::root(state_root),
             anchor.block_root.to_vec(),
         );
-        batch.put(
+        batch.queue_put(
             ColumnFamily::CanonicalBlocks,
             key::slot(slot),
             anchor.block_root.to_vec(),
         );
-        batch.put(
+        batch.queue_put(
             ColumnFamily::ForkChoiceBlocks,
             key::slot_and_root(slot, anchor.block_root),
             header.parent_root.to_vec(),
@@ -234,35 +234,35 @@ impl<B: StorageBackend> Repository<B> {
         let root = commit.block_root;
 
         let mut batch = WriteBatch::new();
-        batch.put(ColumnFamily::BlockHeaders, key::root(root), header.to_ssz());
-        batch.put(
+        batch.queue_put(ColumnFamily::BlockHeaders, key::root(root), header.to_ssz());
+        batch.queue_put(
             ColumnFamily::BlockBodies,
             key::root(root),
             commit.body.to_ssz(),
         );
-        batch.put(
+        batch.queue_put(
             ColumnFamily::BlockProofs,
             key::slot_and_root(slot, root),
             commit.proof.to_ssz(),
         );
-        batch.put(
+        batch.queue_put(
             ColumnFamily::StateDiffs,
             key::root(root),
             StateDiff::of(commit.post_state).to_ssz(),
         );
         if crosses_snapshot_boundary(commit.parent_slot, slot) {
-            batch.put(
+            batch.queue_put(
                 ColumnFamily::StateSnapshots,
                 key::root(root),
                 commit.post_state.to_ssz(),
             );
         }
-        batch.put(
+        batch.queue_put(
             ColumnFamily::StateRoots,
             key::root(header.state_root),
             root.to_vec(),
         );
-        batch.put(
+        batch.queue_put(
             ColumnFamily::ForkChoiceBlocks,
             key::slot_and_root(slot, root),
             header.parent_root.to_vec(),
@@ -295,7 +295,7 @@ impl<B: StorageBackend> Repository<B> {
             if stored.is_some_and(|stored| !supersedes(vote, &stored)) {
                 continue;
             }
-            batch.put(
+            batch.queue_put(
                 ColumnFamily::PendingVotes,
                 key::validator(*validator),
                 vote.to_ssz(),
@@ -396,10 +396,10 @@ impl<B: StorageBackend> Repository<B> {
             },
         };
         for slot in switch.leaving {
-            batch.delete(ColumnFamily::CanonicalBlocks, key::slot(slot));
+            batch.queue_delete(ColumnFamily::CanonicalBlocks, key::slot(slot));
         }
         for (slot, root) in switch.joining {
-            batch.put(
+            batch.queue_put(
                 ColumnFamily::CanonicalBlocks,
                 key::slot(slot),
                 root.to_vec(),
@@ -459,13 +459,13 @@ impl<B: StorageBackend> Repository<B> {
         for (validator, vote) in self.pending_votes()? {
             let stored = self.known_vote(validator)?;
             if stored.is_none_or(|stored| supersedes(&vote, &stored)) {
-                batch.put(
+                batch.queue_put(
                     ColumnFamily::KnownVotes,
                     key::validator(validator),
                     vote.to_ssz(),
                 );
             }
-            batch.delete(ColumnFamily::PendingVotes, key::validator(validator));
+            batch.queue_delete(ColumnFamily::PendingVotes, key::validator(validator));
         }
         Ok(())
     }

--- a/crates/verity-db/tests/chain_storage.rs
+++ b/crates/verity-db/tests/chain_storage.rs
@@ -1,0 +1,253 @@
+//! Storing a chain the state transition actually produced, and getting it back.
+
+mod common;
+
+use common::{Link, anchor_root, chain, extend, identity_of, proof};
+use verity_db::{AnchorCommit, BlockCommit, MemoryBackend, Repository, StorageError, TickCommit};
+use verity_types::primitives::{Interval, Slot};
+use verity_types::{Checkpoint, State};
+
+/// An anchored repository holding `links`, in order.
+fn stored(genesis: &State, links: &[Link]) -> Repository<MemoryBackend> {
+    let mut repository = Repository::open(MemoryBackend::new(), identity_of(genesis))
+        .expect("an empty database opens");
+    repository
+        .commit_anchor(&AnchorCommit {
+            block_root: anchor_root(genesis),
+            state: genesis,
+            body: None,
+            served_from_slot: Slot(0),
+        })
+        .expect("genesis anchors");
+
+    for (index, link) in links.iter().enumerate() {
+        repository
+            .commit_block(&BlockCommit {
+                block_root: link.root,
+                body: &link.body,
+                proof: &proof(u8::try_from(index).unwrap()),
+                post_state: &link.post,
+                parent_slot: link.parent_slot,
+            })
+            .expect("a block from the state transition commits");
+    }
+    repository
+}
+
+#[test]
+fn should_anchor_genesis_as_head_and_as_the_canonical_block_at_its_slot() {
+    let (genesis, _) = chain(4, &[]);
+    let repository = stored(&genesis, &[]);
+    let root = anchor_root(&genesis);
+
+    assert_eq!(repository.head().unwrap(), Some(root));
+    assert_eq!(repository.safe_target().unwrap(), Some(root));
+    assert_eq!(repository.canonical_root(Slot(0)).unwrap(), Some(root));
+    assert_eq!(
+        repository.state_snapshot(root).unwrap().as_ref(),
+        Some(&genesis)
+    );
+    assert_eq!(repository.served_from_slot().unwrap(), Some(Slot(0)));
+}
+
+#[test]
+fn should_rebuild_every_post_state_from_its_snapshot_and_diffs() {
+    let (genesis, links) = chain(4, &[1, 2, 3, 5, 8]);
+    let repository = stored(&genesis, &links);
+
+    for link in &links {
+        assert_eq!(
+            repository.state_at(link.root).unwrap(),
+            link.post,
+            "the state at slot {} did not survive the round trip",
+            link.slot().0
+        );
+    }
+}
+
+#[test]
+fn should_store_a_diff_and_no_snapshot_inside_one_snapshot_interval() {
+    let (genesis, links) = chain(4, &[1, 2]);
+    let repository = stored(&genesis, &links);
+
+    for link in &links {
+        assert!(repository.state_diff(link.root).unwrap().is_some());
+        assert!(
+            repository.state_snapshot(link.root).unwrap().is_none(),
+            "no edge here crosses a 1,024-slot boundary"
+        );
+    }
+}
+
+#[test]
+fn should_store_a_snapshot_when_a_block_edge_crosses_the_interval_boundary() {
+    let (genesis, links) = chain(4, &[1_000, 1_100]);
+    let repository = stored(&genesis, &links);
+
+    assert!(
+        repository.state_snapshot(links[0].root).unwrap().is_none(),
+        "slot 1,000 is inside the first interval"
+    );
+    assert_eq!(
+        repository.state_snapshot(links[1].root).unwrap().as_ref(),
+        Some(&links[1].post),
+        "the 1,000 -> 1,100 edge crosses 1,024"
+    );
+    // The snapshot must still be the state the transition produced, not merely present.
+    assert_eq!(repository.state_at(links[1].root).unwrap(), links[1].post);
+}
+
+#[test]
+fn should_index_a_block_by_its_state_root_and_by_its_parent() {
+    let (genesis, links) = chain(4, &[1, 2]);
+    let repository = stored(&genesis, &links);
+    let child = &links[1];
+
+    let header = repository.block_header(child.root).unwrap().unwrap();
+    assert_eq!(
+        repository
+            .block_root_for_state_root(header.state_root)
+            .unwrap(),
+        Some(child.root)
+    );
+    assert_eq!(
+        repository
+            .fork_choice_parent(child.slot(), child.root)
+            .unwrap(),
+        Some(links[0].root)
+    );
+}
+
+#[test]
+fn should_keep_the_proof_of_every_stored_block() {
+    let (genesis, links) = chain(4, &[1, 2]);
+    let repository = stored(&genesis, &links);
+
+    for (index, link) in links.iter().enumerate() {
+        assert_eq!(
+            repository.block_proof(link.slot(), link.root).unwrap(),
+            Some(proof(u8::try_from(index).unwrap()))
+        );
+    }
+}
+
+#[test]
+fn should_report_missing_data_rather_than_inventing_a_state() {
+    let (genesis, _) = chain(4, &[]);
+    let repository = stored(&genesis, &[]);
+    assert!(matches!(
+        repository.state_at([7u8; 32]).unwrap_err(),
+        StorageError::MissingRow { .. }
+    ));
+}
+
+#[test]
+fn should_refuse_a_block_committed_under_the_wrong_root() {
+    let (genesis, links) = chain(4, &[1]);
+    let mut repository = stored(&genesis, &[]);
+
+    let error = repository
+        .commit_block(&BlockCommit {
+            block_root: [1u8; 32],
+            body: &links[0].body,
+            proof: &proof(0),
+            post_state: &links[0].post,
+            parent_slot: links[0].parent_slot,
+        })
+        .unwrap_err();
+    assert!(matches!(error, StorageError::RejectedBatch(_)));
+    assert!(
+        repository.block_header([1u8; 32]).unwrap().is_none(),
+        "a refused batch writes nothing at all"
+    );
+}
+
+#[test]
+fn should_refuse_an_anchor_whose_root_does_not_follow_from_its_state() {
+    let (genesis, _) = chain(4, &[]);
+    let mut repository = Repository::open(MemoryBackend::new(), identity_of(&genesis)).unwrap();
+
+    let error = repository
+        .commit_anchor(&AnchorCommit {
+            block_root: [3u8; 32],
+            state: &genesis,
+            body: None,
+            served_from_slot: Slot(0),
+        })
+        .unwrap_err();
+    assert!(matches!(error, StorageError::RejectedBatch(_)));
+    assert!(!repository.is_populated().unwrap());
+}
+
+#[test]
+fn should_move_the_canonical_index_to_the_new_branch_on_a_reorg() {
+    // Two children of one parent, at different slots: switching between them exercises both
+    // halves of the walk to the common ancestor.
+    let (genesis, base) = chain(4, &[1]);
+    let short = extend(&base[0].post, 2);
+    let long = extend(&base[0].post, 3);
+
+    let mut repository = stored(&genesis, &[base[0].clone(), short.clone()]);
+    repository
+        .commit_block(&BlockCommit {
+            block_root: long.root,
+            body: &long.body,
+            proof: &proof(9),
+            post_state: &long.post,
+            parent_slot: long.parent_slot,
+        })
+        .unwrap();
+
+    let tick = |head, interval| TickCommit {
+        head,
+        latest_justified: Checkpoint::default(),
+        latest_finalized: Checkpoint::default(),
+        interval: Interval(interval),
+        merge_pending_votes: false,
+    };
+
+    repository.commit_tick(&tick(short.root, 9)).unwrap();
+    assert_eq!(
+        repository.canonical_root(Slot(2)).unwrap(),
+        Some(short.root)
+    );
+
+    repository.commit_tick(&tick(long.root, 14)).unwrap();
+    assert_eq!(
+        repository.canonical_root(Slot(2)).unwrap(),
+        None,
+        "slot 2 left the canonical chain"
+    );
+    assert_eq!(repository.canonical_root(Slot(3)).unwrap(), Some(long.root));
+    assert_eq!(
+        repository.canonical_root(Slot(1)).unwrap(),
+        Some(base[0].root),
+        "the common ancestor is untouched"
+    );
+    assert_eq!(repository.head().unwrap(), Some(long.root));
+}
+
+#[test]
+fn should_serve_a_slot_range_as_the_canonical_roots_it_actually_holds() {
+    let (genesis, links) = chain(4, &[1, 3]);
+    let mut repository = stored(&genesis, &links);
+    repository
+        .commit_tick(&TickCommit {
+            head: links[1].root,
+            latest_justified: Checkpoint::default(),
+            latest_finalized: Checkpoint::default(),
+            interval: Interval(19),
+            merge_pending_votes: false,
+        })
+        .unwrap();
+
+    assert_eq!(
+        repository.canonical_range(Slot(0), Slot(4)).unwrap(),
+        vec![
+            (Slot(0), anchor_root(&genesis)),
+            (Slot(1), links[0].root),
+            (Slot(3), links[1].root),
+        ],
+        "slot 2 is empty, so it is absent rather than zero-filled"
+    );
+}

--- a/crates/verity-db/tests/common/mod.rs
+++ b/crates/verity-db/tests/common/mod.rs
@@ -1,0 +1,114 @@
+#![allow(dead_code)]
+
+//! A real chain to store.
+//!
+//! States are produced by `verity-chain`'s state transition rather than assembled by hand.
+//! A repository test that stores a hand-built state proves only that bytes round-trip; the
+//! interesting failures — a derived header that does not root to the block root, a
+//! reconstruction that does not reproduce `state_root` — only appear against states the
+//! transition actually produced.
+
+use verity_chain::{generate_genesis, hash_tree_root, process_block, process_slots};
+use verity_db::{Identity, stored_header};
+use verity_types::primitives::{Bytes32, Slot, ZERO_HASH};
+use verity_types::{
+    Block, BlockBody, MultiMessageAggregate, State, Validator, ValidatorIndex, Validators,
+};
+
+/// One processed block, with everything a commit needs.
+#[derive(Debug, Clone)]
+pub struct Link {
+    /// The block's root, as its children name it.
+    pub root: Bytes32,
+    /// The slot of the block's parent.
+    pub parent_slot: Slot,
+    /// The block's body.
+    pub body: BlockBody,
+    /// The state the block produced.
+    pub post: State,
+}
+
+impl Link {
+    /// The slot this block sits at.
+    pub fn slot(&self) -> Slot {
+        self.post.slot
+    }
+}
+
+/// A genesis state holding `count` distinguishable validators.
+pub fn genesis(count: u64) -> State {
+    let mut validators = Validators::default();
+    for index in 0..count {
+        let seed = u8::try_from(index % 256).expect("modulo keeps this in range");
+        validators
+            .push(Validator {
+                attestation_public_key: [seed; 52],
+                proposal_public_key: [seed.wrapping_add(128); 52],
+                index: ValidatorIndex(index),
+            })
+            .expect("count stays well under the registry limit");
+    }
+    generate_genesis(0, validators)
+}
+
+/// The identity of a chain anchored at `state`.
+pub fn identity_of(state: &State) -> Identity {
+    Identity {
+        chain_fingerprint: hash_tree_root(state),
+        fork_version: 1,
+    }
+}
+
+/// The root the anchor block is stored under.
+pub fn anchor_root(state: &State) -> Bytes32 {
+    hash_tree_root(&stored_header(state))
+}
+
+/// Extends `parent` with an empty block at `slot`.
+///
+/// # Panics
+///
+/// When `slot` is not ahead of `parent`, which is a bug in the test rather than a rejection
+/// worth returning.
+pub fn extend(parent: &State, slot: u64) -> Link {
+    let parent_slot = parent.slot;
+    let advanced = process_slots(parent, Slot(slot)).expect("the slot is ahead of the parent");
+
+    let proposer = verity_chain::proposer_for_slot(Slot(slot), advanced.validators.len() as u64)
+        .expect("the registry is not empty");
+    let block = Block {
+        slot: Slot(slot),
+        proposer_index: proposer,
+        parent_root: hash_tree_root(&advanced.latest_block_header),
+        state_root: ZERO_HASH,
+        body: BlockBody::default(),
+    };
+
+    let post = process_block(&advanced, &block).expect("an empty block on a well-formed parent");
+    Link {
+        root: hash_tree_root(&stored_header(&post)),
+        parent_slot,
+        body: block.body,
+        post,
+    }
+}
+
+/// A straight chain of empty blocks at the given slots.
+pub fn chain(validators: u64, slots: &[u64]) -> (State, Vec<Link>) {
+    let genesis = genesis(validators);
+    let mut links: Vec<Link> = Vec::new();
+    for slot in slots {
+        let parent = links.last().map_or(&genesis, |link| &link.post);
+        links.push(extend(parent, *slot));
+    }
+    (genesis, links)
+}
+
+/// A proof stand-in. Nothing in `verity-db` verifies a proof; it stores the bytes it is given.
+pub fn proof(marker: u8) -> MultiMessageAggregate {
+    let mut proof = MultiMessageAggregate::default();
+    for _ in 0..64 {
+        proof.proof.push(marker).expect("64 bytes fit in 512 KiB");
+    }
+    proof
+}

--- a/crates/verity-db/tests/identity.rs
+++ b/crates/verity-db/tests/identity.rs
@@ -1,0 +1,119 @@
+//! Opening a database that does not belong to this node.
+//!
+//! `docs/design/storage.md` is unambiguous: a populated database opens only when every
+//! identity value matches, and a mismatch is never treated as an empty database and never
+//! overwritten. These tests pin that behavior, because the failure mode of getting it wrong
+//! is silent — a node that adopts another chain's directory produces a state that verifies
+//! against itself and against nothing else.
+
+mod common;
+
+use common::{anchor_root, chain, identity_of};
+use verity_db::backend::StorageBackend;
+use verity_db::{
+    AnchorCommit, ColumnFamily, Durability, Identity, MemoryBackend, MetadataKey, Repository,
+    StorageError, WriteBatch,
+};
+use verity_types::primitives::Slot;
+
+/// An anchored database, and the identity it was anchored with.
+fn anchored() -> (MemoryBackend, Identity) {
+    let (genesis, _) = chain(4, &[]);
+    let identity = identity_of(&genesis);
+    let mut repository =
+        Repository::open(MemoryBackend::new(), identity).expect("an empty database opens");
+    repository
+        .commit_anchor(&AnchorCommit {
+            block_root: anchor_root(&genesis),
+            state: &genesis,
+            body: None,
+            served_from_slot: Slot(0),
+        })
+        .expect("genesis anchors");
+    (repository.backend().clone(), identity)
+}
+
+#[test]
+fn should_open_an_empty_database_and_wait_for_an_anchor() {
+    let (genesis, _) = chain(4, &[]);
+    let repository = Repository::open(MemoryBackend::new(), identity_of(&genesis))
+        .expect("an empty database is not a mismatched one");
+    assert!(!repository.is_populated().unwrap());
+}
+
+#[test]
+fn should_reopen_a_database_it_anchored_itself() {
+    let (backend, identity) = anchored();
+    let repository = Repository::open(backend, identity).expect("its own database reopens");
+    assert!(repository.is_populated().unwrap());
+}
+
+#[test]
+fn should_refuse_a_database_belonging_to_another_chain() {
+    let (backend, identity) = anchored();
+    let other = Identity {
+        chain_fingerprint: [9u8; 32],
+        ..identity
+    };
+    assert!(matches!(
+        Repository::open(backend, other).unwrap_err(),
+        StorageError::Identity(verity_db::IdentityMismatch::ChainFingerprint { .. })
+    ));
+}
+
+#[test]
+fn should_refuse_a_database_written_under_another_fork() {
+    let (backend, identity) = anchored();
+    let other = Identity {
+        fork_version: identity.fork_version + 1,
+        ..identity
+    };
+    assert!(matches!(
+        Repository::open(backend, other).unwrap_err(),
+        StorageError::Identity(verity_db::IdentityMismatch::ForkVersion { .. })
+    ));
+}
+
+#[test]
+fn should_refuse_a_populated_database_missing_an_identity_value() {
+    let (genesis, _) = chain(4, &[]);
+    let identity = identity_of(&genesis);
+
+    // Only one of the four identity values is present. This is corruption, not an empty
+    // database, and must not be adopted as one.
+    let mut backend = MemoryBackend::new();
+    let mut batch = WriteBatch::new();
+    batch.put(
+        ColumnFamily::Metadata,
+        MetadataKey::ChainFingerprint.as_bytes().to_vec(),
+        identity.chain_fingerprint.to_vec(),
+    );
+    backend.write(batch, Durability::Synced).unwrap();
+
+    assert_eq!(
+        Repository::open(backend, identity).unwrap_err(),
+        StorageError::MissingMetadata(MetadataKey::SchemaVersion)
+    );
+}
+
+#[test]
+fn should_refuse_a_database_whose_stored_containers_changed_shape() {
+    let (genesis, _) = chain(4, &[]);
+    let identity = identity_of(&genesis);
+    let (mut backend, _) = anchored();
+
+    // Stand in for a container whose SSZ shape moved between builds. The bytes still decode;
+    // only the manifest digest says they no longer mean the same thing.
+    let mut batch = WriteBatch::new();
+    batch.put(
+        ColumnFamily::Metadata,
+        MetadataKey::SszSchemaDigest.as_bytes().to_vec(),
+        [1u8; 32].to_vec(),
+    );
+    backend.write(batch, Durability::Synced).unwrap();
+
+    assert!(matches!(
+        Repository::open(backend, identity).unwrap_err(),
+        StorageError::Identity(verity_db::IdentityMismatch::SszSchemaDigest { .. })
+    ));
+}

--- a/crates/verity-db/tests/identity.rs
+++ b/crates/verity-db/tests/identity.rs
@@ -83,7 +83,7 @@ fn should_refuse_a_populated_database_missing_an_identity_value() {
     // database, and must not be adopted as one.
     let mut backend = MemoryBackend::new();
     let mut batch = WriteBatch::new();
-    batch.put(
+    batch.queue_put(
         ColumnFamily::Metadata,
         MetadataKey::ChainFingerprint.as_bytes().to_vec(),
         identity.chain_fingerprint.to_vec(),
@@ -105,7 +105,7 @@ fn should_refuse_a_database_whose_stored_containers_changed_shape() {
     // Stand in for a container whose SSZ shape moved between builds. The bytes still decode;
     // only the manifest digest says they no longer mean the same thing.
     let mut batch = WriteBatch::new();
-    batch.put(
+    batch.queue_put(
         ColumnFamily::Metadata,
         MetadataKey::SszSchemaDigest.as_bytes().to_vec(),
         [1u8; 32].to_vec(),

--- a/crates/verity-db/tests/rocksdb_parity.rs
+++ b/crates/verity-db/tests/rocksdb_parity.rs
@@ -1,0 +1,103 @@
+//! The RocksDB backend must behave as the in-memory one does.
+//!
+//! `docs/design/storage.md` allows no RocksDB-specific behavior past the backend contract.
+//! The value of the in-memory sibling rests entirely on that, so it is checked rather than
+//! assumed: the same commits run against both, and the results are compared.
+
+mod common;
+
+use common::{anchor_root, chain, identity_of, proof};
+use tempfile::tempdir;
+use verity_db::backend::StorageBackend;
+use verity_db::{AnchorCommit, BlockCommit, MemoryBackend, Repository, RocksBackend, TickCommit};
+use verity_types::Checkpoint;
+use verity_types::primitives::{Interval, Slot};
+
+/// Runs one chain through a repository and reports what a reader would see.
+fn run<B: StorageBackend>(backend: B) -> Vec<(Slot, [u8; 32])> {
+    let (genesis, links) = chain(4, &[1, 2, 4]);
+    let mut repository = Repository::open(backend, identity_of(&genesis)).unwrap();
+    repository
+        .commit_anchor(&AnchorCommit {
+            block_root: anchor_root(&genesis),
+            state: &genesis,
+            body: None,
+            served_from_slot: Slot(0),
+        })
+        .unwrap();
+    for (index, link) in links.iter().enumerate() {
+        repository
+            .commit_block(&BlockCommit {
+                block_root: link.root,
+                body: &link.body,
+                proof: &proof(u8::try_from(index).unwrap()),
+                post_state: &link.post,
+                parent_slot: link.parent_slot,
+            })
+            .unwrap();
+    }
+    repository
+        .commit_tick(&TickCommit {
+            head: links[2].root,
+            latest_justified: Checkpoint::default(),
+            latest_finalized: Checkpoint::default(),
+            interval: Interval(24),
+            merge_pending_votes: false,
+        })
+        .unwrap();
+
+    // Reconstruction is the strongest single check available: it reads headers, diffs, and a
+    // snapshot, and fails unless every one of them came back byte-identical.
+    for link in &links {
+        assert_eq!(repository.state_at(link.root).unwrap(), link.post);
+    }
+    repository.canonical_range(Slot(0), Slot(8)).unwrap()
+}
+
+#[test]
+fn should_produce_the_same_canonical_chain_on_both_backends() {
+    let directory = tempdir().expect("a writable temporary directory");
+    let rocks = RocksBackend::open(directory.path()).expect("rocksdb opens a fresh directory");
+    assert_eq!(run(rocks), run(MemoryBackend::new()));
+}
+
+#[test]
+fn should_reopen_a_rocksdb_directory_it_wrote() {
+    let directory = tempdir().expect("a writable temporary directory");
+    let (genesis, _) = chain(4, &[]);
+    let identity = identity_of(&genesis);
+    let root = anchor_root(&genesis);
+
+    {
+        let backend = RocksBackend::open(directory.path()).unwrap();
+        let mut repository = Repository::open(backend, identity).unwrap();
+        repository
+            .commit_anchor(&AnchorCommit {
+                block_root: root,
+                state: &genesis,
+                body: None,
+                served_from_slot: Slot(0),
+            })
+            .unwrap();
+    }
+
+    let reopened = Repository::open(RocksBackend::open(directory.path()).unwrap(), identity)
+        .expect("its own directory reopens");
+    assert_eq!(reopened.head().unwrap(), Some(root));
+    assert_eq!(reopened.state_at(root).unwrap(), genesis);
+}
+
+#[test]
+fn should_refuse_a_second_handle_on_a_directory_already_open() {
+    // The single-writer rule is carried by ownership inside a process. This is the other half
+    // of it: two processes cannot interleave writes into one directory either, because the
+    // engine will not hand out a second handle. The claim is in `lib.rs`, so it is checked
+    // here rather than trusted.
+    let directory = tempdir().expect("a writable temporary directory");
+    let _held = RocksBackend::open(directory.path()).expect("the first handle opens");
+
+    assert!(
+        RocksBackend::open(directory.path()).is_err(),
+        "a directory under an open handle must not open a second time"
+    );
+}

--- a/crates/verity-db/tests/votes_and_retention.rs
+++ b/crates/verity-db/tests/votes_and_retention.rs
@@ -1,0 +1,235 @@
+//! The two things the repository reduces, and the two things it deletes.
+
+mod common;
+
+use common::{anchor_root, chain, identity_of, proof};
+use verity_db::{
+    AnchorCommit, BlockCommit, MemoryBackend, PROOF_RETENTION_SLOTS, Repository, TickCommit,
+};
+use verity_types::primitives::{Interval, Slot, ValidatorIndex};
+use verity_types::{AttestationData, Checkpoint};
+
+/// A vote naming `head` at `slot`.
+fn vote(slot: u64, head: Checkpoint) -> AttestationData {
+    AttestationData {
+        slot: Slot(slot),
+        head,
+        ..AttestationData::default()
+    }
+}
+
+/// A repository holding a chain at the given slots, with a head at the last of them.
+fn with_chain(slots: &[u64]) -> (Repository<MemoryBackend>, Vec<common::Link>) {
+    let (genesis, links) = chain(4, slots);
+    let mut repository = Repository::open(MemoryBackend::new(), identity_of(&genesis)).unwrap();
+    repository
+        .commit_anchor(&AnchorCommit {
+            block_root: anchor_root(&genesis),
+            state: &genesis,
+            body: None,
+            served_from_slot: Slot(0),
+        })
+        .unwrap();
+    for (index, link) in links.iter().enumerate() {
+        repository
+            .commit_block(&BlockCommit {
+                block_root: link.root,
+                body: &link.body,
+                proof: &proof(u8::try_from(index).unwrap()),
+                post_state: &link.post,
+                parent_slot: link.parent_slot,
+            })
+            .unwrap();
+    }
+    (repository, links)
+}
+
+#[test]
+fn should_keep_only_the_newest_vote_per_validator() {
+    let (mut repository, _) = with_chain(&[1]);
+    let validator = ValidatorIndex(2);
+    let old = vote(4, Checkpoint::default());
+    let new = vote(5, Checkpoint::default());
+
+    repository
+        .record_pending_votes(&[(validator, new)], Interval(1))
+        .unwrap();
+    repository
+        .record_pending_votes(&[(validator, old)], Interval(2))
+        .unwrap();
+
+    assert_eq!(
+        repository.pending_vote(validator).unwrap(),
+        Some(new),
+        "an older vote must not displace a newer one"
+    );
+}
+
+#[test]
+fn should_merge_pending_votes_into_the_counted_map_at_the_tick() {
+    let (mut repository, links) = with_chain(&[1]);
+    let validator = ValidatorIndex(0);
+    let cast = vote(1, Checkpoint::default());
+    repository
+        .record_pending_votes(&[(validator, cast)], Interval(3))
+        .unwrap();
+
+    repository
+        .commit_tick(&TickCommit {
+            head: links[0].root,
+            latest_justified: Checkpoint::default(),
+            latest_finalized: Checkpoint::default(),
+            interval: Interval(4),
+            merge_pending_votes: true,
+        })
+        .unwrap();
+
+    assert_eq!(repository.known_vote(validator).unwrap(), Some(cast));
+    assert!(
+        repository.pending_votes().unwrap().is_empty(),
+        "the pending map is cleared whether or not the vote won"
+    );
+    assert_eq!(
+        repository.last_processed_interval().unwrap(),
+        Some(Interval(4))
+    );
+}
+
+#[test]
+fn should_discard_votes_the_fork_choice_can_no_longer_be_moved_by() {
+    let (mut repository, links) = with_chain(&[1, 2]);
+    let finalized = Checkpoint {
+        root: links[0].root,
+        slot: Slot(1),
+    };
+
+    let live = vote(
+        2,
+        Checkpoint {
+            root: links[1].root,
+            slot: Slot(2),
+        },
+    );
+    let below_finalized = vote(1, finalized);
+    let off_chain = vote(
+        5,
+        Checkpoint {
+            root: [9u8; 32],
+            slot: Slot(5),
+        },
+    );
+    repository
+        .record_pending_votes(
+            &[
+                (ValidatorIndex(0), live),
+                (ValidatorIndex(1), below_finalized),
+                (ValidatorIndex(2), off_chain),
+            ],
+            Interval(6),
+        )
+        .unwrap();
+    repository
+        .commit_tick(&TickCommit {
+            head: links[1].root,
+            latest_justified: finalized,
+            latest_finalized: finalized,
+            interval: Interval(9),
+            merge_pending_votes: true,
+        })
+        .unwrap();
+
+    assert_eq!(repository.prune_stale_votes().unwrap(), 2);
+    assert_eq!(
+        repository.known_vote(ValidatorIndex(0)).unwrap(),
+        Some(live)
+    );
+    assert_eq!(repository.known_vote(ValidatorIndex(1)).unwrap(), None);
+    assert_eq!(
+        repository.known_vote(ValidatorIndex(2)).unwrap(),
+        None,
+        "descent that cannot be shown is not descent"
+    );
+}
+
+#[test]
+fn should_not_prune_proofs_before_the_window_has_passed() {
+    let (mut repository, _) = with_chain(&[1]);
+    assert_eq!(
+        repository
+            .prune_block_proofs(Slot(PROOF_RETENTION_SLOTS))
+            .unwrap(),
+        None,
+        "the cutoff saturates at zero for a young chain"
+    );
+}
+
+#[test]
+fn should_not_prune_a_proof_inside_the_non_finalized_range() {
+    let (mut repository, _) = with_chain(&[1]);
+    // Finalization is still at genesis, so a cutoff above it must not be acted on.
+    assert_eq!(
+        repository
+            .prune_block_proofs(Slot(PROOF_RETENTION_SLOTS + 8_400))
+            .unwrap(),
+        None
+    );
+}
+
+#[test]
+fn should_prune_only_proofs_below_the_cutoff() {
+    let (mut repository, links) = with_chain(&[1, 9_000]);
+    let finalized = Checkpoint {
+        root: links[1].root,
+        slot: Slot(9_000),
+    };
+    repository
+        .commit_tick(&TickCommit {
+            head: links[1].root,
+            latest_justified: finalized,
+            latest_finalized: finalized,
+            interval: Interval(45_004),
+            merge_pending_votes: false,
+        })
+        .unwrap();
+
+    let cutoff = repository
+        .prune_block_proofs(Slot(PROOF_RETENTION_SLOTS + 8_400))
+        .unwrap();
+    assert_eq!(cutoff, Some(Slot(8_400)));
+    assert_eq!(
+        repository.block_proof(Slot(1), links[0].root).unwrap(),
+        None
+    );
+    assert_eq!(
+        repository
+            .block_proof(Slot(9_000), links[1].root)
+            .unwrap()
+            .as_ref(),
+        Some(&proof(1)),
+        "a proof above the cutoff survives"
+    );
+    assert!(
+        repository.block_header(links[0].root).unwrap().is_some(),
+        "only the proof expires; the block is retained"
+    );
+}
+
+#[test]
+fn should_refuse_a_range_request_below_the_advertised_floor() {
+    let (repository, _) = with_chain(&[1]);
+    // A node anchored at genesis is bound by the spec floor alone.
+    assert_eq!(
+        repository.range_service_floor(Slot(10_000)).unwrap(),
+        Slot(6_400)
+    );
+    assert!(
+        !repository
+            .can_serve_range(Slot(10_000), Slot(6_399))
+            .unwrap()
+    );
+    assert!(
+        repository
+            .can_serve_range(Slot(10_000), Slot(6_400))
+            .unwrap()
+    );
+}

--- a/docs/design/storage.md
+++ b/docs/design/storage.md
@@ -140,12 +140,24 @@ automatically: an operator must select a new directory and explicitly checkpoint
 
 ## Writer, batches, and restart
 
-`verity-chain` — initially the chain module inside the single `verity-consensus` crate — owns the
-only write capability, with **no exceptions**: the discipline is one writer per database, not one
-writer per column family. P2P, RPC, validator duties, and maintenance submit requests to the chain
-writer rather than writing the backend directly. Read-only snapshot views may run concurrently.
-The rule is strong enough to express in the type system — the chain task holds the backend's only
-mutable handle — so it is enforced by ownership before any model checker is pointed at it.
+The chain writer — the single task that composes `verity-chain`'s decisions with the `Repository`
+described below — owns the only write capability, with **no exceptions**: the discipline is one
+writer per database, not one writer per column family. P2P, RPC, validator duties, and maintenance
+submit requests to it rather than writing the backend directly. Read-only snapshot views may run
+concurrently.
+
+The rule is strong enough to express in the type system, so it is enforced by ownership before any
+model checker is pointed at it. `Repository` owns its backend by value; reads borrow it shared and
+commits borrow it uniquely; a second writer cannot be constructed without moving the repository out
+of the first. Across processes the guarantee is RocksDB's own — it holds an exclusive lock on the
+directory, so a second node aimed at the same path fails to open rather than interleaving writes.
+
+`verity-chain` itself takes no storage dependency: it is pure decisions over container shapes, and
+`verity-db` knows nothing about consensus. The writer is the composition of the two, which is why
+neither crate can reach the other's capability on its own. The [target crate
+layout](../src/reference/architecture.md#crate-layout) folds that composition into `verity-chain`;
+until the crate grows its runtime side, the two halves are separate and the invariant is carried by
+`Repository`'s signatures.
 
 A processed block commits in one cross-column-family `WriteBatch`:
 


### PR DESCRIPTION
Implements `docs/design/storage.md` as the `verity-db` crate: eleven column families behind a four-operation byte-level contract, with a RocksDB implementation and an in-memory sibling that preserves its iteration order.

## What is here

| Module | Concern |
|---|---|
| `backend/` | Point reads, ordered half-open range reads, atomic cross-table batches, range deletes. RocksDB + in-memory. |
| `column.rs`, `key.rs` | The eleven tables, and big-endian keys so lexicographic order is numeric order. |
| `schema.rs` | Schema version, chain fingerprint, fork version, and a SHA-256 digest of the stored-type manifest. |
| `repository.rs`, `read.rs` | Identity-checked open, and typed reads that distinguish legitimate absence from corruption. |
| `writer.rs` | The four commits — anchor, block, safe target, interval tick — each one batch, each checked before it can become durable. |
| `diff.rs`, `reconstruct.rs` | 1,024-slot snapshot boundaries, `StateDiff`, and replay back to the nearest snapshot. |
| `retention.rs` | The 21,600-slot proof window, stale-vote pruning, and the `BlocksByRange` service floor. |
| `votes.rs` | The LMD reduction, under a total order so a restart cannot pick a different survivor. |

## Three decisions the design document left open

**The single-writer rule is carried by ownership, not convention.** `Repository` owns its backend by value; reads borrow it shared and commits borrow it uniquely, so a second writer cannot be constructed without moving the repository out of the first. Across processes it is RocksDB's own exclusive directory lock — asserted in a test rather than claimed in a comment.

**Stored headers are derived from the post-state, not accepted as an argument.** Every field of a stored header is already fixed by the state beside it, so taking one would only create a way to store a header that disagrees with that state. `stored_header` reproduces the header the chain itself roots, and the commit checks it against the block root it was handed.

**`verity-chain` takes no storage dependency.** It is pure decisions over container shapes, and `verity-db` knows nothing about consensus. The writer is the composition of the two, which is why neither crate can reach the other's capability alone. `storage.md` is updated to say this; the [target crate layout](https://github.com/NyxFoundation/verity/blob/develop/docs/src/reference/architecture.md#crate-layout) folds the composition into `verity-chain` later.

## Dependency change

`rocksdb` is taken with `default-features = false` and only `lz4` plus `bindgen-runtime`. The crate writes exactly two compression settings — LZ4 everywhere, and none for `block_proofs`, whose values are high-entropy cryptographic blobs — so snappy, zstd, zlib, and bzip2 would be four more C libraries built into every image to support a setting nothing may select. `bindgen-runtime` is in the default set that was dropped and has to be named again: `librocksdb-sys` runs bindgen on every build.

That introduces real host requirements (a C++ toolchain and `libclang`), so `CONTRIBUTING.md` gains a **Host build requirements** section, including the `LIBCLANG_PATH` workaround for hosts that ship `libclang` only under a versioned name.

## Verification

`cargo fmt --all --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, and `cargo test --locked --all-features --workspace` are all green locally. 55 new tests:

- **`chain_storage`** — states produced by `verity-chain`'s real state transition are committed, then rebuilt from snapshot plus diffs and compared. A hand-built state would only prove that bytes round-trip.
- **`identity`** — another chain, another fork, a missing identity value, and a changed container shape are each refused rather than adopted.
- **`rocksdb_parity`** — the same commits produce the same canonical chain on both backends, a written directory reopens, and a second handle on an open directory fails.
- **`votes_and_retention`** — the LMD reduction, the interval-4 merge, proof expiry on both sides of the cutoff, and the range-service floor.