### PR TITLE
refactor: enforce exhaustive pattern matching on enum branches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,12 @@ unsafe_code = "deny"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
+# Exhaustiveness policy: matches must not hide variants. `manual_let_else` folds the
+# `if let ... else { return }` shape into `let-else`; `match_wildcard_for_single_variants`
+# flags a `_` arm that silently absorbs exactly one remaining variant, which would also
+# absorb any variant leanSpec adds later. Plain `if` on booleans is untouched by both.
+manual_let_else = "warn"
+match_wildcard_for_single_variants = "warn"
 
 # Every external dependency is declared once here and inherited by members with
 # `workspace = true`, so a version appears in exactly one place in the tree.

--- a/crates/verity-db/src/backend/rocks.rs
+++ b/crates/verity-db/src/backend/rocks.rs
@@ -138,7 +138,10 @@ impl StorageBackend for RocksBackend {
         }
 
         let mut write_options = WriteOptions::default();
-        write_options.set_sync(durability == Durability::Synced);
+        write_options.set_sync(match durability {
+            Durability::Synced => true,
+            Durability::Buffered => false,
+        });
         self.db
             .write_opt(rocks_batch, &write_options)
             .map_err(backend)

--- a/crates/verity-db/src/column.rs
+++ b/crates/verity-db/src/column.rs
@@ -82,7 +82,19 @@ impl ColumnFamily {
     /// SSZ and takes LZ4 well.
     #[must_use]
     pub const fn compressed(self) -> bool {
-        !matches!(self, Self::BlockProofs)
+        match self {
+            Self::BlockProofs => false,
+            Self::BlockHeaders
+            | Self::BlockBodies
+            | Self::StateSnapshots
+            | Self::StateDiffs
+            | Self::CanonicalBlocks
+            | Self::StateRoots
+            | Self::ForkChoiceBlocks
+            | Self::KnownVotes
+            | Self::PendingVotes
+            | Self::Metadata => true,
+        }
     }
 
     /// The fixed key width of this table, or `None` where keys are variable-width.

--- a/crates/verity-db/src/read.rs
+++ b/crates/verity-db/src/read.rs
@@ -216,7 +216,7 @@ impl<B: StorageBackend> Repository<B> {
         self.all_votes(ColumnFamily::PendingVotes)
     }
 
-    fn all_votes(
+    pub(crate) fn all_votes(
         &self,
         table: ColumnFamily,
     ) -> Result<Vec<(ValidatorIndex, AttestationData)>, StorageError> {

--- a/crates/verity-db/src/retention.rs
+++ b/crates/verity-db/src/retention.rs
@@ -83,11 +83,7 @@ impl<B: StorageBackend> Repository<B> {
         let mut batch = WriteBatch::new();
         let mut pruned = 0;
         for table in [ColumnFamily::KnownVotes, ColumnFamily::PendingVotes] {
-            let votes = if table == ColumnFamily::KnownVotes {
-                self.known_votes()?
-            } else {
-                self.pending_votes()?
-            };
+            let votes = self.all_votes(table)?;
             for (validator, vote) in votes {
                 if self.vote_is_relevant(vote.head, finalized)? {
                     continue;


### PR DESCRIPTION
## What

Footing-consolidation pass before `verity-p2p` lands: enum branches must be exhaustive so that a variant added upstream surfaces as a compile error, never as a silent default.

- **Workspace lints**: add `clippy::manual_let_else` and `clippy::match_wildcard_for_single_variants` (both promoted to errors in CI by `-D warnings`). Plain boolean `if` is untouched by both.
- **`ColumnFamily::compressed`**: `!matches!(self, Self::BlockProofs)` → exhaustive match. A future column family now has to state whether it compresses, instead of silently opting in. Matches the shape `name()` and `key_width()` already use.
- **`RocksBackend` write sync**: `durability == Durability::Synced` → exhaustive match. A future durability level now has to state whether it fsyncs, instead of silently not syncing.
- **`prune_stale_votes`**: the table-tag equality branch is gone; the loop reads each table through the existing `all_votes(table)` helper (widened to `pub(crate)`), which keeps the table↔fetch pairing in one place, the fetch lazy, and one vote vector live at a time.

## Scope deliberately excluded

- Naming and directory structure (agreed: pattern matching only, this pass).
- `clippy::wildcard_enum_match_arm`: rejected — it would force noise on `#[non_exhaustive]` upstream enums (libp2p, leanSig) the moment p2p work starts.
- Collapsing `ColumnFamily`'s three per-variant property fns into a single descriptor: noted as a candidate if the property count grows, not done here.

## Verification

- `cargo clippy --workspace --all-targets --locked`: zero warnings (the existing code already satisfied both lints; the three sites above were found by manual sweep of `matches!`, enum `==`, and `_` arms — the only remaining wildcard arm matches on an integer, out of scope).
- `cargo test --workspace --locked`: all green.