### PR TITLE
feat(p2p): speak leanSpec's wire protocol over libp2p QUIC

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,6 +122,8 @@ jobs:
           tar -xzf fixtures-prod-scheme.tar.gz -C fixtures-prod \
             --wildcards '*/ssz/*/ssz/test_consensus_containers/*.json' \
             '*/ssz/*/ssz/test_xmss_containers/*.json' \
+            '*/ssz/*/ssz/test_networking_containers/*.json' \
+            '*/networking_codec/*/networking/*/*.json' \
             '*/justifiability/*/state_transition/test_justifiability/*.json' \
             '*/slot_clock/*/chain/test_slot_clock/*.json' \
             '*/state_transition/*/state_transition/*/*.json' \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,53 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,7 +70,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "fixed-cache",
- "foldhash",
+ "foldhash 0.2.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
@@ -67,6 +114,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ark-ff"
@@ -332,10 +385,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "asn1_der"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "atomic-polyfill"
@@ -344,6 +502,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64",
+ "http",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -383,10 +559,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base64"
@@ -494,6 +692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +792,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "chacha20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +817,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -605,6 +842,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -624,7 +872,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -650,6 +907,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "const_format"
@@ -682,6 +945,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +983,15 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -761,6 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -771,6 +1054,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -785,6 +1104,32 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
+dependencies = [
+ "data-encoding",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -815,7 +1160,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -826,6 +1171,20 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -904,6 +1263,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +1297,30 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -973,6 +1373,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1034,6 +1446,38 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "typenum",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
 ]
 
 [[package]]
@@ -1075,6 +1519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,9 +1560,24 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "funty"
@@ -1121,10 +1586,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-bounded"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
@@ -1133,13 +1688,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1162,8 +1728,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1185,9 +1753,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1205,6 +1785,25 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1227,6 +1826,18 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1234,9 +1845,27 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1252,6 +1881,18 @@ dependencies = [
  "spin 0.9.9",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -1278,6 +1919,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.5",
+ "ring",
+ "socket2 0.5.10",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,12 +1990,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.6.5",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1317,6 +2100,164 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
+dependencies = [
+ "async-io",
+ "core-foundation",
+ "fnv",
+ "futures",
+ "if-addrs",
+ "ipnet",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "rtnetlink",
+ "system-configuration",
+ "tokio",
+ "windows",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.9.5",
+ "tokio",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -1380,6 +2321,34 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.5",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itertools"
@@ -1499,6 +2468,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -1618,7 +2588,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha3 0.10.9",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1638,7 +2608,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha3 0.10.9",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1675,6 +2645,388 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libp2p"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
+dependencies = [
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "libp2p-allow-block-list",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-dns",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-identity",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-noise",
+ "libp2p-ping",
+ "libp2p-quic",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-upnp",
+ "libp2p-yamux",
+ "multiaddr",
+ "pin-project",
+ "rw-stream-sink",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249128cd37a2199aff30a7675dffa51caf073b51aa612d2f544b19932b9aebca"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "multistream-select",
+ "parking_lot",
+ "pin-project",
+ "quick-protobuf",
+ "rand 0.8.8",
+ "rw-stream-sink",
+ "thiserror 2.0.20",
+ "tracing",
+ "unsigned-varint 0.8.0",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "hickory-resolver",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.49.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3573f3d8e30bd62cda336df5c7c1041a1caa40a648376b8e1e274d585c0ed25c"
+dependencies = [
+ "async-channel",
+ "asynchronous-codec",
+ "base64",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "hashlink 0.9.1",
+ "hex_fmt",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.8",
+ "regex",
+ "sha2",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "smallvec",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "hkdf",
+ "k256",
+ "multihash",
+ "prost",
+ "rand 0.8.8",
+ "sha2",
+ "thiserror 2.0.20",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
+dependencies = [
+ "futures",
+ "hickory-proto",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.8",
+ "smallvec",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-metrics"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-identity",
+ "libp2p-ping",
+ "libp2p-swarm",
+ "pin-project",
+ "prometheus-client",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc73eacbe6462a0eb92a6527cac6e63f02026e5407f8831bde8293f19217bfbf"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "quick-protobuf",
+ "rand 0.8.8",
+ "snow",
+ "static_assertions",
+ "thiserror 2.0.20",
+ "tracing",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bb7fcdfd9fead4144a3859da0b49576f171a8c8c7c0bfc7c541921d25e60d3"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.8",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc597d70bf7f6f30cbe07081802c836184e48416e89e9ce73a0ba2c56a319e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-tls",
+ "quinn",
+ "quinn-proto",
+ "rand 0.8.8",
+ "ring",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f1cca83488b90102abac7b67d5c36fc65bc02ed47620228af7ed002e6a1478"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-bounded",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.8",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce88c6c4bf746c8482480345ea3edfd08301f49e026889d1cbccfa1808a9ed9e"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "hashlink 0.10.0",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm-derive",
+ "multistream-select",
+ "rand 0.8.8",
+ "smallvec",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-swarm-derive"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
+dependencies = [
+ "heck",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6585b9309699f58704ec9ab0bb102eca7a3777170fa91a8678d73ca9cafa93"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libc",
+ "libp2p-core",
+ "socket2 0.6.5",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
+dependencies = [
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "rcgen",
+ "ring",
+ "rustls",
+ "rustls-webpki",
+ "thiserror 2.0.20",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-upnp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "igd-next",
+ "libp2p-core",
+ "libp2p-swarm",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+dependencies = [
+ "either",
+ "futures",
+ "libp2p-core",
+ "thiserror 2.0.20",
+ "tracing",
+ "yamux 0.12.1",
+ "yamux 0.13.10",
+]
 
 [[package]]
 name = "librocksdb-sys"
@@ -1749,6 +3101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +3120,12 @@ name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4-sys"
@@ -1780,6 +3144,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "match-lookup"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e39695cc0b640f3cb378053832db3d2133422d49e8dcae5c866a2aaf1f730"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1802,6 +3177,34 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
 
 [[package]]
 name = "mt-air"
@@ -1925,6 +3328,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "libp2p-identity",
+ "multibase",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.8.0",
+ "url",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
+dependencies = [
+ "base-x",
+ "base256emoji",
+ "base45",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
+dependencies = [
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "multistream-select"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b897d7bd4f0af82e68d40d0344cf37e97f9c97ddf74a098de3e4da05e96ca395"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93af8261786086024cd5e96e0a991dd65ced07bbf7c233a487bbc96b971d5539"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,7 +3465,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2004,10 +3529,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "p3-baby-bear"
@@ -2214,6 +3758,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +3791,22 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -2275,6 +3851,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +3891,43 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2322,6 +3955,15 @@ dependencies = [
  "embedded-io 0.6.1",
  "heapless",
  "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2369,6 +4011,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,10 +4053,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "quick-protobuf-codec"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "quick-protobuf",
+ "thiserror 1.0.69",
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "futures-io",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.5",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "fastbloom",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.5",
+ "tracing",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "quote"
@@ -2448,7 +4216,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -2499,6 +4267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +4311,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -2619,6 +4409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,6 +4422,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2646,6 +4456,24 @@ checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "nix",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -2714,6 +4542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,7 +4560,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2742,6 +4614,17 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rw-stream-sink"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+dependencies = [
+ "futures",
+ "pin-project",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2987,6 +4870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,6 +4886,49 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "ring",
+ "rustc_version 0.4.1",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "spin"
@@ -3095,12 +5027,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-info"
 version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanVM?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -3118,7 +5088,16 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3127,7 +5106,18 @@ version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3181,6 +5171,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,6 +5194,46 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2 0.6.5",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -3226,11 +5266,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3265,7 +5312,7 @@ checksum = "f09cb459317a3811f76644334473239d696cd8efc606963ae7d1c308cead3b74"
 dependencies = [
  "ansi_term",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3308,6 +5355,12 @@ dependencies = [
  "num-integer",
  "strength_reduce",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
@@ -3364,10 +5417,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml-norway"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
@@ -3378,6 +5477,17 @@ dependencies = [
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3438,6 +5548,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "verity-p2p"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "libp2p",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
+ "serde",
+ "serde_json",
+ "sha2",
+ "snap",
+ "tokio",
+ "verity-types",
+]
+
+[[package]]
 name = "verity-types"
 version = "0.0.0"
 dependencies = [
@@ -3463,6 +5592,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3526,6 +5664,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,6 +5702,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,6 +5733,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3589,6 +5775,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,12 +5815,94 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -3631,12 +5920,125 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
+name = "yamux"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.8",
+ "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.5",
+ "static_assertions",
+ "web-time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -3660,6 +6062,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3677,6 +6100,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,26 @@ libp2p = { version = "0.56", default-features = false, features = [
     "secp256k1",
 ] }
 
+# The async runtime for the I/O Edge. Only `verity-p2p` consumes it today; the feature set is
+# what the network service actually uses — `rt` to spawn the swarm task, `sync` for the
+# command/event channels, `macros` for `select!`, `time` for request timeouts — plus
+# `rt-multi-thread` so integration tests can drive two nodes on one runtime.
+# Required to implement `libp2p::request_response::Codec`, whose trait definition uses
+# `#[async_trait]` — this is upstream's shape, not a choice made here.
+async-trait = "0.1"
+tokio = { version = "1", default-features = false, features = [
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "macros",
+    "time",
+] }
+futures = "0.3"
+
+# Snappy, in both of its formats. leanSpec uses the raw block format for gossip payloads and
+# the CRC-framed format for req/resp chunks; `snap` exposes both (`raw`, `read`/`write`).
+snap = "1.1"
+
 # --- Storage -------------------------------------------------------------------------------
 # See docs/src/reference/architecture.md "Storage engine and retention" for why an LSM engine and not a B-tree one.
 #
@@ -145,6 +165,7 @@ verity-types = { path = "crates/verity-types", version = "0.0.0" }
 verity-chain = { path = "crates/verity-chain", version = "0.0.0" }
 verity-crypto = { path = "crates/verity-crypto", version = "0.0.0" }
 verity-db = { path = "crates/verity-db", version = "0.0.0" }
+verity-p2p = { path = "crates/verity-p2p", version = "0.0.0" }
 
 # --- Test-only -----------------------------------------------------------------------------
 # Scoped to SSZ round-trip properties in `verity-types`. This is a deliberate, narrow exception

--- a/crates/verity-p2p/Cargo.toml
+++ b/crates/verity-p2p/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "verity-p2p"
+description = "The I/O Edge network service: gossipsub and req/resp over libp2p QUIC, speaking leanSpec's wire protocol."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+
+# Thin glue over upstream rust-libp2p (kickoff decision: no fork). The crate owns the wire
+# protocol — topics, message IDs, snappy formats, req/resp framing — and nothing above it:
+# no SSZ decode of gossip payloads, no signature verification, no peer scoring, no sync
+# state machine. Those belong to the verification stage and the sync service
+# (docs/design/concurrency.md, docs/design/sync.md); gossip leaves this crate as raw bytes.
+#
+# `sha2` computes the gossip message ID (SHA-256 truncated to 20 bytes), a transport
+# identifier — not a consensus root, which stays behind `libssz-merkle` elsewhere.
+#
+# `verity-types` supplies the two shapes the wire protocol itself owns a copy of: the
+# `Checkpoint` pair inside `Status`, and the `Slot` in `BlocksByRangeRequest`. Response
+# chunks (blocks) are deliberately NOT decoded here — they cross the API as raw SSZ bytes.
+[dependencies]
+async-trait.workspace = true
+futures.workspace = true
+libp2p.workspace = true
+libssz.workspace = true
+libssz-derive.workspace = true
+libssz-merkle.workspace = true
+libssz-types.workspace = true
+sha2.workspace = true
+snap.workspace = true
+tokio.workspace = true
+verity-types.workspace = true
+
+[dev-dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/verity-p2p/src/behaviour.rs
+++ b/crates/verity-p2p/src/behaviour.rs
@@ -1,0 +1,47 @@
+//! The composed libp2p behaviour: identify, gossipsub, and the three req/resp protocols.
+
+use libp2p::swarm::NetworkBehaviour;
+use libp2p::{gossipsub, identify, identity, request_response};
+
+use crate::gossip;
+use crate::reqresp;
+use crate::reqresp::codec::Codec;
+use crate::reqresp::messages::Protocol;
+
+/// Identify protocol-version string. leanSpec defines no identify protocol; this is
+/// interop plumbing — go-libp2p peers gate gossipsub GRAFT on an identify exchange, so
+/// registering the behaviour keeps Verity meshable with them.
+const IDENTIFY_PROTOCOL_VERSION: &str = "leanconsensus";
+
+/// Everything the swarm speaks. One req/resp behaviour per protocol — see
+/// [`reqresp::build_behaviour`] for why that split is what keeps upstream libp2p usable
+/// without a fork.
+#[derive(NetworkBehaviour)]
+pub struct Behaviour {
+    /// Peer identification, for gossipsub interop; its events are deliberately unhandled.
+    pub identify: identify::Behaviour,
+    /// Gossip, at leanSpec's parameters.
+    pub gossipsub: gossipsub::Behaviour,
+    /// The status handshake.
+    pub status: request_response::Behaviour<Codec>,
+    /// Blocks by root.
+    pub blocks_by_root: request_response::Behaviour<Codec>,
+    /// Blocks by slot range.
+    pub blocks_by_range: request_response::Behaviour<Codec>,
+}
+
+impl Behaviour {
+    /// Assembles the behaviour for a node identified by `local_public_key`.
+    pub fn new(local_public_key: identity::PublicKey) -> Result<Self, &'static str> {
+        Ok(Self {
+            identify: identify::Behaviour::new(
+                identify::Config::new(IDENTIFY_PROTOCOL_VERSION.to_string(), local_public_key)
+                    .with_agent_version(format!("verity/{}", env!("CARGO_PKG_VERSION"))),
+            ),
+            gossipsub: gossip::build_behaviour()?,
+            status: reqresp::build_behaviour(Protocol::Status),
+            blocks_by_root: reqresp::build_behaviour(Protocol::BlocksByRoot),
+            blocks_by_range: reqresp::build_behaviour(Protocol::BlocksByRange),
+        })
+    }
+}

--- a/crates/verity-p2p/src/config.rs
+++ b/crates/verity-p2p/src/config.rs
@@ -1,0 +1,90 @@
+//! Wire constants and the network service configuration.
+//!
+//! Every constant here transcribes leanSpec `src/lean_spec/node/networking/config.py` (and
+//! the gossip parameters in `gossipsub/parameters.py`), read at commit
+//! `0588c2d215a955a516378677a92db2a5666802f3`. Values the spec leaves free — channel
+//! capacities above all — are fields on [`NetworkConfig`] instead, per
+//! `docs/design/concurrency.md` "Deliberately deferred to implementation".
+
+use std::time::Duration;
+
+use libp2p::{Multiaddr, identity::Keypair};
+use verity_types::SubnetId;
+
+/// Maximum number of blocks in one `BlocksByRoot` or `BlocksByRange` request, and the
+/// maximum number of response chunks a requester accepts.
+pub const MAX_REQUEST_BLOCKS: usize = 1024;
+
+/// Maximum uncompressed payload size, in bytes, for both gossip messages and req/resp
+/// chunks (10 MiB).
+pub const MAX_PAYLOAD_SIZE: usize = 10 * 1024 * 1024;
+
+/// Maximum byte length of the UTF-8 message carried by an error response.
+pub const MAX_ERROR_MESSAGE_SIZE: usize = 256;
+
+/// The sliding history window, in slots, a `BlocksByRange` responder MUST serve. A request
+/// whose `start_slot` falls below `current_slot - MIN_SLOTS_FOR_BLOCK_REQUESTS` is answered
+/// with `RESOURCE_UNAVAILABLE`. Enforcing this is the responder's policy, not this crate's;
+/// the constant lives here because it is part of the wire contract.
+pub const MIN_SLOTS_FOR_BLOCK_REQUESTS: u64 = 3600;
+
+/// Per-request timeout for req/resp, both as requester and as responder.
+pub const RESP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Message-ID domain prefix for a gossip payload whose snappy decompression succeeded.
+pub const MESSAGE_DOMAIN_VALID_SNAPPY: [u8; 4] = [0x01, 0x00, 0x00, 0x00];
+
+/// Message-ID domain prefix for a gossip payload whose snappy decompression failed.
+pub const MESSAGE_DOMAIN_INVALID_SNAPPY: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
+
+/// Worst-case compressed size for a payload of `uncompressed` bytes in either snappy
+/// format: the framing overhead plus snappy's maximum expansion of one sixth. A chunk
+/// whose compressed byte count exceeds this bound for its declared uncompressed length is
+/// malformed, whatever its content.
+#[must_use]
+pub const fn max_compressed_len(uncompressed: usize) -> usize {
+    32 + uncompressed + uncompressed / 6
+}
+
+/// Configuration for [`crate::service::spawn`].
+///
+/// The buffer capacities are the tunables `docs/design/concurrency.md` defers to
+/// implementation: every buffer is bounded, gossip is dropped (never awaited) when the
+/// event buffer is full, and the defaults are sized against per-slot gossip volume
+/// (order hundreds).
+pub struct NetworkConfig {
+    /// The node's libp2p identity. The lean network convention is secp256k1.
+    pub keypair: Keypair,
+    /// Address to listen on, e.g. `/ip4/0.0.0.0/udp/9000/quic-v1`.
+    pub listen: Multiaddr,
+    /// The fork-digest segment of topic names, e.g. `12345678`. Opaque to this crate:
+    /// leanSpec treats it as a caller-supplied string, and so does Verity.
+    pub network_name: String,
+    /// Peers to dial at startup, e.g. `/ip4/10.0.0.1/udp/9000/quic-v1/p2p/16Uiu2HAm...`.
+    pub bootnodes: Vec<Multiaddr>,
+    /// Attestation subnets to subscribe to, in addition to the block and aggregation
+    /// topics which are always subscribed.
+    pub attestation_subnets: Vec<SubnetId>,
+    /// Capacity of the command channel into the network task.
+    pub command_buffer: usize,
+    /// Capacity of the event channel out of the network task — the single drop point of
+    /// the inbound pipeline.
+    pub event_buffer: usize,
+}
+
+impl NetworkConfig {
+    /// A configuration with the deferred tunables at their defaults; the caller supplies
+    /// everything the spec or the operator fixes.
+    #[must_use]
+    pub fn new(keypair: Keypair, listen: Multiaddr, network_name: String) -> Self {
+        Self {
+            keypair,
+            listen,
+            network_name,
+            bootnodes: Vec::new(),
+            attestation_subnets: vec![SubnetId(0)],
+            command_buffer: 64,
+            event_buffer: 512,
+        }
+    }
+}

--- a/crates/verity-p2p/src/error.rs
+++ b/crates/verity-p2p/src/error.rs
@@ -1,0 +1,154 @@
+//! Failure types crossing the service API.
+
+use libp2p::request_response::OutboundFailure;
+
+use crate::reqresp::messages::ErrorCode;
+
+/// Why an outbound req/resp request produced no [`crate::Response`].
+///
+/// Transport-level failures only. A peer that answered with an error *response* is not a
+/// failure of the request machinery — it arrives as [`crate::Response::Error`] — with one
+/// exception: an error chunk that is itself malformed (bad framing, oversized message) is
+/// indistinguishable from a broken stream and lands in [`RequestError::Io`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestError {
+    /// No response arrived within the protocol timeout.
+    Timeout,
+    /// The connection closed before a response arrived.
+    ConnectionClosed,
+    /// The peer does not speak the requested protocol at all. `docs/design/sync.md`
+    /// Decision 3 makes this the one outcome that sets a peer's capability flag.
+    UnsupportedProtocol,
+    /// Dialing the peer failed.
+    DialFailure,
+    /// The stream broke or its content violated the framing rules.
+    Io(String),
+    /// The network task stopped before the request completed.
+    ServiceStopped,
+}
+
+impl RequestError {
+    /// Collapses libp2p's failure taxonomy onto the outcomes the sync service's scoring
+    /// table distinguishes (`docs/design/sync.md`, Decision 3).
+    #[must_use]
+    pub fn from_outbound_failure(failure: &OutboundFailure) -> Self {
+        match failure {
+            OutboundFailure::Timeout => Self::Timeout,
+            OutboundFailure::ConnectionClosed => Self::ConnectionClosed,
+            OutboundFailure::UnsupportedProtocols => Self::UnsupportedProtocol,
+            OutboundFailure::DialFailure => Self::DialFailure,
+            OutboundFailure::Io(e) => Self::Io(e.to_string()),
+        }
+    }
+}
+
+impl std::fmt::Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "request timed out"),
+            Self::ConnectionClosed => write!(f, "connection closed before a response arrived"),
+            Self::UnsupportedProtocol => write!(f, "peer does not support the protocol"),
+            Self::DialFailure => write!(f, "dialing the peer failed"),
+            Self::Io(e) => write!(f, "stream failure: {e}"),
+            Self::ServiceStopped => write!(f, "network service stopped"),
+        }
+    }
+}
+
+impl std::error::Error for RequestError {}
+
+/// Why a publish did not reach the mesh.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishError {
+    /// No mesh peer is subscribed to the topic yet. Transient during startup — the mesh
+    /// forms on the gossipsub heartbeat — so callers may retry.
+    InsufficientPeers,
+    /// The exact message is already in the duplicate cache.
+    Duplicate,
+    /// The payload exceeds the transmit cap.
+    PayloadTooLarge,
+    /// Any other gossipsub-internal failure.
+    Other(String),
+    /// The network task stopped.
+    ServiceStopped,
+}
+
+impl From<libp2p::gossipsub::PublishError> for PublishError {
+    fn from(error: libp2p::gossipsub::PublishError) -> Self {
+        use libp2p::gossipsub::PublishError as Upstream;
+        match error {
+            Upstream::NoPeersSubscribedToTopic => Self::InsufficientPeers,
+            Upstream::Duplicate => Self::Duplicate,
+            Upstream::MessageTooLarge => Self::PayloadTooLarge,
+            other => Self::Other(other.to_string()),
+        }
+    }
+}
+
+impl std::fmt::Display for PublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InsufficientPeers => write!(f, "no mesh peer subscribed to the topic"),
+            Self::Duplicate => write!(f, "message already published"),
+            Self::PayloadTooLarge => write!(f, "payload exceeds the transmit cap"),
+            Self::Other(e) => write!(f, "publish failed: {e}"),
+            Self::ServiceStopped => write!(f, "network service stopped"),
+        }
+    }
+}
+
+impl std::error::Error for PublishError {}
+
+/// Why a dial command failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandError {
+    /// The network task stopped.
+    ServiceStopped,
+    /// The command was accepted by the task but failed immediately, e.g. a malformed
+    /// dial address.
+    Failed(String),
+}
+
+impl std::fmt::Display for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServiceStopped => write!(f, "network service stopped"),
+            Self::Failed(e) => write!(f, "command failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for CommandError {}
+
+/// Why the network service could not be built at all.
+#[derive(Debug)]
+pub enum BuildError {
+    /// Assembling the behaviour failed.
+    Behaviour(String),
+    /// Binding the listen address failed.
+    Listen(String),
+    /// Dialing a configured bootnode failed immediately (malformed address).
+    Bootnode(String),
+}
+
+impl std::fmt::Display for BuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Behaviour(e) => write!(f, "building the behaviour failed: {e}"),
+            Self::Listen(e) => write!(f, "binding the listen address failed: {e}"),
+            Self::Bootnode(e) => write!(f, "dialing a bootnode failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for BuildError {}
+
+impl std::fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRequest => write!(f, "invalid request"),
+            Self::ServerError => write!(f, "server error"),
+            Self::ResourceUnavailable => write!(f, "resource unavailable"),
+        }
+    }
+}

--- a/crates/verity-p2p/src/gossip/message_id.rs
+++ b/crates/verity-p2p/src/gossip/message_id.rs
@@ -1,0 +1,93 @@
+//! The gossip message-ID function.
+//!
+//! Transcribed from leanSpec `node/networking/gossipsub/message.py`:
+//!
+//! ```text
+//! message_id = SHA256(domain ‖ uint64_le(len(topic)) ‖ topic ‖ data)[:20]
+//! ```
+//!
+//! where `data` is the decompressed payload when snappy decompression succeeds (domain
+//! `MESSAGE_DOMAIN_VALID_SNAPPY`) and the raw transmitted bytes when it fails (domain
+//! `MESSAGE_DOMAIN_INVALID_SNAPPY`). A payload that decompresses but declares a length
+//! above the payload cap is treated as invalid: caching an ID for content the node would
+//! refuse to allocate is the same decompression-bomb it refuses elsewhere.
+//!
+//! This is a transport identifier — deduplication and IWANT bookkeeping — not a consensus
+//! root, which is why SHA-256 appears here directly rather than through `libssz-merkle`.
+
+use libp2p::gossipsub::MessageId;
+use sha2::{Digest, Sha256};
+
+use crate::config::{MAX_PAYLOAD_SIZE, MESSAGE_DOMAIN_INVALID_SNAPPY, MESSAGE_DOMAIN_VALID_SNAPPY};
+use crate::wire::snappy::decompress_block;
+
+/// Bytes of the truncated SHA-256 that form a message ID.
+pub const MESSAGE_ID_LEN: usize = 20;
+
+/// The bare hash: `SHA256(domain ‖ uint64_le(len(topic)) ‖ topic ‖ data)[:20]`, with the
+/// domain chosen by the caller. [`compute_message_id`] is the wrapper that chooses it;
+/// this form exists because leanSpec's conformance vectors supply the domain explicitly.
+#[must_use]
+pub fn message_id_with_domain(domain: &[u8], topic: &[u8], data: &[u8]) -> [u8; MESSAGE_ID_LEN] {
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update((topic.len() as u64).to_le_bytes());
+    hasher.update(topic);
+    hasher.update(data);
+    let mut id = [0u8; MESSAGE_ID_LEN];
+    id.copy_from_slice(&hasher.finalize()[..MESSAGE_ID_LEN]);
+    id
+}
+
+/// Computes the message ID for a message received or published on `topic` with
+/// transmitted (compressed) payload `data`.
+#[must_use]
+pub fn compute_message_id(topic: &str, data: &[u8]) -> MessageId {
+    let (domain, payload) = match decompress_block(data, MAX_PAYLOAD_SIZE) {
+        Ok(decompressed) => (MESSAGE_DOMAIN_VALID_SNAPPY, decompressed),
+        Err(_) => (MESSAGE_DOMAIN_INVALID_SNAPPY, data.to_vec()),
+    };
+    MessageId::new(&message_id_with_domain(&domain, topic.as_bytes(), &payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::snappy::compress_block;
+
+    #[test]
+    fn should_use_valid_domain_when_payload_decompresses() {
+        let topic = "/leanconsensus/12345678/block/ssz_snappy";
+        let payload = b"ssz bytes";
+        let id = compute_message_id(topic, &compress_block(payload));
+
+        let mut hasher = Sha256::new();
+        hasher.update(MESSAGE_DOMAIN_VALID_SNAPPY);
+        hasher.update((topic.len() as u64).to_le_bytes());
+        hasher.update(topic.as_bytes());
+        hasher.update(payload);
+        assert_eq!(id.0, &hasher.finalize()[..MESSAGE_ID_LEN]);
+    }
+
+    #[test]
+    fn should_use_invalid_domain_when_payload_is_not_snappy() {
+        let topic = "/leanconsensus/12345678/block/ssz_snappy";
+        let raw = [0xffu8; 16];
+        let id = compute_message_id(topic, &raw);
+
+        let mut hasher = Sha256::new();
+        hasher.update(MESSAGE_DOMAIN_INVALID_SNAPPY);
+        hasher.update((topic.len() as u64).to_le_bytes());
+        hasher.update(topic.as_bytes());
+        hasher.update(raw);
+        assert_eq!(id.0, &hasher.finalize()[..MESSAGE_ID_LEN]);
+    }
+
+    #[test]
+    fn should_differ_when_topic_differs_for_same_payload() {
+        let payload = compress_block(b"same bytes");
+        let a = compute_message_id("/leanconsensus/net/block/ssz_snappy", &payload);
+        let b = compute_message_id("/leanconsensus/net/aggregation/ssz_snappy", &payload);
+        assert_ne!(a, b);
+    }
+}

--- a/crates/verity-p2p/src/gossip/mod.rs
+++ b/crates/verity-p2p/src/gossip/mod.rs
@@ -1,0 +1,47 @@
+//! Gossip: the topic grammar, the message-ID function, and the gossipsub behaviour
+//! configured to leanSpec's parameters.
+
+pub mod message_id;
+pub mod topic;
+
+use std::time::Duration;
+
+use libp2p::gossipsub;
+use verity_types::config::{JUSTIFICATION_LOOKBACK_SLOTS, SECONDS_PER_SLOT};
+
+use crate::config::{MAX_PAYLOAD_SIZE, max_compressed_len};
+use crate::gossip::message_id::compute_message_id;
+
+/// Builds the gossipsub behaviour with leanSpec's mesh and cache parameters
+/// (`gossipsub/parameters.py` at the pinned revision).
+///
+/// Messages are unsigned and anonymous — the lean protocol authenticates content by XMSS
+/// signature inside the payload, never by libp2p envelope. Message validation gating
+/// (`validate_messages`) is deliberately NOT enabled: the current spec forwards before any
+/// application-level verification, and `docs/design/concurrency.md` Decision 2 keeps
+/// Verity on that behavior.
+pub fn build_behaviour() -> Result<gossipsub::Behaviour, &'static str> {
+    let config = gossipsub::ConfigBuilder::default()
+        .mesh_n(8)
+        .mesh_n_low(6)
+        .mesh_n_high(12)
+        .gossip_lazy(6)
+        .heartbeat_interval(Duration::from_millis(700))
+        .fanout_ttl(Duration::from_secs(60))
+        .history_length(6)
+        .history_gossip(3)
+        // seen_ttl = SECONDS_PER_SLOT * JUSTIFICATION_LOOKBACK_SLOTS * 2.
+        .duplicate_cache_time(Duration::from_secs(
+            SECONDS_PER_SLOT * JUSTIFICATION_LOOKBACK_SLOTS * 2,
+        ))
+        .validation_mode(gossipsub::ValidationMode::Anonymous)
+        .message_id_fn(|message| compute_message_id(message.topic.as_str(), &message.data))
+        .max_transmit_size(max_compressed_len(MAX_PAYLOAD_SIZE))
+        // Not a leanSpec parameter: a defensive bound on how many messages one RPC frame
+        // may carry, so a single peer cannot make one frame arbitrarily expensive.
+        .max_messages_per_rpc(Some(500))
+        .idontwant_message_size_threshold(1024)
+        .build()
+        .map_err(|_| "invalid gossipsub configuration")?;
+    gossipsub::Behaviour::new(gossipsub::MessageAuthenticity::Anonymous, config)
+}

--- a/crates/verity-p2p/src/gossip/topic.rs
+++ b/crates/verity-p2p/src/gossip/topic.rs
@@ -1,0 +1,167 @@
+//! The gossip topic grammar: `/{prefix}/{network_name}/{topic_name}/{encoding}`.
+//!
+//! Transcribed from leanSpec `node/networking/gossipsub/topic.py`. The `network_name`
+//! segment is opaque here, exactly as it is upstream: the spec supplies it as a caller
+//! string (a fork-digest rendering), and no fork-digest computation exists in the
+//! networking spec to transcribe.
+
+use std::fmt;
+
+use verity_types::SubnetId;
+
+/// First segment of every lean gossip topic.
+pub const TOPIC_PREFIX: &str = "leanconsensus";
+/// Last segment of every lean gossip topic: SSZ payloads, raw-snappy compressed.
+pub const ENCODING_POSTFIX: &str = "ssz_snappy";
+/// Topic-name segment for block gossip.
+pub const BLOCK_TOPIC_NAME: &str = "block";
+/// Topic-name segment for aggregated-attestation gossip.
+pub const AGGREGATION_TOPIC_NAME: &str = "aggregation";
+/// Prefix of the per-subnet attestation topic-name segment, `attestation_{subnet_id}`.
+pub const ATTESTATION_SUBNET_TOPIC_PREFIX: &str = "attestation";
+
+/// Which gossip channel a message belongs to, independent of the network it is on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GossipKind {
+    /// `SignedBlock` gossip.
+    Block,
+    /// `SignedAggregatedAttestation` gossip.
+    Aggregation,
+    /// Per-subnet `SignedAttestation` gossip.
+    Attestation(SubnetId),
+}
+
+impl GossipKind {
+    /// The `topic_name` segment for this kind.
+    fn topic_name(self) -> String {
+        match self {
+            Self::Block => BLOCK_TOPIC_NAME.to_string(),
+            Self::Aggregation => AGGREGATION_TOPIC_NAME.to_string(),
+            Self::Attestation(subnet) => {
+                format!("{ATTESTATION_SUBNET_TOPIC_PREFIX}_{}", subnet.0)
+            }
+        }
+    }
+
+    /// Parses a `topic_name` segment.
+    fn from_topic_name(name: &str) -> Option<Self> {
+        if name == BLOCK_TOPIC_NAME {
+            return Some(Self::Block);
+        }
+        if name == AGGREGATION_TOPIC_NAME {
+            return Some(Self::Aggregation);
+        }
+        let subnet = name
+            .strip_prefix(ATTESTATION_SUBNET_TOPIC_PREFIX)?
+            .strip_prefix('_')?;
+        // Leading zeros or signs would make two spellings of one subnet; refuse them so a
+        // topic string has exactly one parse.
+        if subnet.is_empty() || (subnet.len() > 1 && subnet.starts_with('0')) {
+            return None;
+        }
+        let id: u64 = subnet.parse().ok()?;
+        Some(Self::Attestation(SubnetId(id)))
+    }
+}
+
+/// A fully-qualified gossip topic on one network.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GossipTopic {
+    /// The channel.
+    pub kind: GossipKind,
+    /// The fork-digest segment naming the network.
+    pub network_name: String,
+}
+
+impl GossipTopic {
+    /// Builds the topic for `kind` on the network named `network_name`.
+    #[must_use]
+    pub fn new(kind: GossipKind, network_name: &str) -> Self {
+        Self {
+            kind,
+            network_name: network_name.to_string(),
+        }
+    }
+
+    /// Parses a full topic string. Returns `None` for anything that is not a lean topic —
+    /// including a lean topic on a different network, which the caller distinguishes by
+    /// comparing `network_name`.
+    #[must_use]
+    pub fn parse(topic: &str) -> Option<Self> {
+        let mut segments = topic.strip_prefix('/')?.split('/');
+        let prefix = segments.next()?;
+        let network_name = segments.next()?;
+        let topic_name = segments.next()?;
+        let encoding = segments.next()?;
+        if segments.next().is_some() || prefix != TOPIC_PREFIX || encoding != ENCODING_POSTFIX {
+            return None;
+        }
+        Some(Self {
+            kind: GossipKind::from_topic_name(topic_name)?,
+            network_name: network_name.to_string(),
+        })
+    }
+}
+
+impl fmt::Display for GossipTopic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "/{TOPIC_PREFIX}/{}/{}/{ENCODING_POSTFIX}",
+            self.network_name,
+            self.kind.topic_name()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_format_topics_when_built_from_kinds() {
+        assert_eq!(
+            GossipTopic::new(GossipKind::Block, "12345678").to_string(),
+            "/leanconsensus/12345678/block/ssz_snappy"
+        );
+        assert_eq!(
+            GossipTopic::new(GossipKind::Aggregation, "12345678").to_string(),
+            "/leanconsensus/12345678/aggregation/ssz_snappy"
+        );
+        assert_eq!(
+            GossipTopic::new(GossipKind::Attestation(SubnetId(3)), "12345678").to_string(),
+            "/leanconsensus/12345678/attestation_3/ssz_snappy"
+        );
+    }
+
+    #[test]
+    fn should_round_trip_when_parsing_formatted_topics() {
+        for kind in [
+            GossipKind::Block,
+            GossipKind::Aggregation,
+            GossipKind::Attestation(SubnetId(0)),
+            GossipKind::Attestation(SubnetId(17)),
+        ] {
+            let topic = GossipTopic::new(kind, "0badf00d");
+            let parsed = GossipTopic::parse(&topic.to_string()).expect("round trip");
+            assert_eq!(parsed, topic);
+        }
+    }
+
+    #[test]
+    fn should_reject_topics_when_grammar_is_violated() {
+        for bad in [
+            "leanconsensus/net/block/ssz_snappy",    // missing leading slash
+            "/eth2/net/block/ssz_snappy",            // wrong prefix
+            "/leanconsensus/net/block/ssz",          // wrong encoding
+            "/leanconsensus/net/blocks/ssz_snappy",  // unknown topic name
+            "/leanconsensus/net/block/ssz_snappy/x", // trailing segment
+            "/leanconsensus/net/attestation/ssz_snappy", // subnet-less attestation
+            "/leanconsensus/net/attestation_/ssz_snappy", // empty subnet
+            "/leanconsensus/net/attestation_01/ssz_snappy", // non-canonical subnet
+            "/leanconsensus/net/attestation_-1/ssz_snappy", // signed subnet
+        ] {
+            assert!(GossipTopic::parse(bad).is_none(), "accepted: {bad}");
+        }
+    }
+}

--- a/crates/verity-p2p/src/lib.rs
+++ b/crates/verity-p2p/src/lib.rs
@@ -1,0 +1,124 @@
+//! The I/O Edge network service: leanSpec's wire protocol over upstream libp2p.
+//!
+//! # What belongs here
+//!
+//! The wire protocol and nothing above it. This crate owns the gossip topic grammar, the
+//! gossip message-ID function, both snappy formats, the req/resp framing with its response
+//! codes, and the one long-lived task that drives the libp2p swarm. Payload *meaning* is
+//! deliberately absent: gossip leaves this crate as raw uncompressed SSZ bytes, and block
+//! chunks in req/resp responses cross the API as raw SSZ bytes in both directions. The
+//! network task performs topic checks and deduplication only — no SSZ decode of consensus
+//! containers, no cryptography — so network liveness never waits on a proof
+//! (`docs/design/concurrency.md`, Decision 2).
+//!
+//! The req/resp *envelope* types are the exception, because they are wire protocol, not
+//! consensus payload: [`Status`], [`BlocksByRootRequest`], and [`BlocksByRangeRequest`] are
+//! decoded here — a responder cannot serve a request it cannot read.
+//!
+//! What this crate deliberately does not own, and who does:
+//!
+//! - **Verification and decode of gossip payloads** — the verification stage
+//!   (`docs/design/concurrency.md`, Decision 2). Raw bytes out, `try_send`, drops counted.
+//! - **Peer scoring, sync state machine, request orchestration** — the sync service
+//!   (`docs/design/sync.md`). This crate reports request outcomes; it never judges peers.
+//! - **Answering requests** — whoever owns the data. Inbound requests surface as events
+//!   carrying a response channel; the responder policy (serving window, refusal codes)
+//!   lives with the storage owner, not here.
+//!
+//! # Source
+//!
+//! Wire constants, topic strings, protocol IDs, framing, and the message-ID function are
+//! transcribed from leanSpec `src/lean_spec/node/networking/`, read at commit
+//! `0588c2d215a955a516378677a92db2a5666802f3`. leanSpec is the only authority for the wire
+//! format; where a Verity design document disagrees, leanSpec wins.
+//!
+//! # Example — two nodes on localhost
+//!
+//! ```no_run
+//! use verity_p2p::{
+//!     GossipKind, NetworkConfig, NetworkEvent, Request, Response, Status, identity,
+//! };
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Node A listens on an ephemeral port.
+//! let config_a = NetworkConfig::new(
+//!     identity::Keypair::generate_secp256k1(),
+//!     "/ip4/127.0.0.1/udp/0/quic-v1".parse()?,
+//!     "00000000".to_string(),
+//! );
+//! let (node_a, mut events_a) = verity_p2p::spawn(config_a)?;
+//! let peer_a = node_a.local_peer_id();
+//!
+//! // The bound address (with the real port) arrives as an event; appending `/p2p/<id>`
+//! // makes it dialable.
+//! let listen_a = loop {
+//!     if let Some(NetworkEvent::NewListenAddr(addr)) = events_a.recv().await {
+//!         break addr;
+//!     }
+//! };
+//! let addr_a = listen_a.with_p2p(peer_a).expect("address with peer id");
+//!
+//! // The event stream must be drained continuously, typically in its own task: gossip,
+//! // inbound requests, and connection changes all arrive here, and an inbound request
+//! // that is never answered times out on the peer's side.
+//! tokio::spawn(async move {
+//!     while let Some(event) = events_a.recv().await {
+//!         if let NetworkEvent::InboundRequest { request: Request::Status(_), channel, .. } = event
+//!         {
+//!             let response = Response::Status(Status::default());
+//!             let _ = node_a.respond(channel, response).await;
+//!         }
+//!     }
+//! });
+//!
+//! // Node B boots with A as its bootnode — same network name, or gossip is discarded.
+//! let mut config_b = NetworkConfig::new(
+//!     identity::Keypair::generate_secp256k1(),
+//!     "/ip4/127.0.0.1/udp/0/quic-v1".parse()?,
+//!     "00000000".to_string(),
+//! );
+//! config_b.bootnodes = vec![addr_a];
+//! let (node_b, mut _events_b) = verity_p2p::spawn(config_b)?;
+//!
+//! // Ask A for its status, and publish a block payload (raw SSZ bytes — the caller
+//! // encodes; this crate only compresses). Publishing can fail with
+//! // `PublishError::InsufficientPeers` until the gossip mesh forms; retry on it.
+//! let status = node_b.request(peer_a, Request::Status(Status::default())).await?;
+//! node_b.publish(GossipKind::Block, vec![0u8; 64]).await?;
+//! # Ok(()) }
+//! ```
+//!
+//! # Discovery is out of scope, deliberately
+//!
+//! Peers are reached by dialing configured multiaddrs (bootnodes). leanSpec carries an ENR
+//! module and ethlambda runs discv5, but no Verity design document commits to a discovery
+//! mechanism and a devnet-sized network is fully connected by static configuration.
+//! Revisit trigger: joining a network whose peer set is not known at configuration time.
+
+pub mod behaviour;
+pub mod config;
+pub mod error;
+pub mod gossip;
+pub mod reqresp;
+pub mod service;
+pub mod wire;
+
+pub use behaviour::{Behaviour, BehaviourEvent};
+pub use config::{
+    MAX_ERROR_MESSAGE_SIZE, MAX_PAYLOAD_SIZE, MAX_REQUEST_BLOCKS, MIN_SLOTS_FOR_BLOCK_REQUESTS,
+    NetworkConfig, RESP_TIMEOUT, max_compressed_len,
+};
+pub use error::{BuildError, CommandError, PublishError, RequestError};
+pub use gossip::message_id::{MESSAGE_ID_LEN, compute_message_id, message_id_with_domain};
+pub use gossip::topic::{GossipKind, GossipTopic};
+pub use reqresp::messages::{
+    BlocksByRangeRequest, BlocksByRootRequest, ErrorCode, Protocol, Request, RequestedBlockRoots,
+    Response, Status,
+};
+pub use service::{
+    NetworkCommand, NetworkCounters, NetworkEvent, NetworkHandle, ResponseChannel, spawn,
+};
+
+// Re-exported so consumers can name addresses and peers without depending on libp2p
+// directly; the version is pinned once, in the workspace manifest.
+pub use libp2p::{Multiaddr, PeerId, identity};

--- a/crates/verity-p2p/src/reqresp/codec.rs
+++ b/crates/verity-p2p/src/reqresp/codec.rs
@@ -1,0 +1,425 @@
+//! The req/resp stream codec: varint-prefixed, snappy-framed SSZ chunks.
+//!
+//! Wire shapes, from leanSpec `node/networking/reqresp/codec.py`:
+//!
+//! ```text
+//! request        := [varint: uncompressed length][snappy-framed SSZ payload]
+//! response chunk := [response code: 1 byte][varint: uncompressed length][snappy-framed payload]
+//! ```
+//!
+//! A `Status` response is exactly one chunk. A blocks response is zero or more `SUCCESS`
+//! chunks — one raw SSZ `SignedBlock` each — terminated by the end of the stream, or cut
+//! short by a single error chunk. Every declared length is capped before any allocation:
+//! the caps are what stand between a hostile length claim and memory.
+
+use std::io;
+
+use async_trait::async_trait;
+use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use libp2p::request_response;
+use libssz::{SszDecode, SszEncode};
+
+use crate::config::{MAX_ERROR_MESSAGE_SIZE, MAX_PAYLOAD_SIZE, MAX_REQUEST_BLOCKS};
+use crate::reqresp::messages::{ErrorCode, Protocol, RESPONSE_CODE_SUCCESS, Request, Response};
+use crate::wire::snappy::{compress_framed, read_framed};
+use crate::wire::varint::{read_varint, write_varint};
+
+/// Largest legal SSZ encoding of each request, used as the read cap: 80 bytes of
+/// `Status`, a 4-byte offset plus 32 bytes per root for `BlocksByRootRequest`, and two
+/// fixed `uint64` fields for `BlocksByRangeRequest`.
+const fn max_request_len(protocol: Protocol) -> usize {
+    match protocol {
+        Protocol::Status => 80,
+        Protocol::BlocksByRoot => 4 + 32 * MAX_REQUEST_BLOCKS,
+        Protocol::BlocksByRange => 16,
+    }
+}
+
+/// The stream codec shared by the three per-protocol behaviours; the negotiated protocol
+/// arrives as an argument and selects the envelope type.
+#[derive(Debug, Clone, Default)]
+pub struct Codec;
+
+#[async_trait]
+impl request_response::Codec for Codec {
+    type Protocol = Protocol;
+    type Request = Request;
+    type Response = Response;
+
+    async fn read_request<T>(&mut self, protocol: &Protocol, io: &mut T) -> io::Result<Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let payload = read_chunk_payload(io, max_request_len(*protocol)).await?;
+        match protocol {
+            Protocol::Status => Ok(Request::Status(decode_ssz(&payload)?)),
+            Protocol::BlocksByRoot => Ok(Request::BlocksByRoot(decode_ssz(&payload)?)),
+            Protocol::BlocksByRange => Ok(Request::BlocksByRange(decode_ssz(&payload)?)),
+        }
+    }
+
+    async fn read_response<T>(&mut self, protocol: &Protocol, io: &mut T) -> io::Result<Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        match protocol {
+            Protocol::Status => read_status_response(io).await,
+            Protocol::BlocksByRoot | Protocol::BlocksByRange => read_blocks_response(io).await,
+        }
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        protocol: &Protocol,
+        io: &mut T,
+        request: Request,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        if request.protocol() != *protocol {
+            return Err(io::Error::other("request variant does not match protocol"));
+        }
+        let ssz = match &request {
+            Request::Status(status) => status.to_ssz(),
+            Request::BlocksByRoot(roots) => roots.to_ssz(),
+            Request::BlocksByRange(range) => range.to_ssz(),
+        };
+        io.write_all(&encode_chunk_payload(&ssz)?).await
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        protocol: &Protocol,
+        io: &mut T,
+        response: Response,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        let wire = encode_response(*protocol, &response)?;
+        io.write_all(&wire).await
+    }
+}
+
+/// Encodes one chunk payload: varint of the uncompressed length, then the framed bytes.
+fn encode_chunk_payload(payload: &[u8]) -> io::Result<Vec<u8>> {
+    let mut wire = Vec::new();
+    write_varint(&mut wire, payload.len() as u64);
+    wire.extend_from_slice(&compress_framed(payload)?);
+    Ok(wire)
+}
+
+/// Reads one chunk payload, refusing a declared length above `max` before reading a
+/// single frame.
+async fn read_chunk_payload<T>(io: &mut T, max: usize) -> io::Result<Vec<u8>>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let declared = read_varint(io).await?;
+    if declared > max as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "chunk declares a length above the protocol cap",
+        ));
+    }
+    // The cap fits in usize on every supported target, so the narrowing is checked once.
+    let declared = usize::try_from(declared)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "length beyond addressable"))?;
+    read_framed(io, declared).await
+}
+
+/// Reads the single chunk of a `Status` response.
+async fn read_status_response<T>(io: &mut T) -> io::Result<Response>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let mut code = [0u8; 1];
+    io.read_exact(&mut code).await?;
+    match ErrorCode::from_byte(code[0]) {
+        None => {
+            let payload = read_chunk_payload(io, max_request_len(Protocol::Status)).await?;
+            Ok(Response::Status(decode_ssz(&payload)?))
+        }
+        Some(code) => read_error_chunk(io, code).await,
+    }
+}
+
+/// Reads a blocks response: `SUCCESS` chunks until end-of-stream, or one error chunk.
+async fn read_blocks_response<T>(io: &mut T) -> io::Result<Response>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let mut chunks: Vec<Vec<u8>> = Vec::new();
+    loop {
+        let mut code = [0u8; 1];
+        if io.read(&mut code).await? == 0 {
+            return Ok(Response::Blocks(chunks));
+        }
+        match ErrorCode::from_byte(code[0]) {
+            None => {
+                if chunks.len() == MAX_REQUEST_BLOCKS {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "more response chunks than MAX_REQUEST_BLOCKS",
+                    ));
+                }
+                chunks.push(read_chunk_payload(io, MAX_PAYLOAD_SIZE).await?);
+            }
+            Some(code) => return read_error_chunk(io, code).await,
+        }
+    }
+}
+
+/// Reads the message chunk of an error response.
+async fn read_error_chunk<T>(io: &mut T, code: ErrorCode) -> io::Result<Response>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let payload = read_chunk_payload(io, MAX_ERROR_MESSAGE_SIZE).await?;
+    Ok(Response::Error {
+        code,
+        // Untrusted peer text destined for logs: lossy decoding cannot fail and cannot
+        // grow past the already-enforced byte cap.
+        message: String::from_utf8_lossy(&payload).into_owned(),
+    })
+}
+
+/// Encodes a whole response for the stream, enforcing protocol/variant coherence and the
+/// responder-side caps.
+fn encode_response(protocol: Protocol, response: &Response) -> io::Result<Vec<u8>> {
+    match (protocol, response) {
+        (Protocol::Status, Response::Status(status)) => {
+            let mut wire = vec![RESPONSE_CODE_SUCCESS];
+            wire.extend_from_slice(&encode_chunk_payload(&status.to_ssz())?);
+            Ok(wire)
+        }
+        (Protocol::BlocksByRoot | Protocol::BlocksByRange, Response::Blocks(chunks)) => {
+            if chunks.len() > MAX_REQUEST_BLOCKS {
+                return Err(io::Error::other(
+                    "more block chunks than MAX_REQUEST_BLOCKS",
+                ));
+            }
+            let mut wire = Vec::new();
+            for chunk in chunks {
+                if chunk.len() > MAX_PAYLOAD_SIZE {
+                    return Err(io::Error::other("block chunk above the payload cap"));
+                }
+                wire.push(RESPONSE_CODE_SUCCESS);
+                wire.extend_from_slice(&encode_chunk_payload(chunk)?);
+            }
+            Ok(wire)
+        }
+        (_, Response::Error { code, message }) => {
+            if message.len() > MAX_ERROR_MESSAGE_SIZE {
+                return Err(io::Error::other("error message above the message cap"));
+            }
+            let mut wire = vec![code.as_byte()];
+            wire.extend_from_slice(&encode_chunk_payload(message.as_bytes())?);
+            Ok(wire)
+        }
+        (Protocol::Status, Response::Blocks(_))
+        | (Protocol::BlocksByRoot | Protocol::BlocksByRange, Response::Status(_)) => {
+            Err(io::Error::other("response variant does not match protocol"))
+        }
+    }
+}
+
+/// Decodes an SSZ payload, mapping the failure onto the codec's error space.
+fn decode_ssz<V: SszDecode>(payload: &[u8]) -> io::Result<V> {
+    V::from_ssz_bytes(payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("ssz: {e:?}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+    use futures::io::Cursor;
+    use libssz_types::SszList;
+    use request_response::Codec as _;
+    use verity_types::{Checkpoint, Slot};
+
+    use super::*;
+    use crate::reqresp::messages::{BlocksByRangeRequest, BlocksByRootRequest, Status};
+
+    fn sample_status() -> Status {
+        Status {
+            finalized: Checkpoint {
+                root: [3u8; 32],
+                slot: Slot(100),
+            },
+            head: Checkpoint {
+                root: [4u8; 32],
+                slot: Slot(140),
+            },
+        }
+    }
+
+    fn round_trip_request(protocol: Protocol, request: Request) -> Request {
+        block_on(async {
+            let mut wire = Cursor::new(Vec::new());
+            Codec
+                .write_request(&protocol, &mut wire, request)
+                .await
+                .expect("write");
+            let mut wire = Cursor::new(wire.into_inner());
+            Codec
+                .read_request(&protocol, &mut wire)
+                .await
+                .expect("read")
+        })
+    }
+
+    fn round_trip_response(protocol: Protocol, response: Response) -> Response {
+        block_on(async {
+            let mut wire = Cursor::new(Vec::new());
+            Codec
+                .write_response(&protocol, &mut wire, response)
+                .await
+                .expect("write");
+            let mut wire = Cursor::new(wire.into_inner());
+            Codec
+                .read_response(&protocol, &mut wire)
+                .await
+                .expect("read")
+        })
+    }
+
+    #[test]
+    fn should_round_trip_every_request_kind() {
+        let status = Request::Status(sample_status());
+        assert_eq!(round_trip_request(Protocol::Status, status.clone()), status);
+
+        let roots = Request::BlocksByRoot(BlocksByRootRequest {
+            roots: SszList::try_from(vec![[7u8; 32], [8u8; 32]]).expect("within limit"),
+        });
+        assert_eq!(
+            round_trip_request(Protocol::BlocksByRoot, roots.clone()),
+            roots
+        );
+
+        let range = Request::BlocksByRange(BlocksByRangeRequest {
+            start_slot: Slot(42),
+            count: 512,
+        });
+        assert_eq!(
+            round_trip_request(Protocol::BlocksByRange, range.clone()),
+            range
+        );
+    }
+
+    #[test]
+    fn should_round_trip_status_and_blocks_responses() {
+        let status = Response::Status(sample_status());
+        assert_eq!(
+            round_trip_response(Protocol::Status, status.clone()),
+            status
+        );
+
+        let blocks = Response::Blocks(vec![vec![1u8; 300], vec![2u8; 4096], Vec::new()]);
+        assert_eq!(
+            round_trip_response(Protocol::BlocksByRange, blocks.clone()),
+            blocks
+        );
+
+        let empty = Response::Blocks(Vec::new());
+        assert_eq!(
+            round_trip_response(Protocol::BlocksByRoot, empty.clone()),
+            empty
+        );
+    }
+
+    #[test]
+    fn should_round_trip_error_responses_on_every_protocol() {
+        for protocol in [
+            Protocol::Status,
+            Protocol::BlocksByRoot,
+            Protocol::BlocksByRange,
+        ] {
+            let error = Response::Error {
+                code: ErrorCode::ResourceUnavailable,
+                message: "below the serving window".to_string(),
+            };
+            assert_eq!(round_trip_response(protocol, error.clone()), error);
+        }
+    }
+
+    #[test]
+    fn should_reject_write_when_variant_does_not_match_protocol() {
+        block_on(async {
+            let mut wire = Cursor::new(Vec::new());
+            let result = Codec
+                .write_request(
+                    &Protocol::Status,
+                    &mut wire,
+                    Request::BlocksByRange(BlocksByRangeRequest::default()),
+                )
+                .await;
+            assert!(result.is_err());
+
+            let mut wire = Cursor::new(Vec::new());
+            let result = Codec
+                .write_response(&Protocol::Status, &mut wire, Response::Blocks(Vec::new()))
+                .await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn should_reject_request_when_declared_length_exceeds_protocol_cap() {
+        block_on(async {
+            // A Status request claiming 81 bytes: over the 80-byte cap, refused before
+            // any frame is read.
+            let mut wire = Vec::new();
+            write_varint(&mut wire, 81);
+            let mut wire = Cursor::new(wire);
+            let err = Codec
+                .read_request(&Protocol::Status, &mut wire)
+                .await
+                .expect_err("over cap");
+            assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        });
+    }
+
+    #[test]
+    fn should_degrade_unknown_error_codes_when_reading_responses() {
+        block_on(async {
+            let mut wire = vec![0x7f]; // unknown code in the server-error range
+            wire.extend_from_slice(&encode_chunk_payload(b"boom").expect("encode"));
+            let mut wire = Cursor::new(wire);
+            let response = Codec
+                .read_response(&Protocol::Status, &mut wire)
+                .await
+                .expect("read");
+            assert_eq!(
+                response,
+                Response::Error {
+                    code: ErrorCode::ServerError,
+                    message: "boom".to_string(),
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn should_stop_at_error_chunk_when_blocks_stream_fails_midway() {
+        block_on(async {
+            let mut wire = vec![RESPONSE_CODE_SUCCESS];
+            wire.extend_from_slice(&encode_chunk_payload(&[9u8; 64]).expect("encode"));
+            wire.push(ErrorCode::ServerError.as_byte());
+            wire.extend_from_slice(&encode_chunk_payload(b"lost the database").expect("encode"));
+            let mut wire = Cursor::new(wire);
+            let response = Codec
+                .read_response(&Protocol::BlocksByRange, &mut wire)
+                .await
+                .expect("read");
+            assert_eq!(
+                response,
+                Response::Error {
+                    code: ErrorCode::ServerError,
+                    message: "lost the database".to_string(),
+                }
+            );
+        });
+    }
+}

--- a/crates/verity-p2p/src/reqresp/messages.rs
+++ b/crates/verity-p2p/src/reqresp/messages.rs
@@ -1,0 +1,211 @@
+//! The req/resp envelope types: protocol IDs, request containers, and response shapes.
+//!
+//! Container shapes transcribe leanSpec `node/networking/reqresp/message.py` field for
+//! field, in leanSpec's order. Blocks inside responses are NOT decoded here — a chunk
+//! crosses this crate as raw SSZ bytes, and the sync service decodes and structurally
+//! validates it (`docs/design/sync.md`, Decision 2).
+
+use libssz_derive::{HashTreeRoot, SszDecode, SszEncode};
+use libssz_types::SszList;
+use verity_types::{Bytes32, Checkpoint, Slot};
+
+use crate::config::MAX_REQUEST_BLOCKS;
+
+/// Protocol ID for the status handshake.
+pub const STATUS_PROTOCOL_V1: &str = "/leanconsensus/req/status/1/ssz_snappy";
+/// Protocol ID for requesting blocks by root.
+pub const BLOCKS_BY_ROOT_PROTOCOL_V1: &str = "/leanconsensus/req/blocks_by_root/1/ssz_snappy";
+/// Protocol ID for requesting a slot range of blocks.
+pub const BLOCKS_BY_RANGE_PROTOCOL_V1: &str = "/leanconsensus/req/blocks_by_range/1/ssz_snappy";
+
+/// The three req/resp protocols, each negotiated by its own behaviour instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Protocol {
+    /// The status handshake.
+    Status,
+    /// Blocks by root.
+    BlocksByRoot,
+    /// Blocks by slot range.
+    BlocksByRange,
+}
+
+impl AsRef<str> for Protocol {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Status => STATUS_PROTOCOL_V1,
+            Self::BlocksByRoot => BLOCKS_BY_ROOT_PROTOCOL_V1,
+            Self::BlocksByRange => BLOCKS_BY_RANGE_PROTOCOL_V1,
+        }
+    }
+}
+
+/// The status handshake payload: the sender's finalized and head checkpoints. 80 bytes,
+/// deliberately validator-set-free.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, SszEncode, SszDecode, HashTreeRoot)]
+pub struct Status {
+    /// The sender's latest finalized checkpoint.
+    pub finalized: Checkpoint,
+    /// The sender's current head.
+    pub head: Checkpoint,
+}
+
+/// The roots list inside a [`BlocksByRootRequest`].
+pub type RequestedBlockRoots = SszList<Bytes32, MAX_REQUEST_BLOCKS>;
+
+/// Request for specific blocks by their roots. Missing roots are skipped silently —
+/// a partial response is legal.
+#[derive(Debug, Clone, Default, PartialEq, Eq, SszEncode, SszDecode, HashTreeRoot)]
+pub struct BlocksByRootRequest {
+    /// The roots requested.
+    pub roots: RequestedBlockRoots,
+}
+
+/// Request for a contiguous slot range of blocks. leanSpec omits the legacy `step` field:
+/// the stride is always one slot.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, SszEncode, SszDecode, HashTreeRoot)]
+pub struct BlocksByRangeRequest {
+    /// First slot of the range.
+    pub start_slot: Slot,
+    /// Number of slots covered, at most [`MAX_REQUEST_BLOCKS`].
+    pub count: u64,
+}
+
+/// An outbound or inbound request, tagged by protocol.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Request {
+    /// A status handshake.
+    Status(Status),
+    /// A blocks-by-root request.
+    BlocksByRoot(BlocksByRootRequest),
+    /// A blocks-by-range request.
+    BlocksByRange(BlocksByRangeRequest),
+}
+
+impl Request {
+    /// The protocol this request travels on, hence the behaviour that must send it.
+    #[must_use]
+    pub fn protocol(&self) -> Protocol {
+        match self {
+            Self::Status(_) => Protocol::Status,
+            Self::BlocksByRoot(_) => Protocol::BlocksByRoot,
+            Self::BlocksByRange(_) => Protocol::BlocksByRange,
+        }
+    }
+}
+
+/// A response, either the protocol's success payload or the peer's error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Response {
+    /// The responder's status, answering a status handshake.
+    Status(Status),
+    /// Block chunks answering a blocks request, one raw SSZ `SignedBlock` each, in the
+    /// order the responder sent them. Possibly empty — an empty response is how a
+    /// responder says "none of those roots" or "no blocks in that range".
+    Blocks(Vec<Vec<u8>>),
+    /// The peer refused or failed the request.
+    Error {
+        /// The response code, never `SUCCESS`.
+        code: ErrorCode,
+        /// The peer's human-readable explanation. Bounded, possibly empty, and
+        /// untrusted — for logs only.
+        message: String,
+    },
+}
+
+/// Non-success response codes.
+///
+/// `RESOURCE_UNAVAILABLE` deserves its asymmetry: it is the *legal* answer for history
+/// below the serving window, and the sync service's scoring table treats it as neutral
+/// (`docs/design/sync.md`, Decision 3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    /// The request was malformed or out of bounds.
+    InvalidRequest,
+    /// The responder failed internally.
+    ServerError,
+    /// The responder does not have the requested data.
+    ResourceUnavailable,
+}
+
+/// The wire byte of the success response code.
+pub const RESPONSE_CODE_SUCCESS: u8 = 0;
+
+impl ErrorCode {
+    /// The wire byte of this code.
+    #[must_use]
+    pub fn as_byte(self) -> u8 {
+        match self {
+            Self::InvalidRequest => 1,
+            Self::ServerError => 2,
+            Self::ResourceUnavailable => 3,
+        }
+    }
+
+    /// Classifies a non-success wire byte, degrading gracefully exactly as leanSpec's
+    /// codec does: unknown codes 4–127 read as a server error, 128–255 as an invalid
+    /// request.
+    ///
+    /// Returns `None` for [`RESPONSE_CODE_SUCCESS`], which is not an error.
+    #[must_use]
+    pub fn from_byte(byte: u8) -> Option<Self> {
+        match byte {
+            RESPONSE_CODE_SUCCESS => None,
+            1 => Some(Self::InvalidRequest),
+            2 => Some(Self::ServerError),
+            3 => Some(Self::ResourceUnavailable),
+            4..=127 => Some(Self::ServerError),
+            128..=255 => Some(Self::InvalidRequest),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libssz::{SszDecode, SszEncode};
+
+    use super::*;
+
+    #[test]
+    fn should_encode_status_as_eighty_bytes() {
+        let status = Status {
+            finalized: Checkpoint {
+                root: [1u8; 32],
+                slot: Slot(9),
+            },
+            head: Checkpoint {
+                root: [2u8; 32],
+                slot: Slot(12),
+            },
+        };
+        let bytes = status.to_ssz();
+        assert_eq!(bytes.len(), 80);
+        assert_eq!(Status::from_ssz_bytes(&bytes).expect("round trip"), status);
+    }
+
+    #[test]
+    fn should_round_trip_blocks_by_range_request() {
+        let request = BlocksByRangeRequest {
+            start_slot: Slot(3600),
+            count: 64,
+        };
+        let bytes = request.to_ssz();
+        assert_eq!(bytes.len(), 16);
+        assert_eq!(
+            BlocksByRangeRequest::from_ssz_bytes(&bytes).expect("round trip"),
+            request
+        );
+    }
+
+    #[test]
+    fn should_degrade_unknown_response_codes_as_leanspec_does() {
+        assert_eq!(ErrorCode::from_byte(0), None);
+        assert_eq!(ErrorCode::from_byte(1), Some(ErrorCode::InvalidRequest));
+        assert_eq!(ErrorCode::from_byte(2), Some(ErrorCode::ServerError));
+        assert_eq!(
+            ErrorCode::from_byte(3),
+            Some(ErrorCode::ResourceUnavailable)
+        );
+        assert_eq!(ErrorCode::from_byte(64), Some(ErrorCode::ServerError));
+        assert_eq!(ErrorCode::from_byte(200), Some(ErrorCode::InvalidRequest));
+    }
+}

--- a/crates/verity-p2p/src/reqresp/mod.rs
+++ b/crates/verity-p2p/src/reqresp/mod.rs
@@ -1,0 +1,26 @@
+//! Req/resp: the three lean protocols, their envelope types, and the stream codec.
+
+pub mod codec;
+pub mod messages;
+
+use libp2p::request_response::{self, ProtocolSupport};
+
+use crate::config::RESP_TIMEOUT;
+use crate::reqresp::codec::Codec;
+use crate::reqresp::messages::Protocol;
+
+/// One `request_response::Behaviour` per protocol, on purpose.
+///
+/// Upstream libp2p offers every protocol a behaviour registers when it opens an outbound
+/// stream, and the *responder* picks — so a single behaviour carrying all three protocols
+/// could send a `Status` request down a `blocks_by_range` stream. ethlambda solved this
+/// by forking libp2p; Verity's kickoff decision (fork only on concrete, unavoidable need)
+/// is satisfied without one: a behaviour that registers exactly one protocol can only
+/// negotiate that protocol, and choosing the behaviour chooses the protocol.
+pub fn build_behaviour(protocol: Protocol) -> request_response::Behaviour<Codec> {
+    request_response::Behaviour::with_codec(
+        Codec,
+        [(protocol, ProtocolSupport::Full)],
+        request_response::Config::default().with_request_timeout(RESP_TIMEOUT),
+    )
+}

--- a/crates/verity-p2p/src/service.rs
+++ b/crates/verity-p2p/src/service.rs
@@ -1,0 +1,511 @@
+//! The network task: one tokio task owning the swarm, commands in, events out.
+//!
+//! This is the "network task" of `docs/design/concurrency.md` Decision 2. Its inbound
+//! contract is deliberately minimal — topic check and deduplication only, then `try_send`
+//! of raw bytes — so that network liveness (mesh maintenance, keep-alives) never waits on
+//! anything downstream. The event channel is the single drop point of the inbound
+//! pipeline: when it is full, raw gossip is dropped and counted, never awaited.
+//!
+//! Shutdown follows the lifecycle rule that channel closure is the only signal: dropping
+//! every [`NetworkHandle`] (and the command senders inside pending requests) closes the
+//! command channel, the task breaks out of its loop, and dropping its event sender closes
+//! the event stream for downstream consumers.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use futures::StreamExt;
+use libp2p::gossipsub::{self, IdentTopic};
+use libp2p::request_response::{self, OutboundRequestId};
+use libp2p::swarm::SwarmEvent;
+use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::behaviour::{Behaviour, BehaviourEvent};
+use crate::config::{MAX_PAYLOAD_SIZE, NetworkConfig};
+use crate::error::{BuildError, CommandError, PublishError, RequestError};
+use crate::gossip::topic::{GossipKind, GossipTopic};
+use crate::reqresp::messages::{Protocol, Request, Response};
+use crate::wire::snappy::{compress_block, decompress_block};
+
+/// The channel on which an inbound request awaits its response. Carried inside
+/// [`NetworkEvent::InboundRequest`] and returned through [`NetworkHandle::respond`].
+pub type ResponseChannel = request_response::ResponseChannel<Response>;
+
+/// Commands into the network task.
+pub enum NetworkCommand {
+    /// Dial a peer at an address.
+    Dial {
+        /// The address to dial, e.g. `/ip4/10.0.0.1/udp/9000/quic-v1/p2p/16Uiu...`.
+        address: Multiaddr,
+        /// Resolves once the dial is initiated (not established).
+        reply: oneshot::Sender<Result<(), CommandError>>,
+    },
+    /// Publish uncompressed SSZ bytes on a gossip channel.
+    Publish {
+        /// The gossip channel.
+        kind: GossipKind,
+        /// The uncompressed SSZ payload; this crate compresses it.
+        payload: Vec<u8>,
+        /// Resolves with the publish outcome.
+        reply: oneshot::Sender<Result<(), PublishError>>,
+    },
+    /// Send a req/resp request to a peer.
+    SendRequest {
+        /// The peer to ask. Must be connected or dialable by its known addresses.
+        peer: PeerId,
+        /// The request; its variant selects the protocol.
+        request: Request,
+        /// Resolves with the peer's response or the transport failure.
+        reply: oneshot::Sender<Result<Response, RequestError>>,
+    },
+    /// Answer an inbound request received via [`NetworkEvent::InboundRequest`].
+    Respond {
+        /// The channel that arrived with the request.
+        channel: ResponseChannel,
+        /// The response to send.
+        response: Response,
+    },
+}
+
+/// Events out of the network task.
+///
+/// The receiver returned by [`spawn`] must be drained continuously — typically by a
+/// dedicated task looping on `recv()`. Gossip, inbound requests, and connection changes
+/// all arrive here; a consumer that stops receiving stops answering peers, and a full
+/// event channel sheds gossip (by design) and then other events (counted).
+#[derive(Debug)]
+pub enum NetworkEvent {
+    /// The swarm bound a listen address. With port 0 in the configuration, this is where
+    /// the actual port becomes known.
+    NewListenAddr(Multiaddr),
+    /// First connection to a peer established.
+    PeerConnected(PeerId),
+    /// Last connection to a peer closed.
+    PeerDisconnected(PeerId),
+    /// A gossip message on a subscribed topic of this network, decompressed. Raw SSZ
+    /// bytes — decoding and verification happen downstream, never here.
+    Gossip {
+        /// The gossip channel the message arrived on.
+        kind: GossipKind,
+        /// The uncompressed SSZ payload.
+        payload: Vec<u8>,
+    },
+    /// A peer sent a request; answer it via [`NetworkHandle::respond`]. Dropping the
+    /// channel instead lets the peer's request time out.
+    InboundRequest {
+        /// The requesting peer.
+        peer: PeerId,
+        /// The decoded request envelope.
+        request: Request,
+        /// Where the response goes.
+        channel: ResponseChannel,
+    },
+}
+
+/// Drop and failure counters, shared between the task and its handle. The wiring point
+/// for `verity-metrics` once it exists; until then the counts are at least observable.
+#[derive(Debug, Default)]
+pub struct NetworkCounters {
+    gossip_dropped: AtomicU64,
+    gossip_invalid: AtomicU64,
+    events_dropped: AtomicU64,
+}
+
+impl NetworkCounters {
+    /// Gossip messages dropped because the event channel was full — the pipeline's one
+    /// deliberate load-shedding point.
+    pub fn gossip_dropped(&self) -> u64 {
+        self.gossip_dropped.load(Ordering::Relaxed)
+    }
+
+    /// Gossip messages discarded as undecodable: foreign or malformed topic, wrong
+    /// network, or failed decompression. Counted, never peer-punished
+    /// (`docs/design/sync.md`, Decision 3).
+    pub fn gossip_invalid(&self) -> u64 {
+        self.gossip_invalid.load(Ordering::Relaxed)
+    }
+
+    /// Non-gossip events dropped on a full event channel.
+    pub fn events_dropped(&self) -> u64 {
+        self.events_dropped.load(Ordering::Relaxed)
+    }
+}
+
+/// Cloneable handle for talking to the network task.
+#[derive(Clone)]
+pub struct NetworkHandle {
+    commands: mpsc::Sender<NetworkCommand>,
+    local_peer_id: PeerId,
+    counters: Arc<NetworkCounters>,
+}
+
+impl NetworkHandle {
+    /// The local peer ID derived from the configured keypair.
+    #[must_use]
+    pub fn local_peer_id(&self) -> PeerId {
+        self.local_peer_id
+    }
+
+    /// The task's drop and failure counters.
+    #[must_use]
+    pub fn counters(&self) -> Arc<NetworkCounters> {
+        Arc::clone(&self.counters)
+    }
+
+    /// Dials a peer. Resolves when the dial is initiated; the connection itself is
+    /// reported later as [`NetworkEvent::PeerConnected`].
+    pub async fn dial(&self, address: Multiaddr) -> Result<(), CommandError> {
+        let (reply, response) = oneshot::channel();
+        self.commands
+            .send(NetworkCommand::Dial { address, reply })
+            .await
+            .map_err(|_| CommandError::ServiceStopped)?;
+        response.await.map_err(|_| CommandError::ServiceStopped)?
+    }
+
+    /// Publishes uncompressed SSZ bytes on a gossip channel.
+    pub async fn publish(&self, kind: GossipKind, payload: Vec<u8>) -> Result<(), PublishError> {
+        let (reply, response) = oneshot::channel();
+        self.commands
+            .send(NetworkCommand::Publish {
+                kind,
+                payload,
+                reply,
+            })
+            .await
+            .map_err(|_| PublishError::ServiceStopped)?;
+        response.await.map_err(|_| PublishError::ServiceStopped)?
+    }
+
+    /// Sends a request and awaits the peer's response.
+    pub async fn request(&self, peer: PeerId, request: Request) -> Result<Response, RequestError> {
+        let (reply, response) = oneshot::channel();
+        self.commands
+            .send(NetworkCommand::SendRequest {
+                peer,
+                request,
+                reply,
+            })
+            .await
+            .map_err(|_| RequestError::ServiceStopped)?;
+        response.await.map_err(|_| RequestError::ServiceStopped)?
+    }
+
+    /// Answers an inbound request.
+    pub async fn respond(
+        &self,
+        channel: ResponseChannel,
+        response: Response,
+    ) -> Result<(), CommandError> {
+        self.commands
+            .send(NetworkCommand::Respond { channel, response })
+            .await
+            .map_err(|_| CommandError::ServiceStopped)
+    }
+}
+
+/// Builds the swarm, subscribes the configured topics, dials the bootnodes, and spawns
+/// the network task. Returns the handle and the event stream.
+pub fn spawn(
+    config: NetworkConfig,
+) -> Result<(NetworkHandle, mpsc::Receiver<NetworkEvent>), BuildError> {
+    let mut swarm = build_swarm(&config)?;
+    let local_peer_id = *swarm.local_peer_id();
+
+    swarm
+        .listen_on(config.listen.clone())
+        .map_err(|e| BuildError::Listen(e.to_string()))?;
+    subscribe_topics(&mut swarm, &config)?;
+    for bootnode in &config.bootnodes {
+        swarm
+            .dial(bootnode.clone())
+            .map_err(|e| BuildError::Bootnode(format!("{bootnode}: {e}")))?;
+    }
+
+    let (command_tx, command_rx) = mpsc::channel(config.command_buffer);
+    let (event_tx, event_rx) = mpsc::channel(config.event_buffer);
+    let counters = Arc::new(NetworkCounters::default());
+
+    let service = Service {
+        swarm,
+        commands: command_rx,
+        events: event_tx,
+        pending: HashMap::new(),
+        network_name: config.network_name,
+        counters: Arc::clone(&counters),
+    };
+    tokio::spawn(service.run());
+
+    Ok((
+        NetworkHandle {
+            commands: command_tx,
+            local_peer_id,
+            counters,
+        },
+        event_rx,
+    ))
+}
+
+/// Builds the QUIC swarm. Transport security and multiplexing come from QUIC itself —
+/// no separate noise or yamux layer, matching leanSpec's transport stack.
+fn build_swarm(config: &NetworkConfig) -> Result<Swarm<Behaviour>, BuildError> {
+    let swarm = SwarmBuilder::with_existing_identity(config.keypair.clone())
+        .with_tokio()
+        .with_quic()
+        .with_behaviour(|key| {
+            Behaviour::new(key.public())
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })
+        })
+        .map_err(|e| BuildError::Behaviour(e.to_string()))?
+        .with_swarm_config(|c| {
+            // Consensus connections are long-lived by design; without this, libp2p's
+            // idle timeout would sever a healthy but momentarily quiet peer.
+            c.with_idle_connection_timeout(Duration::from_secs(24 * 60 * 60))
+        })
+        .build();
+    Ok(swarm)
+}
+
+/// Subscribes the always-on block and aggregation topics plus the configured attestation
+/// subnets.
+fn subscribe_topics(
+    swarm: &mut Swarm<Behaviour>,
+    config: &NetworkConfig,
+) -> Result<(), BuildError> {
+    let mut kinds = vec![GossipKind::Block, GossipKind::Aggregation];
+    kinds.extend(
+        config
+            .attestation_subnets
+            .iter()
+            .map(|subnet| GossipKind::Attestation(*subnet)),
+    );
+    for kind in kinds {
+        let topic = GossipTopic::new(kind, &config.network_name);
+        swarm
+            .behaviour_mut()
+            .gossipsub
+            .subscribe(&IdentTopic::new(topic.to_string()))
+            .map_err(|e| BuildError::Behaviour(format!("subscribing {topic}: {e:?}")))?;
+    }
+    Ok(())
+}
+
+/// The state owned by the network task.
+struct Service {
+    swarm: Swarm<Behaviour>,
+    commands: mpsc::Receiver<NetworkCommand>,
+    events: mpsc::Sender<NetworkEvent>,
+    /// Outbound requests awaiting a response. Keyed by protocol as well as ID because
+    /// each per-protocol behaviour numbers its requests independently.
+    pending:
+        HashMap<(Protocol, OutboundRequestId), oneshot::Sender<Result<Response, RequestError>>>,
+    network_name: String,
+    counters: Arc<NetworkCounters>,
+}
+
+impl Service {
+    async fn run(mut self) {
+        loop {
+            tokio::select! {
+                // Commands first: the node's own work (duty products, sync requests)
+                // ahead of any volume of network input, mirroring the chain task's bias.
+                biased;
+                command = self.commands.recv() => match command {
+                    Some(command) => self.handle_command(command),
+                    // Every handle dropped: shutdown. Pending oneshots drop with the
+                    // task, resolving their awaiters to ServiceStopped.
+                    None => break,
+                },
+                event = self.swarm.select_next_some() => self.handle_swarm_event(event),
+            }
+        }
+    }
+
+    fn handle_command(&mut self, command: NetworkCommand) {
+        match command {
+            NetworkCommand::Dial { address, reply } => {
+                let result = self
+                    .swarm
+                    .dial(address)
+                    .map_err(|e| CommandError::Failed(e.to_string()));
+                let _ = reply.send(result);
+            }
+            NetworkCommand::Publish {
+                kind,
+                payload,
+                reply,
+            } => {
+                let _ = reply.send(self.publish(kind, &payload));
+            }
+            NetworkCommand::SendRequest {
+                peer,
+                request,
+                reply,
+            } => {
+                let protocol = request.protocol();
+                let behaviour = self.swarm.behaviour_mut();
+                let id = match protocol {
+                    Protocol::Status => behaviour.status.send_request(&peer, request),
+                    Protocol::BlocksByRoot => behaviour.blocks_by_root.send_request(&peer, request),
+                    Protocol::BlocksByRange => {
+                        behaviour.blocks_by_range.send_request(&peer, request)
+                    }
+                };
+                self.pending.insert((protocol, id), reply);
+            }
+            NetworkCommand::Respond { channel, response } => {
+                // `send_response` only feeds the channel that arrived with the request;
+                // which behaviour instance relays it is immaterial, so the status
+                // behaviour serves all three protocols here. A `Err` return means the
+                // inbound stream already timed out — nothing to do but let it go.
+                let _ = self
+                    .swarm
+                    .behaviour_mut()
+                    .status
+                    .send_response(channel, response);
+            }
+        }
+    }
+
+    fn publish(&mut self, kind: GossipKind, payload: &[u8]) -> Result<(), PublishError> {
+        if payload.len() > MAX_PAYLOAD_SIZE {
+            return Err(PublishError::PayloadTooLarge);
+        }
+        let topic = GossipTopic::new(kind, &self.network_name);
+        self.swarm
+            .behaviour_mut()
+            .gossipsub
+            .publish(IdentTopic::new(topic.to_string()), compress_block(payload))
+            .map(|_| ())
+            .map_err(PublishError::from)
+    }
+
+    fn handle_swarm_event(&mut self, event: SwarmEvent<BehaviourEvent>) {
+        match event {
+            SwarmEvent::NewListenAddr { address, .. } => {
+                self.emit(NetworkEvent::NewListenAddr(address));
+            }
+            SwarmEvent::ConnectionEstablished {
+                peer_id,
+                num_established,
+                ..
+            } if num_established.get() == 1 => {
+                self.emit(NetworkEvent::PeerConnected(peer_id));
+            }
+            SwarmEvent::ConnectionClosed {
+                peer_id,
+                num_established: 0,
+                ..
+            } => {
+                self.emit(NetworkEvent::PeerDisconnected(peer_id));
+            }
+            SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(gossipsub::Event::Message {
+                message,
+                ..
+            })) => {
+                self.handle_gossip(&message);
+            }
+            SwarmEvent::Behaviour(BehaviourEvent::Status(event)) => {
+                self.handle_reqresp(Protocol::Status, event);
+            }
+            SwarmEvent::Behaviour(BehaviourEvent::BlocksByRoot(event)) => {
+                self.handle_reqresp(Protocol::BlocksByRoot, event);
+            }
+            SwarmEvent::Behaviour(BehaviourEvent::BlocksByRange(event)) => {
+                self.handle_reqresp(Protocol::BlocksByRange, event);
+            }
+            // Identify runs for gossipsub interop only; gossipsub's own subscription
+            // and peer bookkeeping events need no reaction; the remaining swarm-level
+            // events (dial progress, listener lifecycle, ...) carry no obligation for
+            // this task.
+            _ => {}
+        }
+    }
+
+    /// Topic check and deduplication only — the gossipsub behaviour has already
+    /// deduplicated by message ID; what remains is deciding whether the topic is ours
+    /// and handing the bytes on.
+    fn handle_gossip(&mut self, message: &gossipsub::Message) {
+        let Some(topic) = GossipTopic::parse(message.topic.as_str()) else {
+            self.counters.gossip_invalid.fetch_add(1, Ordering::Relaxed);
+            return;
+        };
+        if topic.network_name != self.network_name {
+            self.counters.gossip_invalid.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        let Ok(payload) = decompress_block(&message.data, MAX_PAYLOAD_SIZE) else {
+            self.counters.gossip_invalid.fetch_add(1, Ordering::Relaxed);
+            return;
+        };
+        // The single deliberate drop point: full channel means the node is behind, and
+        // what is shed is raw gossip — peer-recoverable by range sync.
+        if self
+            .events
+            .try_send(NetworkEvent::Gossip {
+                kind: topic.kind,
+                payload,
+            })
+            .is_err()
+        {
+            self.counters.gossip_dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn handle_reqresp(
+        &mut self,
+        protocol: Protocol,
+        event: request_response::Event<Request, Response>,
+    ) {
+        match event {
+            request_response::Event::Message {
+                peer,
+                message:
+                    request_response::Message::Request {
+                        request, channel, ..
+                    },
+                ..
+            } => {
+                // Dropping the event (full channel) drops the response channel with it;
+                // the peer sees a timeout — the same outcome as any overloaded responder.
+                self.emit(NetworkEvent::InboundRequest {
+                    peer,
+                    request,
+                    channel,
+                });
+            }
+            request_response::Event::Message {
+                message:
+                    request_response::Message::Response {
+                        request_id,
+                        response,
+                    },
+                ..
+            } => {
+                if let Some(reply) = self.pending.remove(&(protocol, request_id)) {
+                    let _ = reply.send(Ok(response));
+                }
+            }
+            request_response::Event::OutboundFailure {
+                request_id, error, ..
+            } => {
+                if let Some(reply) = self.pending.remove(&(protocol, request_id)) {
+                    let _ = reply.send(Err(RequestError::from_outbound_failure(&error)));
+                }
+            }
+            // An inbound failure is the *peer's* problem to retry; the response-sent
+            // acknowledgement carries no obligation.
+            request_response::Event::InboundFailure { .. }
+            | request_response::Event::ResponseSent { .. } => {}
+        }
+    }
+
+    fn emit(&mut self, event: NetworkEvent) {
+        if self.events.try_send(event).is_err() {
+            self.counters.events_dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}

--- a/crates/verity-p2p/src/wire/mod.rs
+++ b/crates/verity-p2p/src/wire/mod.rs
@@ -1,0 +1,5 @@
+//! The two byte-level encodings under every lean wire format: unsigned LEB128 varints and
+//! snappy in both of its formats.
+
+pub mod snappy;
+pub mod varint;

--- a/crates/verity-p2p/src/wire/snappy.rs
+++ b/crates/verity-p2p/src/wire/snappy.rs
@@ -1,0 +1,270 @@
+//! Snappy, in the two formats the lean wire protocol uses.
+//!
+//! Gossip payloads use the **raw block** format. Req/resp chunks use the **framed** format
+//! (CRC-checked frames per google/snappy's `framing_format.txt`). The two are not
+//! interchangeable: a raw block has no frame headers, and a framed stream is unreadable as
+//! a raw block. leanSpec `node/networking/client/event_source/live.py` states the split;
+//! this module keeps both behind names that say which is which.
+//!
+//! The framed reader works frame by frame rather than wrapping the stream in a
+//! decompressor, because a req/resp response is a *sequence* of chunks on one stream: the
+//! reader must consume exactly the frames carrying the declared uncompressed length and
+//! leave the next chunk's first byte in place. Frame accounting is the only way to know
+//! where to stop without buffering the whole stream.
+
+use std::io::{self, Read, Write};
+
+use futures::{AsyncRead, AsyncReadExt};
+
+use crate::config::max_compressed_len;
+
+/// Frame-type byte for the stream identifier ("sNaPpY").
+const FRAME_STREAM_IDENTIFIER: u8 = 0xff;
+/// Frame-type byte for a compressed data frame.
+const FRAME_COMPRESSED_DATA: u8 = 0x00;
+/// Frame-type byte for an uncompressed data frame.
+const FRAME_UNCOMPRESSED_DATA: u8 = 0x01;
+/// First frame-type byte of the reserved unskippable range (through 0x7f).
+const FRAME_RESERVED_UNSKIPPABLE_MIN: u8 = 0x02;
+/// Last frame-type byte of the reserved unskippable range.
+const FRAME_RESERVED_UNSKIPPABLE_MAX: u8 = 0x7f;
+/// Bytes of CRC-32C prefixing the data in every data frame.
+const FRAME_CRC_LEN: usize = 4;
+
+/// Compresses a gossip payload in the raw block format.
+#[must_use]
+pub fn compress_block(payload: &[u8]) -> Vec<u8> {
+    snap::raw::Encoder::new()
+        .compress_vec(payload)
+        // Raw-block compression of an in-memory slice has no failure mode: every input
+        // is compressible and the output buffer is sized by the encoder itself.
+        .unwrap_or_default()
+}
+
+/// Decompresses a raw-block gossip payload, refusing any declared length above `max`.
+pub fn decompress_block(compressed: &[u8], max: usize) -> io::Result<Vec<u8>> {
+    let declared = snap::raw::decompress_len(compressed)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    if declared > max {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "snappy block declares a length above the payload cap",
+        ));
+    }
+    snap::raw::Decoder::new()
+        .decompress_vec(compressed)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// The complete stream-identifier frame every framed section begins with.
+const STREAM_IDENTIFIER_FRAME: [u8; 10] =
+    [0xff, 0x06, 0x00, 0x00, b's', b'N', b'a', b'P', b'p', b'Y'];
+
+/// Compresses a req/resp payload in the framed format, stream identifier included.
+///
+/// An empty payload still carries the identifier — leanSpec's `frame_compress(b"")` is
+/// the ten identifier bytes, and a reader consumes them to find the next chunk's first
+/// byte. `snap`'s encoder writes its header lazily on the first data byte, so the empty
+/// case is spelled out.
+pub fn compress_framed(payload: &[u8]) -> io::Result<Vec<u8>> {
+    if payload.is_empty() {
+        return Ok(STREAM_IDENTIFIER_FRAME.to_vec());
+    }
+    let mut encoder = snap::write::FrameEncoder::new(Vec::new());
+    encoder.write_all(payload)?;
+    encoder
+        .into_inner()
+        .map_err(|e| io::Error::other(e.to_string()))
+}
+
+/// Reads exactly the snappy frames carrying `uncompressed_len` bytes off an async stream
+/// and returns the decompressed payload, leaving the stream positioned on the byte after
+/// the last consumed frame.
+///
+/// Refuses reserved unskippable frames, a malformed stream identifier, a frame sequence
+/// whose decompressed size oversteps the declared length, and a compressed byte count
+/// beyond [`max_compressed_len`] of the declared length. CRC verification happens in the
+/// final decode pass over the collected frames.
+pub async fn read_framed<T>(io: &mut T, uncompressed_len: usize) -> io::Result<Vec<u8>>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let max_compressed = max_compressed_len(uncompressed_len);
+    let mut collected: Vec<u8> = Vec::new();
+    let mut decompressed_total = 0usize;
+    // Every framed section begins with the stream identifier — even a zero-length one,
+    // which is *only* the identifier. Reading at least one frame here is what keeps a
+    // multi-chunk stream aligned: the identifier's ten bytes must not be mistaken for
+    // the next chunk's response code.
+    let mut first = true;
+    while first || decompressed_total < uncompressed_len {
+        let mut header = [0u8; 4];
+        io.read_exact(&mut header).await?;
+        let frame_type = header[0];
+        let payload_len =
+            usize::from(header[1]) | usize::from(header[2]) << 8 | usize::from(header[3]) << 16;
+        if first && frame_type != FRAME_STREAM_IDENTIFIER {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "framed section does not start with the stream identifier",
+            ));
+        }
+        first = false;
+        if collected.len() + header.len() + payload_len > max_compressed {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snappy frames exceed the worst-case compressed size",
+            ));
+        }
+        let mut payload = vec![0u8; payload_len];
+        io.read_exact(&mut payload).await?;
+        decompressed_total += frame_contribution(frame_type, &payload)?;
+        if decompressed_total > uncompressed_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snappy frames decompress past the declared length",
+            ));
+        }
+        collected.extend_from_slice(&header);
+        collected.extend_from_slice(&payload);
+    }
+    decode_collected_frames(&collected, uncompressed_len)
+}
+
+/// How many decompressed bytes a frame contributes, validating the frame type.
+fn frame_contribution(frame_type: u8, payload: &[u8]) -> io::Result<usize> {
+    match frame_type {
+        FRAME_STREAM_IDENTIFIER => {
+            if payload == b"sNaPpY" {
+                Ok(0)
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "malformed snappy stream identifier",
+                ))
+            }
+        }
+        FRAME_COMPRESSED_DATA => {
+            let data = payload.get(FRAME_CRC_LEN..).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "snappy data frame too short")
+            })?;
+            snap::raw::decompress_len(data)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        }
+        FRAME_UNCOMPRESSED_DATA => {
+            if payload.len() < FRAME_CRC_LEN {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "snappy data frame too short",
+                ));
+            }
+            Ok(payload.len() - FRAME_CRC_LEN)
+        }
+        FRAME_RESERVED_UNSKIPPABLE_MIN..=FRAME_RESERVED_UNSKIPPABLE_MAX => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "reserved unskippable snappy frame",
+        )),
+        // Padding (0xfe) and the reserved skippable range (0x80–0xfd) carry no data.
+        _ => Ok(0),
+    }
+}
+
+/// Decompresses the collected frames, verifying CRCs and the exact declared length.
+fn decode_collected_frames(collected: &[u8], uncompressed_len: usize) -> io::Result<Vec<u8>> {
+    let mut decoder = snap::read::FrameDecoder::new(collected);
+    let mut payload = Vec::with_capacity(uncompressed_len);
+    decoder.read_to_end(&mut payload)?;
+    if payload.len() != uncompressed_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "snappy frames decompress to a different length than declared",
+        ));
+    }
+    Ok(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+    use futures::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn should_round_trip_when_block_compressed() {
+        let payload = b"lean consensus".repeat(100);
+        let compressed = compress_block(&payload);
+        let restored = decompress_block(&compressed, payload.len()).expect("round trip");
+        assert_eq!(restored, payload);
+    }
+
+    #[test]
+    fn should_reject_block_when_declared_length_exceeds_cap() {
+        let compressed = compress_block(&[0u8; 1024]);
+        assert!(decompress_block(&compressed, 1023).is_err());
+    }
+
+    #[test]
+    fn should_round_trip_when_frame_compressed() {
+        let payload = b"status and blocks".repeat(9000);
+        let compressed = compress_framed(&payload).expect("compress");
+        let restored =
+            block_on(read_framed(&mut Cursor::new(compressed), payload.len())).expect("read");
+        assert_eq!(restored, payload);
+    }
+
+    #[test]
+    fn should_leave_following_bytes_unread_when_chunk_ends() {
+        let payload = vec![7u8; 500];
+        let mut wire = compress_framed(&payload).expect("compress");
+        wire.extend_from_slice(b"NEXT");
+        let mut cursor = Cursor::new(wire);
+        let restored = block_on(read_framed(&mut cursor, payload.len())).expect("read");
+        assert_eq!(restored, payload);
+        let mut rest = Vec::new();
+        block_on(cursor.read_to_end(&mut rest)).expect("rest");
+        assert_eq!(rest, b"NEXT");
+    }
+
+    #[test]
+    fn should_carry_only_the_stream_identifier_when_payload_is_empty() {
+        let compressed = compress_framed(&[]).expect("compress");
+        assert_eq!(compressed, STREAM_IDENTIFIER_FRAME);
+
+        let mut wire = compressed;
+        wire.extend_from_slice(b"XX");
+        let mut cursor = Cursor::new(wire);
+        let restored = block_on(read_framed(&mut cursor, 0)).expect("read");
+        assert!(restored.is_empty());
+        let mut rest = Vec::new();
+        block_on(cursor.read_to_end(&mut rest)).expect("rest");
+        assert_eq!(rest, b"XX");
+    }
+
+    #[test]
+    fn should_reject_frames_when_reserved_unskippable_type_appears() {
+        // Stream identifier, then a reserved unskippable frame.
+        let mut wire = vec![0xff, 0x06, 0x00, 0x00];
+        wire.extend_from_slice(b"sNaPpY");
+        wire.extend_from_slice(&[0x02, 0x01, 0x00, 0x00, 0xaa]);
+        let err = block_on(read_framed(&mut Cursor::new(wire), 1)).expect_err("reserved");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn should_reject_frames_when_they_decompress_past_declared_length() {
+        let compressed = compress_framed(&[1u8; 100]).expect("compress");
+        let err = block_on(read_framed(&mut Cursor::new(compressed), 50)).expect_err("overrun");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn should_reject_frames_when_crc_is_corrupted() {
+        let payload = vec![3u8; 200];
+        let mut wire = compress_framed(&payload).expect("compress");
+        // Flip a CRC bit in the first data frame (after the 10-byte stream identifier
+        // and the 4-byte frame header).
+        wire[14] ^= 0xff;
+        assert!(block_on(read_framed(&mut Cursor::new(wire), payload.len())).is_err());
+    }
+}

--- a/crates/verity-p2p/src/wire/varint.rs
+++ b/crates/verity-p2p/src/wire/varint.rs
@@ -1,0 +1,117 @@
+//! Unsigned LEB128 varints, as leanSpec `node/networking/varint.py` defines them.
+//!
+//! A `u64` occupies at most [`MAX_VARINT_LEN`] bytes; a tenth byte may only contribute the
+//! single remaining bit. Reads are strict about both bounds because a varint prefixes every
+//! req/resp chunk: a decoder lenient here would let a peer smuggle an unbounded length claim
+//! past the payload caps.
+
+use std::io;
+
+use futures::{AsyncRead, AsyncReadExt};
+
+/// Maximum encoded length of a `u64` varint.
+pub const MAX_VARINT_LEN: usize = 10;
+
+/// Appends the LEB128 encoding of `value` to `out`.
+pub fn write_varint(out: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            out.push(byte);
+            return;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+/// Reads one varint from an async stream, one byte at a time.
+///
+/// Errors on end-of-stream mid-varint, on an encoding longer than [`MAX_VARINT_LEN`]
+/// bytes, and on a tenth byte carrying more than the one bit a `u64` has left.
+pub async fn read_varint<T>(io: &mut T) -> io::Result<u64>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let mut value: u64 = 0;
+    for index in 0..MAX_VARINT_LEN {
+        let mut byte = [0u8; 1];
+        io.read_exact(&mut byte).await?;
+        let group = u64::from(byte[0] & 0x7f);
+        // The tenth byte holds bits 63.. — anything beyond bit 63 overflows a u64.
+        if index == MAX_VARINT_LEN - 1 && group > 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "varint overflows u64",
+            ));
+        }
+        value |= group << (7 * index);
+        if byte[0] & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "varint longer than 10 bytes",
+    ))
+}
+
+/// Decodes one varint from the front of a byte slice, returning the value and the number
+/// of bytes consumed. Same strictness as [`read_varint`].
+pub fn decode_varint(bytes: &[u8]) -> io::Result<(u64, usize)> {
+    let mut value: u64 = 0;
+    for (index, byte) in bytes.iter().enumerate().take(MAX_VARINT_LEN) {
+        let group = u64::from(byte & 0x7f);
+        if index == MAX_VARINT_LEN - 1 && group > 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "varint overflows u64",
+            ));
+        }
+        value |= group << (7 * index);
+        if byte & 0x80 == 0 {
+            return Ok((value, index + 1));
+        }
+    }
+    let kind = if bytes.len() < MAX_VARINT_LEN {
+        io::ErrorKind::UnexpectedEof
+    } else {
+        io::ErrorKind::InvalidData
+    };
+    Err(io::Error::new(kind, "truncated or over-long varint"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_round_trip_boundary_values_when_encoded_and_decoded() {
+        for value in [0u64, 1, 127, 128, 300, 16383, 16384, u64::MAX - 1, u64::MAX] {
+            let mut buf = Vec::new();
+            write_varint(&mut buf, value);
+            let (decoded, consumed) = decode_varint(&buf).expect("round trip");
+            assert_eq!(decoded, value);
+            assert_eq!(consumed, buf.len());
+        }
+    }
+
+    #[test]
+    fn should_reject_encoding_when_it_overflows_u64() {
+        // Ten continuation groups followed by a value the tenth byte cannot hold.
+        let bytes = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x02];
+        assert!(decode_varint(&bytes).is_err());
+    }
+
+    #[test]
+    fn should_reject_encoding_when_longer_than_ten_bytes() {
+        let bytes = [0x80u8; 11];
+        assert!(decode_varint(&bytes).is_err());
+    }
+
+    #[test]
+    fn should_report_eof_when_the_final_byte_is_missing() {
+        let err = decode_varint(&[0x80]).expect_err("truncated");
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+}

--- a/crates/verity-p2p/tests/networking_fixtures.rs
+++ b/crates/verity-p2p/tests/networking_fixtures.rs
@@ -1,0 +1,575 @@
+//! Conformance against leanSpec networking vectors.
+//!
+//! Two fixture formats are consumed:
+//!
+//! - `networking_codec_test` (`fixtures/consensus/networking_codec/`) — wire-format
+//!   vectors: varints, both snappy formats, gossip topics, the message-ID function, and
+//!   req/resp chunk framing, plus rejection vectors for each decoder.
+//! - `ssz_test` for `test_networking_containers` — SSZ vectors for the envelope types
+//!   this crate defines (`Status`, `BlocksByRootRequest`).
+//!
+//! Gated on `VERITY_FIXTURES` pointing at an extracted `fixtures-prod-scheme` tree; the
+//! fast `cargo test` gate leaves it unset and the tests return. CI's fixtures job always
+//! sets it, and fails if no vector matched.
+//!
+//! Vectors for layers Verity does not hand-implement are counted and skipped, not
+//! silently dropped: the gossipsub RPC protobuf lives inside upstream libp2p, and ENR /
+//! peer-ID derivation belongs to a discovery layer the crate deliberately does not have.
+//!
+//! # What "matching" means where compression is involved
+//!
+//! Snappy is a self-describing format whose *compressor* output is implementation-defined:
+//! the reference vectors were produced by C snappy, and Rust's `snap` legitimately picks
+//! different (equally valid) encodings for some inputs. Interop needs mutual
+//! decodability, not identical compressor choices, so vectors that embed compressed bytes
+//! are checked as: (a) this crate's decoder recovers the payload from the *reference*
+//! bytes — the direction that talks to other clients — and (b) this crate's own
+//! encode/decode round trip preserves the payload. Everything uncompressed — varints,
+//! topic strings, message IDs, response-code bytes, chunk structure — is checked
+//! byte-exactly.
+//!
+//! Source: leanSpec `main` @ `0588c2d215a955a516378677a92db2a5666802f3`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use futures::executor::block_on;
+use futures::io::Cursor;
+use libssz::{SszDecode, SszEncode};
+use libssz_merkle::{HashTreeRoot, Sha2Hasher};
+use serde::Deserialize;
+use verity_p2p::wire::snappy::{compress_block, compress_framed, decompress_block, read_framed};
+use verity_p2p::wire::varint::{decode_varint, write_varint};
+use verity_p2p::{
+    BlocksByRootRequest, GossipKind, GossipTopic, MAX_PAYLOAD_SIZE, Status, message_id_with_domain,
+};
+use verity_types::SubnetId;
+
+/// Codec kinds this crate implements no counterpart for. `gossipsub_rpc` is upstream
+/// libp2p's protobuf; `enr` and `peer_id` are discovery-layer machinery.
+const SKIPPED_KINDS: &[&str] = &["gossipsub_rpc", "enr", "peer_id"];
+
+/// Rejection decoders skipped for the same reason.
+const SKIPPED_DECODERS: &[&str] = &["gossipsub_rpc", "enr"];
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodecFixture {
+    codec: serde_json::Value,
+    output: serde_json::Value,
+    #[serde(default)]
+    rejection_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SszFixture {
+    type_name: String,
+    serialized: String,
+    #[serde(default)]
+    root: String,
+    #[serde(default)]
+    rejection_reason: Option<String>,
+}
+
+enum Outcome {
+    Matched,
+    Skipped,
+}
+
+#[test]
+fn should_match_leanspec_networking_codec_vectors_when_fixtures_are_present() {
+    let Some(root) = fixtures_dir() else {
+        eprintln!("skipping: set VERITY_FIXTURES to run leanSpec networking vectors");
+        return;
+    };
+    let mut files = Vec::new();
+    collect_json_under(&root, "networking_codec", &mut files);
+    assert!(
+        !files.is_empty(),
+        "no networking_codec JSON under {}",
+        root.display()
+    );
+
+    let mut matched = 0usize;
+    let mut skipped = 0usize;
+    let mut failures = Vec::new();
+    for path in &files {
+        for (id, fixture) in read_cases::<CodecFixture>(path, &mut failures) {
+            match run_codec_case(&fixture) {
+                Ok(Outcome::Matched) => matched += 1,
+                Ok(Outcome::Skipped) => skipped += 1,
+                Err(error) => failures.push(format!("{} ({id}): {error}", path.display())),
+            }
+        }
+    }
+
+    eprintln!("matched {matched} leanSpec networking codec vectors, skipped {skipped}");
+    assert!(
+        failures.is_empty(),
+        "{} networking vector(s) disagreed with leanSpec:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+    assert!(
+        matched > 0,
+        "no networking vector matched; {skipped} skipped"
+    );
+}
+
+#[test]
+fn should_match_leanspec_networking_container_vectors_when_fixtures_are_present() {
+    let Some(root) = fixtures_dir() else {
+        eprintln!("skipping: set VERITY_FIXTURES to run leanSpec networking vectors");
+        return;
+    };
+    let mut files = Vec::new();
+    collect_json_under(&root, "test_networking_containers", &mut files);
+    assert!(
+        !files.is_empty(),
+        "no test_networking_containers JSON under {}",
+        root.display()
+    );
+
+    let mut matched = 0usize;
+    let mut failures = Vec::new();
+    for path in &files {
+        for (id, fixture) in read_cases::<SszFixture>(path, &mut failures) {
+            match run_ssz_case(&fixture) {
+                Ok(()) => matched += 1,
+                Err(error) => failures.push(format!("{} ({id}): {error}", path.display())),
+            }
+        }
+    }
+
+    eprintln!("matched {matched} leanSpec networking container vectors");
+    assert!(
+        failures.is_empty(),
+        "{} container vector(s) disagreed with leanSpec:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+    assert!(matched > 0, "no networking container vector matched");
+}
+
+fn fixtures_dir() -> Option<PathBuf> {
+    std::env::var_os("VERITY_FIXTURES").map(PathBuf::from)
+}
+
+/// Collects every `.json` whose path contains `component` as a directory name.
+fn collect_json_under(dir: &Path, component: &str, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_json_under(&path, component, out);
+            continue;
+        }
+        let is_json = path.extension().is_some_and(|ext| ext == "json");
+        let in_suite = path.components().any(|c| c.as_os_str() == component);
+        if is_json && in_suite {
+            out.push(path);
+        }
+    }
+}
+
+fn read_cases<T: for<'de> Deserialize<'de>>(
+    path: &Path,
+    failures: &mut Vec<String>,
+) -> BTreeMap<String, T> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) => {
+            failures.push(format!("{}: read error: {error}", path.display()));
+            return BTreeMap::new();
+        }
+    };
+    match serde_json::from_str(&text) {
+        Ok(cases) => cases,
+        Err(error) => {
+            failures.push(format!("{}: json: {error}", path.display()));
+            BTreeMap::new()
+        }
+    }
+}
+
+// ── networking_codec dispatch ──────────────────────────────────────────────────────────
+
+fn run_codec_case(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let kind = fixture.codec["kind"]
+        .as_str()
+        .ok_or("codec carries no kind")?;
+    if SKIPPED_KINDS.contains(&kind) {
+        return Ok(Outcome::Skipped);
+    }
+    match kind {
+        "varint" => check_varint(fixture),
+        "gossip_topic" => check_gossip_topic(fixture),
+        "gossip_message_id" => check_message_id(fixture),
+        "reqresp_request" => check_reqresp_request(fixture),
+        "reqresp_response" => check_reqresp_response(fixture),
+        "reqresp_response_stream" => check_response_stream(fixture),
+        "snappy_block" => check_snappy_block(fixture),
+        "snappy_frame" => check_snappy_frame(fixture),
+        "decode_failure" => check_decode_failure(fixture),
+        other => Err(format!("unhandled codec kind {other}")),
+    }
+}
+
+fn field<'a>(value: &'a serde_json::Value, name: &str) -> Result<&'a serde_json::Value, String> {
+    value
+        .get(name)
+        .ok_or_else(|| format!("missing field {name}"))
+}
+
+fn hex_field(value: &serde_json::Value, name: &str) -> Result<Vec<u8>, String> {
+    from_hex(
+        field(value, name)?
+            .as_str()
+            .ok_or(format!("{name}: not a string"))?,
+    )
+}
+
+fn str_field<'a>(value: &'a serde_json::Value, name: &str) -> Result<&'a str, String> {
+    field(value, name)?
+        .as_str()
+        .ok_or(format!("{name}: not a string"))
+}
+
+fn u64_field(value: &serde_json::Value, name: &str) -> Result<u64, String> {
+    field(value, name)?
+        .as_u64()
+        .ok_or(format!("{name}: not a u64"))
+}
+
+fn check_varint(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let value = u64_field(&fixture.codec, "value")?;
+    let expected = hex_field(&fixture.output, "encoded")?;
+    let expected_len = u64_field(&fixture.output, "byteLength")? as usize;
+
+    let mut encoded = Vec::new();
+    write_varint(&mut encoded, value);
+    if encoded != expected {
+        return Err(format!(
+            "varint({value}) = 0x{}, want 0x{}",
+            hex_encode(&encoded),
+            hex_encode(&expected)
+        ));
+    }
+    if encoded.len() != expected_len {
+        return Err(format!("byte length {} != {expected_len}", encoded.len()));
+    }
+    let (decoded, consumed) = decode_varint(&encoded).map_err(|e| e.to_string())?;
+    if decoded != value || consumed != encoded.len() {
+        return Err(format!(
+            "decode({value}) round trip failed: {decoded}/{consumed}"
+        ));
+    }
+    Ok(Outcome::Matched)
+}
+
+fn check_gossip_topic(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let topic_kind = str_field(&fixture.codec, "topicKind")?;
+    let network_name = str_field(&fixture.codec, "networkName")?;
+    let kind = match topic_kind {
+        "block" => GossipKind::Block,
+        "aggregation" => GossipKind::Aggregation,
+        "attestation" => GossipKind::Attestation(SubnetId(u64_field(&fixture.codec, "subnetId")?)),
+        other => return Err(format!("unhandled topic kind {other}")),
+    };
+    let topic = GossipTopic::new(kind, network_name);
+    let expected = str_field(&fixture.output, "topicString")?;
+    if topic.to_string() != expected {
+        return Err(format!("topic {} != {expected}", topic));
+    }
+    let parsed = GossipTopic::parse(expected).ok_or("reference topic did not parse")?;
+    if parsed != topic {
+        return Err("topic parse round trip failed".into());
+    }
+    if let Some(expected_network) = fixture.codec.get("expectedNetworkName") {
+        let expected_network = expected_network.as_str().ok_or("expectedNetworkName")?;
+        let fork_valid = fixture.output["forkValid"]
+            .as_bool()
+            .ok_or("missing forkValid")?;
+        if (parsed.network_name == expected_network) != fork_valid {
+            return Err(format!(
+                "fork validation of {} against {expected_network}: want {fork_valid}",
+                parsed.network_name
+            ));
+        }
+    }
+    Ok(Outcome::Matched)
+}
+
+fn check_message_id(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let topic = hex_field(&fixture.codec, "topic")?;
+    let data = hex_field(&fixture.codec, "data")?;
+    let domain = hex_field(&fixture.codec, "domain")?;
+    let expected = hex_field(&fixture.output, "messageId")?;
+    let id = message_id_with_domain(&domain, &topic, &data);
+    if id.as_slice() != expected {
+        return Err(format!(
+            "message id 0x{} != 0x{}",
+            hex_encode(&id),
+            hex_encode(&expected)
+        ));
+    }
+    Ok(Outcome::Matched)
+}
+
+/// Encodes one req/resp chunk payload the way the crate's codec does.
+fn encode_chunk(payload: &[u8]) -> Result<Vec<u8>, String> {
+    let mut wire = Vec::new();
+    write_varint(&mut wire, payload.len() as u64);
+    wire.extend_from_slice(&compress_framed(payload).map_err(|e| e.to_string())?);
+    Ok(wire)
+}
+
+/// Decodes one whole-buffer req/resp chunk payload strictly: the varint, the payload
+/// cap, the framed bytes, full consumption, and an exact length match.
+fn decode_chunk(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let (declared, consumed) = decode_varint(bytes).map_err(|e| e.to_string())?;
+    if declared > MAX_PAYLOAD_SIZE as u64 {
+        return Err("declared length above the payload cap".into());
+    }
+    let mut cursor = Cursor::new(&bytes[consumed..]);
+    let payload =
+        block_on(read_framed(&mut cursor, declared as usize)).map_err(|e| e.to_string())?;
+    if (cursor.position() as usize) != bytes.len() - consumed {
+        return Err("trailing bytes after the framed payload".into());
+    }
+    Ok(payload)
+}
+
+fn check_reqresp_request(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let ssz_data = hex_field(&fixture.codec, "sszData")?;
+    let expected = hex_field(&fixture.output, "encoded")?;
+    if decode_chunk(&expected)? != ssz_data {
+        return Err("request decode did not recover the reference payload".into());
+    }
+    let encoded = encode_chunk(&ssz_data)?;
+    if decode_chunk(&encoded)? != ssz_data {
+        return Err("request encode/decode round trip failed".into());
+    }
+    Ok(Outcome::Matched)
+}
+
+fn check_reqresp_response(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let code = u64_field(&fixture.codec, "responseCode")? as u8;
+    let ssz_data = hex_field(&fixture.codec, "sszData")?;
+    let expected = hex_field(&fixture.output, "encoded")?;
+
+    let (first, rest) = expected.split_first().ok_or("empty response")?;
+    if *first != code || decode_chunk(rest)? != ssz_data {
+        return Err("response decode did not recover the reference code and payload".into());
+    }
+    let mut encoded = vec![code];
+    encoded.extend_from_slice(&encode_chunk(&ssz_data)?);
+    if decode_chunk(&encoded[1..])? != ssz_data {
+        return Err("response encode/decode round trip failed".into());
+    }
+    Ok(Outcome::Matched)
+}
+
+fn check_response_stream(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let chunks = field(&fixture.codec, "chunks")?
+        .as_array()
+        .ok_or("chunks: not an array")?;
+    let expected = hex_field(&fixture.output, "encoded")?;
+    let expected_count = u64_field(&fixture.output, "chunkCount")? as usize;
+
+    let mut encoded = Vec::new();
+    let mut inputs = Vec::new();
+    for chunk in chunks {
+        let code = u64_field(chunk, "responseCode")? as u8;
+        let payload = hex_field(chunk, "sszData")?;
+        encoded.push(code);
+        encoded.extend_from_slice(&encode_chunk(&payload)?);
+        inputs.push((code, payload));
+    }
+
+    // The reference stream and this crate's own encoding must both decode, chunk by
+    // chunk exactly as the wire reader works — code byte, varint, frames, repeat until
+    // end of stream — back to the same chunk sequence.
+    let decoded = decode_stream(&expected)?;
+    if decoded.len() != expected_count || decoded != inputs {
+        return Err("stream decode did not recover the reference chunk sequence".into());
+    }
+    if decode_stream(&encoded)? != inputs {
+        return Err("stream encode/decode round trip failed".into());
+    }
+    Ok(Outcome::Matched)
+}
+
+/// Decodes a whole response stream into its `(code, payload)` chunks.
+fn decode_stream(bytes: &[u8]) -> Result<Vec<(u8, Vec<u8>)>, String> {
+    let mut decoded = Vec::new();
+    let mut remaining = bytes;
+    while let Some((code, rest)) = remaining.split_first() {
+        let (declared, consumed) = decode_varint(rest).map_err(|e| e.to_string())?;
+        let mut cursor = Cursor::new(&rest[consumed..]);
+        let payload =
+            block_on(read_framed(&mut cursor, declared as usize)).map_err(|e| e.to_string())?;
+        let used = consumed + cursor.position() as usize;
+        decoded.push((*code, payload));
+        remaining = &rest[used..];
+    }
+    Ok(decoded)
+}
+
+fn check_snappy_block(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let data = hex_field(&fixture.codec, "data")?;
+    let expected = hex_field(&fixture.output, "compressed")?;
+    let expected_len = u64_field(&fixture.output, "compressedLength")? as usize;
+    let uncompressed_len = u64_field(&fixture.output, "uncompressedLength")? as usize;
+    if data.len() != uncompressed_len {
+        return Err("uncompressedLength disagrees with data".into());
+    }
+
+    if expected.len() != expected_len {
+        return Err("compressedLength disagrees with the reference bytes".into());
+    }
+    let restored = decompress_block(&expected, MAX_PAYLOAD_SIZE).map_err(|e| e.to_string())?;
+    if restored != data {
+        return Err("block decompression did not recover the reference payload".into());
+    }
+    let round_trip =
+        decompress_block(&compress_block(&data), MAX_PAYLOAD_SIZE).map_err(|e| e.to_string())?;
+    if round_trip != data {
+        return Err("block compress/decompress round trip failed".into());
+    }
+    Ok(Outcome::Matched)
+}
+
+fn check_snappy_frame(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let data = hex_field(&fixture.codec, "data")?;
+    let expected = hex_field(&fixture.output, "framed")?;
+    let expected_len = u64_field(&fixture.output, "framedLength")? as usize;
+    let uncompressed_len = u64_field(&fixture.output, "uncompressedLength")? as usize;
+
+    if expected.len() != expected_len {
+        return Err("framedLength disagrees with the reference bytes".into());
+    }
+    let mut cursor = Cursor::new(expected.as_slice());
+    let restored =
+        block_on(read_framed(&mut cursor, uncompressed_len)).map_err(|e| e.to_string())?;
+    if restored != data || (cursor.position() as usize) != expected.len() {
+        return Err("frame decompression did not recover the reference payload".into());
+    }
+    let framed = compress_framed(&data).map_err(|e| e.to_string())?;
+    let mut cursor = Cursor::new(framed.as_slice());
+    let round_trip =
+        block_on(read_framed(&mut cursor, uncompressed_len)).map_err(|e| e.to_string())?;
+    if round_trip != data {
+        return Err("frame compress/decompress round trip failed".into());
+    }
+    Ok(Outcome::Matched)
+}
+
+/// Whole-buffer framed decompression with unknown length, mirroring leanSpec's
+/// `frame_decompress` for rejection vectors: empty input and every malformed frame must
+/// fail.
+fn frame_decompress_strict(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    if bytes.is_empty() {
+        return Err("empty framed input".into());
+    }
+    let mut decoder = snap::read::FrameDecoder::new(bytes);
+    let mut payload = Vec::new();
+    decoder
+        .read_to_end(&mut payload)
+        .map_err(|e| e.to_string())?;
+    Ok(payload)
+}
+
+fn check_decode_failure(fixture: &CodecFixture) -> Result<Outcome, String> {
+    let decoder = str_field(&fixture.codec, "decoder")?;
+    if SKIPPED_DECODERS.contains(&decoder) {
+        return Ok(Outcome::Skipped);
+    }
+    if fixture.rejection_reason.is_none() {
+        return Err("decode_failure vector carries no rejectionReason".into());
+    }
+    let raw = hex_field(&fixture.codec, "rawBytes")?;
+    let rejected = match decoder {
+        "varint" => decode_varint(&raw).is_err(),
+        "snappy_block" => decompress_block(&raw, MAX_PAYLOAD_SIZE).is_err(),
+        "snappy_frame" => frame_decompress_strict(&raw).is_err(),
+        "reqresp_request" => decode_chunk(&raw).is_err(),
+        "reqresp_response" => raw
+            .split_first()
+            .ok_or(())
+            .and_then(|(_, rest)| decode_chunk(rest).map_err(|_| ()))
+            .is_err(),
+        other => return Err(format!("unhandled rejection decoder {other}")),
+    };
+    if rejected {
+        Ok(Outcome::Matched)
+    } else {
+        Err(format!("{decoder} accepted input leanSpec rejects"))
+    }
+}
+
+// ── SSZ container dispatch ─────────────────────────────────────────────────────────────
+
+fn run_ssz_case(fixture: &SszFixture) -> Result<(), String> {
+    let bytes = from_hex(&fixture.serialized)?;
+    let reject = fixture.rejection_reason.is_some();
+    let root = if reject {
+        Vec::new()
+    } else if fixture.root.is_empty() {
+        return Err("valid vector carries no root".into());
+    } else {
+        from_hex(&fixture.root)?
+    };
+    match fixture.type_name.as_str() {
+        "Status" => apply::<Status>(&bytes, &root, reject),
+        "BlocksByRootRequest" => apply::<BlocksByRootRequest>(&bytes, &root, reject),
+        other => Err(format!("unhandled SSZ type {other}")),
+    }
+}
+
+fn apply<T>(bytes: &[u8], root: &[u8], reject: bool) -> Result<(), String>
+where
+    T: SszDecode + SszEncode + HashTreeRoot + PartialEq + std::fmt::Debug,
+{
+    if reject {
+        return match T::from_ssz_bytes(bytes) {
+            Err(_) => Ok(()),
+            Ok(_) => Err("decode succeeded; leanSpec expects rejection".into()),
+        };
+    }
+    let decoded = T::from_ssz_bytes(bytes).map_err(|error| format!("decode: {error:?}"))?;
+    if decoded.to_ssz() != bytes {
+        return Err("encode mismatch".into());
+    }
+    let computed = decoded.hash_tree_root(&Sha2Hasher);
+    if computed.as_slice() != root {
+        return Err(format!(
+            "root mismatch: got 0x{}, want 0x{}",
+            hex_encode(computed.as_slice()),
+            hex_encode(root)
+        ));
+    }
+    Ok(())
+}
+
+// ── hex helpers ────────────────────────────────────────────────────────────────────────
+
+fn from_hex(text: &str) -> Result<Vec<u8>, String> {
+    let text = text.strip_prefix("0x").unwrap_or(text);
+    if !text.len().is_multiple_of(2) {
+        return Err(format!("odd-length hex ({})", text.len()));
+    }
+    (0..text.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&text[i..i + 2], 16).map_err(|_| format!("invalid hex at {i}")))
+        .collect()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}

--- a/crates/verity-p2p/tests/two_nodes.rs
+++ b/crates/verity-p2p/tests/two_nodes.rs
@@ -1,0 +1,205 @@
+//! Two real nodes on localhost QUIC: gossip and all three req/resp protocols, end to end.
+//!
+//! This is the crate's "does it actually network" test: two swarms, real UDP sockets on
+//! 127.0.0.1, the full stack from topic subscription through snappy framing. Everything
+//! here drives the public service API only — no reaching into the swarm.
+
+use std::time::Duration;
+
+use libssz::SszEncode;
+use tokio::sync::mpsc;
+use tokio::time::{sleep, timeout};
+use verity_p2p::{
+    BlocksByRangeRequest, BlocksByRootRequest, ErrorCode, GossipKind, Multiaddr, NetworkConfig,
+    NetworkEvent, NetworkHandle, PublishError, Request, RequestError, Response, Status, identity,
+};
+use verity_types::{Checkpoint, SignedBlock, Slot};
+
+/// One network name for the whole test; both nodes must agree or gossip is discarded.
+const NETWORK_NAME: &str = "0badf00d";
+
+/// Generous per-stage deadline; QUIC handshakes and gossipsub heartbeats are fast, but CI
+/// machines are not.
+const STAGE_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn node_config() -> NetworkConfig {
+    NetworkConfig::new(
+        identity::Keypair::generate_secp256k1(),
+        "/ip4/127.0.0.1/udp/0/quic-v1".parse().expect("multiaddr"),
+        NETWORK_NAME.to_string(),
+    )
+}
+
+/// Reads events until `select` yields, discarding everything else.
+async fn wait_for<T>(
+    events: &mut mpsc::Receiver<NetworkEvent>,
+    mut select: impl FnMut(NetworkEvent) -> Option<T>,
+) -> T {
+    timeout(STAGE_TIMEOUT, async {
+        loop {
+            let event = events.recv().await.expect("event stream closed");
+            if let Some(found) = select(event) {
+                return found;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for an event")
+}
+
+fn sample_status() -> Status {
+    Status {
+        finalized: Checkpoint {
+            root: [0xaa; 32],
+            slot: Slot(96),
+        },
+        head: Checkpoint {
+            root: [0xbb; 32],
+            slot: Slot(128),
+        },
+    }
+}
+
+/// Answers every inbound request on `events`, and forwards gossip payloads for the test
+/// body to assert on.
+fn run_responder(
+    handle: NetworkHandle,
+    mut events: mpsc::Receiver<NetworkEvent>,
+    gossip: mpsc::Sender<(GossipKind, Vec<u8>)>,
+    served_blocks: Vec<Vec<u8>>,
+) {
+    tokio::spawn(async move {
+        while let Some(event) = events.recv().await {
+            match event {
+                NetworkEvent::InboundRequest {
+                    request, channel, ..
+                } => {
+                    let response = match request {
+                        Request::Status(_) => Response::Status(sample_status()),
+                        Request::BlocksByRange(_) => Response::Blocks(served_blocks.clone()),
+                        Request::BlocksByRoot(_) => Response::Error {
+                            code: ErrorCode::ResourceUnavailable,
+                            message: "pruned below the serving window".to_string(),
+                        },
+                    };
+                    handle.respond(channel, response).await.expect("respond");
+                }
+                NetworkEvent::Gossip { kind, payload } => {
+                    gossip.send((kind, payload)).await.expect("forward gossip");
+                }
+                _ => {}
+            }
+        }
+    });
+}
+
+/// Publishes with retries while the mesh forms; gossipsub refuses to publish before a
+/// peer subscription for the topic is known.
+async fn publish_when_meshed(handle: &NetworkHandle, kind: GossipKind, payload: Vec<u8>) {
+    timeout(STAGE_TIMEOUT, async {
+        loop {
+            match handle.publish(kind, payload.clone()).await {
+                Ok(()) => return,
+                Err(PublishError::InsufficientPeers) => sleep(Duration::from_millis(200)).await,
+                Err(other) => panic!("publish failed: {other}"),
+            }
+        }
+    })
+    .await
+    .expect("mesh never formed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_serve_gossip_and_all_reqresp_protocols_between_two_nodes() {
+    // Node A listens; its bound address becomes known through the event stream.
+    let (handle_a, mut events_a) = verity_p2p::spawn(node_config()).expect("spawn node A");
+    let listen_a = wait_for(&mut events_a, |event| match event {
+        NetworkEvent::NewListenAddr(address) => Some(address),
+        _ => None,
+    })
+    .await;
+    let addr_a: Multiaddr = listen_a
+        .with_p2p(handle_a.local_peer_id())
+        .expect("address with peer id");
+
+    // Node B boots with A as its only bootnode.
+    let mut config_b = node_config();
+    config_b.bootnodes = vec![addr_a];
+    let (handle_b, mut events_b) = verity_p2p::spawn(config_b).expect("spawn node B");
+    let peer_a = handle_a.local_peer_id();
+
+    wait_for(&mut events_b, |event| match event {
+        NetworkEvent::PeerConnected(peer) if peer == peer_a => Some(()),
+        _ => None,
+    })
+    .await;
+
+    // From here node A is driven by a responder task; the test body plays node B.
+    let served_blocks = vec![
+        SignedBlock::default().to_ssz(),
+        SignedBlock::default().to_ssz(),
+    ];
+    let (gossip_tx, mut gossip_rx) = mpsc::channel(8);
+    run_responder(handle_a.clone(), events_a, gossip_tx, served_blocks.clone());
+
+    // Status: B asks, A answers with its checkpoints.
+    let response = handle_b
+        .request(peer_a, Request::Status(Status::default()))
+        .await
+        .expect("status request");
+    assert_eq!(response, Response::Status(sample_status()));
+
+    // BlocksByRange: chunks come back byte-for-byte, in order.
+    let response = handle_b
+        .request(
+            peer_a,
+            Request::BlocksByRange(BlocksByRangeRequest {
+                start_slot: Slot(0),
+                count: 2,
+            }),
+        )
+        .await
+        .expect("range request");
+    assert_eq!(response, Response::Blocks(served_blocks));
+
+    // BlocksByRoot: the responder's error crosses intact, code and message.
+    let response = handle_b
+        .request(
+            peer_a,
+            Request::BlocksByRoot(BlocksByRootRequest::default()),
+        )
+        .await
+        .expect("root request");
+    assert_eq!(
+        response,
+        Response::Error {
+            code: ErrorCode::ResourceUnavailable,
+            message: "pruned below the serving window".to_string(),
+        }
+    );
+
+    // Gossip: B publishes a block payload; A receives it decompressed on the block topic.
+    let payload = SignedBlock::default().to_ssz();
+    publish_when_meshed(&handle_b, GossipKind::Block, payload.clone()).await;
+    let (kind, received) = timeout(STAGE_TIMEOUT, gossip_rx.recv())
+        .await
+        .expect("timed out waiting for gossip")
+        .expect("gossip channel closed");
+    assert_eq!(kind, GossipKind::Block);
+    assert_eq!(received, payload);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_report_dial_failure_when_peer_has_no_known_address() {
+    let (handle, _events) = verity_p2p::spawn(node_config()).expect("spawn");
+    let stranger = identity::Keypair::generate_secp256k1()
+        .public()
+        .to_peer_id();
+    let result = timeout(
+        STAGE_TIMEOUT,
+        handle.request(stranger, Request::Status(Status::default())),
+    )
+    .await
+    .expect("request never resolved");
+    assert_eq!(result, Err(RequestError::DialFailure));
+}


### PR DESCRIPTION
## What

Adds `crates/verity-p2p` — the I/O Edge network service: gossipsub and req/resp over upstream rust-libp2p (QUIC transport, secp256k1 identity), transcribed from leanSpec `src/lean_spec/node/networking/` at `0588c2d215a955a516378677a92db2a5666802f3`.

The crate owns the wire protocol and nothing above it:

- **Gossip** — topic grammar `/leanconsensus/{net}/{block|aggregation|attestation_N}/ssz_snappy`, the `SHA256(domain ‖ len ‖ topic ‖ data)[:20]` message-ID function, raw-snappy payloads, anonymous mode, leanSpec mesh parameters (D=8/6/12, 700 ms heartbeat, 24 s seen-TTL). No `validate_messages` gating — propagation is not gated, per the spec reference and `docs/design/concurrency.md` Decision 2.
- **Req/resp** — `/leanconsensus/req/{status,blocks_by_root,blocks_by_range}/1/ssz_snappy`, LEB128 varint + snappy-framed chunks, response codes with leanSpec's graceful degradation (4–127 → server error, 128–255 → invalid request), 10 MiB payload cap, 1024-chunk cap, 10 s timeout. `Status`/`BlocksByRootRequest`/`BlocksByRangeRequest` are transcribed field for field; block chunks stay raw SSZ bytes in both directions.
- **Service** — one tokio task owning the swarm; bounded command/event channels; gossip leaves as raw decompressed bytes via `try_send` (the pipeline's single drop point, counted); inbound requests surface as events carrying a response channel. Peer scoring, the sync state machine, and payload verification are deliberately absent (they belong to the sync service and verification stage per `docs/design/sync.md` / `concurrency.md`).

## Notable decisions

- **No libp2p fork.** Upstream `request_response` offers every registered protocol on outbound streams and lets the responder pick — the reason ethlambda forked libp2p. One `Behaviour` instance per protocol makes outbound selection structural, keeping the kickoff rule (fork only on concrete, unavoidable need).
- **Frame-accounting chunk reader.** Response chunks share one stream, so the reader consumes exactly the snappy frames carrying the declared length and leaves the next chunk's code byte in place; every declared length is capped before any allocation. An empty payload still carries the 10-byte stream identifier, matching `frame_compress(b"")`.
- **Conformance = mutual decodability where compression is involved.** Snappy compressor output is implementation-defined; C snappy (which produced the vectors) and Rust `snap` pick different valid encodings for some inputs. Vectors embedding compressed bytes are checked as: our decoder recovers the reference payload, and our own encode/decode round-trips. Everything uncompressed (varints, topics, message IDs, response codes, chunk structure) is checked byte-exactly.
- **Discovery is out of scope** (no ENR/discv5); peers come from configured bootnode multiaddrs. Documented revisit trigger: a network whose peer set is not known at configuration time.

## CI

The fixtures job now extracts two more suites from the pinned tarball: `networking_codec` (127 vectors: 84 matched, 43 skipped as out-of-crate layers — gossipsub RPC protobuf lives inside upstream libp2p, ENR/peer-ID in a discovery layer Verity does not have) and `test_networking_containers` (SSZ vectors for `Status`/`BlocksByRootRequest`, which live in this crate).

`Cargo.lock` grows the libp2p tree; the leanSig (`15cbdd43`), leanVM (`e2592df4`), and Plonky3 (`3f67d136`) pins are unchanged.

## Verified locally

- `cargo fmt --all --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test --locked --all-features --workspace`, `cargo build --locked --workspace`, `cargo deny --locked --all-features check` — all green.
- Fixture suites against the sha256-pinned `fixtures-prod-scheme.tar.gz`: networking codec 84 matched / 43 counted skips, networking containers 6 matched, existing suites unaffected.
- `tests/two_nodes.rs`: two real swarms over localhost QUIC — gossip round trip and all three req/resp protocols including the error-response and dial-failure paths.
- Independent fresh-context verification confirmed the wire constants against the pinned leanSpec commit, and a cold-start consumer was built against the rustdoc alone (its findings fed the crate-level example).