### PR TITLE
feat(node): catch up over the wire, and serve what peers ask for

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,7 +127,9 @@ jobs:
             '*/justifiability/*/state_transition/test_justifiability/*.json' \
             '*/slot_clock/*/chain/test_slot_clock/*.json' \
             '*/state_transition/*/state_transition/*/*.json' \
-            '*/fork_choice/*/fork_choice/*/*.json'
+            '*/fork_choice/*/fork_choice/*/*.json' \
+            '*/sync/*/sync/test_checkpoint_verify/*.json' \
+            '*/sync/*/sync/test_checkpoint_verify_advanced/*.json'
 
       # Pre-generated production-scheme keys, so signing tests do not pay key generation.
       # Pinned by sha256 the same way the fixtures are, and bumped by hand.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +978,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1061,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2155,18 +2181,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.5",
  "tokio",
@@ -2319,7 +2363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io",
- "core-foundation",
+ "core-foundation 0.9.4",
  "fnv",
  "futures",
  "if-addrs",
@@ -2536,6 +2580,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3662,6 +3750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "p3-baby-bear"
 version = "0.5.1"
 source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
@@ -4517,6 +4611,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4686,6 +4814,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4694,6 +4834,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4740,6 +4907,24 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -4803,6 +4988,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5151,6 +5359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5168,7 +5385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -5347,6 +5564,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5389,6 +5616,45 @@ checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -5696,7 +5962,11 @@ version = "0.0.0"
 dependencies = [
  "hex",
  "libssz",
+ "rand 0.10.2",
+ "reqwest",
+ "rustls",
  "serde",
+ "serde_json",
  "serde_norway",
  "tempfile",
  "tokio",
@@ -5769,6 +6039,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5806,6 +6086,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5838,6 +6128,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5845,6 +6145,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5868,6 +6177,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -5989,11 +6307,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6007,18 +6334,33 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -6032,15 +6374,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6056,9 +6416,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6068,9 +6440,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5971,6 +5971,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "verity-chain",
  "verity-crypto",
  "verity-db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,30 @@ futures = "0.3"
 # the CRC-framed format for req/resp chunks; `snap` exposes both (`raw`, `read`/`write`).
 snap = "1.1"
 
+# The HTTP client, for checkpoint sync and nothing else. `default-features = false` drops the
+# native-TLS stack and the JSON and compression layers: the two endpoints return raw SSZ bytes,
+# so nothing here parses JSON. rustls rather than native-TLS is the choice ethlambda and ream
+# both made, and it reuses the rustls already in the tree behind `libp2p-quic`.
+#
+# `rustls-no-provider` rather than reqwest's `rustls`, and the difference is a C toolchain.
+# reqwest's `rustls` feature expands to `__rustls-aws-lc-rs`, which pulls `aws-lc-sys` — a C
+# library needing cmake and a C compiler on every build host — and leaves the tree with two
+# crypto providers, because libp2p-quic already brought `ring`. Selecting no provider here and
+# installing `ring` as the process default (see `verity-node`'s checkpoint module) keeps one
+# provider and adds no C dependency, which is the same reasoning that trims rocksdb's codecs
+# below.
+reqwest = { version = "0.13", default-features = false, features = [
+    "rustls-no-provider",
+] }
+
+# Named directly only to install the process-wide crypto provider `rustls-no-provider` leaves
+# unset. Already in the tree behind libp2p-quic, with the same feature.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+
+# Score-weighted peer selection (`docs/design/sync.md`, Decision 3). Nothing consensus-critical
+# depends on it: the draw decides who is asked for blocks, never what is believed.
+rand = "0.10"
+
 # --- Storage -------------------------------------------------------------------------------
 # See docs/src/reference/architecture.md "Storage engine and retention" for why an LSM engine and not a B-tree one.
 #

--- a/crates/verity-chain/src/view.rs
+++ b/crates/verity-chain/src/view.rs
@@ -108,6 +108,24 @@ impl ChainView {
         self.store.blocks.get(&root)
     }
 
+    /// The highest slot of any block in view, canonical or not.
+    ///
+    /// Only verified blocks enter the store, so this is an authenticated lower bound on where
+    /// the network's tip is. A value far below the current slot means the network is not
+    /// producing rather than that this node is behind, which is the distinction the validator
+    /// duty gate turns on (`verity-validator`'s `serves_duties`).
+    ///
+    /// Falls back to the head's slot when the snapshot holds nothing but its anchor.
+    #[must_use]
+    pub fn max_known_block_slot(&self) -> Slot {
+        self.store
+            .blocks
+            .values()
+            .map(|block| block.slot)
+            .max_by_key(|slot| slot.0)
+            .unwrap_or_else(|| self.head_checkpoint().slot)
+    }
+
     /// Every block root in view — what a proposer may stand behind a vote for.
     #[must_use]
     pub fn known_block_roots(&self) -> HashSet<Bytes32> {

--- a/crates/verity-db/src/backend/memory.rs
+++ b/crates/verity-db/src/backend/memory.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 use crate::column::ColumnFamily;
 use crate::error::StorageError;
 
-use super::{Durability, Op, Rows, StorageBackend, WriteBatch};
+use super::{Durability, Op, Rows, StorageBackend, StorageReader, WriteBatch};
 
 /// A volatile backend holding every table in a sorted map.
 #[derive(Debug, Clone, Default)]
@@ -65,7 +65,7 @@ impl MemoryBackend {
     }
 }
 
-impl StorageBackend for MemoryBackend {
+impl StorageReader for MemoryBackend {
     fn get(&self, table: ColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
         Ok(self
             .tables
@@ -86,7 +86,9 @@ impl StorageBackend for MemoryBackend {
                 .collect()
         }))
     }
+}
 
+impl StorageBackend for MemoryBackend {
     fn write(&mut self, batch: WriteBatch, _durability: Durability) -> Result<(), StorageError> {
         // Atomicity is free: nothing observes the map between two ops of one `write` call,
         // because the writer holds the only mutable handle.
@@ -99,7 +101,9 @@ impl StorageBackend for MemoryBackend {
 
 #[cfg(test)]
 mod tests {
-    use super::{ColumnFamily, Durability, MemoryBackend, StorageBackend, WriteBatch};
+    use super::{
+        ColumnFamily, Durability, MemoryBackend, StorageBackend, StorageReader, WriteBatch,
+    };
 
     fn seeded() -> MemoryBackend {
         let mut backend = MemoryBackend::new();

--- a/crates/verity-db/src/backend/mod.rs
+++ b/crates/verity-db/src/backend/mod.rs
@@ -16,6 +16,11 @@
 //! here. That rule is expressible in the type system, so it is enforced by ownership: reads
 //! borrow shared, writes borrow unique, and a second writer cannot be constructed without
 //! moving the backend out of the first.
+//!
+//! The split between [`StorageReader`] and [`StorageBackend`] carries the same rule across
+//! *tasks*, where ownership alone cannot: the range-sync responder runs beside the chain
+//! writer and reads the same open database, so it holds a [`RocksReader`] — a handle with no
+//! `write` at all — rather than a second backend it is trusted not to write through.
 
 pub mod memory;
 pub mod rocks;
@@ -24,7 +29,7 @@ use crate::column::ColumnFamily;
 use crate::error::StorageError;
 
 pub use memory::MemoryBackend;
-pub use rocks::RocksBackend;
+pub use rocks::{RocksBackend, RocksReader};
 
 /// Key-value pairs read from one table, in ascending key order.
 ///
@@ -152,11 +157,17 @@ impl WriteBatch {
     }
 }
 
-/// A key-value engine the repository can be built on.
+/// The read half of a key-value engine the repository can be built on.
 ///
 /// Implementors own no consensus meaning: keys and values are opaque bytes, and the ordering
 /// guarantee below is the only structure the repository is allowed to rely on.
-pub trait StorageBackend {
+///
+/// The read half is a trait of its own so that a handle which *cannot* write is expressible.
+/// One database has exactly one writer (`docs/design/storage.md`), and readers that share it
+/// — the range-sync responder today, RPC later — hold a `Repository` over an implementor of
+/// this trait alone. A `Repository` built on a read-only backend has only the read half of
+/// the API, checked by the compiler rather than by a runtime refusal.
+pub trait StorageReader {
     /// Reads the value at `key`, or `None` when the table holds no such key.
     ///
     /// # Errors
@@ -175,7 +186,10 @@ pub trait StorageBackend {
     ///
     /// [`StorageError::Backend`] when the engine fails.
     fn range(&self, table: ColumnFamily, start: &[u8], end: &[u8]) -> Result<Rows, StorageError>;
+}
 
+/// A key-value engine that can also be written to: the one handle the chain writer holds.
+pub trait StorageBackend: StorageReader {
     /// Applies every op in `batch` atomically, or none of them.
     ///
     /// # Errors

--- a/crates/verity-db/src/backend/rocks.rs
+++ b/crates/verity-db/src/backend/rocks.rs
@@ -10,6 +10,7 @@
 //! whether that log is fsynced before the call returns.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use rocksdb::{
     ColumnFamilyDescriptor, DB, DBCompressionType, IteratorMode, Options, ReadOptions,
@@ -19,13 +20,44 @@ use rocksdb::{
 use crate::column::ColumnFamily;
 use crate::error::StorageError;
 
-use super::{Durability, Op, Rows, StorageBackend, WriteBatch};
+use super::{Durability, Op, Rows, StorageBackend, StorageReader, WriteBatch};
+
+/// A read-only handle on an open database, shareable across tasks.
+///
+/// RocksDB takes an exclusive lock on its directory, so a second reader cannot simply open
+/// the same path: it has to share the handle the writer opened. `DB` is `Sync` and its reads
+/// take `&self`, so sharing one behind an `Arc` is the engine's own supported arrangement,
+/// and a read here is consistent with whatever the writer has already committed.
+///
+/// The type carries no `write`, which is what keeps `docs/design/storage.md`'s one-writer
+/// rule true across tasks rather than only across owners.
+#[derive(Debug, Clone)]
+pub struct RocksReader {
+    db: Arc<DB>,
+    path: PathBuf,
+}
+
+impl RocksReader {
+    /// The directory this database lives in.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn handle(&self, table: ColumnFamily) -> Result<&rocksdb::ColumnFamily, StorageError> {
+        self.db.cf_handle(table.name()).ok_or_else(|| {
+            StorageError::Backend(format!(
+                "column family {table} is absent from {}",
+                self.path.display()
+            ))
+        })
+    }
+}
 
 /// A RocksDB database with one column family per logical table.
 #[derive(Debug)]
 pub struct RocksBackend {
-    db: DB,
-    path: PathBuf,
+    reader: RocksReader,
 }
 
 impl RocksBackend {
@@ -51,7 +83,12 @@ impl RocksBackend {
             .map(|table| ColumnFamilyDescriptor::new(table.name(), table_options(table)));
 
         let db = DB::open_cf_descriptors(&db_options, &path, descriptors).map_err(backend)?;
-        Ok(Self { db, path })
+        Ok(Self {
+            reader: RocksReader {
+                db: Arc::new(db),
+                path,
+            },
+        })
     }
 
     /// The directory this database lives in.
@@ -60,16 +97,13 @@ impl RocksBackend {
     /// operator has to be told where to look.
     #[must_use]
     pub fn path(&self) -> &Path {
-        &self.path
+        self.reader.path()
     }
 
-    fn handle(&self, table: ColumnFamily) -> Result<&rocksdb::ColumnFamily, StorageError> {
-        self.db.cf_handle(table.name()).ok_or_else(|| {
-            StorageError::Backend(format!(
-                "column family {table} is absent from {}",
-                self.path.display()
-            ))
-        })
+    /// A read-only handle on the same open database, for a task that must not write.
+    #[must_use]
+    pub fn reader(&self) -> RocksReader {
+        self.reader.clone()
     }
 }
 
@@ -93,7 +127,7 @@ fn backend(error: rocksdb::Error) -> StorageError {
     StorageError::Backend(error.to_string())
 }
 
-impl StorageBackend for RocksBackend {
+impl StorageReader for RocksReader {
     fn get(&self, table: ColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
         self.db.get_cf(self.handle(table)?, key).map_err(backend)
     }
@@ -120,19 +154,31 @@ impl StorageBackend for RocksBackend {
         }
         Ok(rows)
     }
+}
 
+impl StorageReader for RocksBackend {
+    fn get(&self, table: ColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
+        self.reader.get(table, key)
+    }
+
+    fn range(&self, table: ColumnFamily, start: &[u8], end: &[u8]) -> Result<Rows, StorageError> {
+        self.reader.range(table, start, end)
+    }
+}
+
+impl StorageBackend for RocksBackend {
     fn write(&mut self, batch: WriteBatch, durability: Durability) -> Result<(), StorageError> {
         let mut rocks_batch = RocksBatch::default();
         for op in batch.ops() {
             match op {
                 Op::Put { table, key, value } => {
-                    rocks_batch.put_cf(self.handle(*table)?, key, value);
+                    rocks_batch.put_cf(self.reader.handle(*table)?, key, value);
                 }
                 Op::Delete { table, key } => {
-                    rocks_batch.delete_cf(self.handle(*table)?, key);
+                    rocks_batch.delete_cf(self.reader.handle(*table)?, key);
                 }
                 Op::DeleteRange { table, start, end } => {
-                    rocks_batch.delete_range_cf(self.handle(*table)?, start, end);
+                    rocks_batch.delete_range_cf(self.reader.handle(*table)?, start, end);
                 }
             }
         }
@@ -142,7 +188,8 @@ impl StorageBackend for RocksBackend {
             Durability::Synced => true,
             Durability::Buffered => false,
         });
-        self.db
+        self.reader
+            .db
             .write_opt(rocks_batch, &write_options)
             .map_err(backend)
     }

--- a/crates/verity-db/src/lib.rs
+++ b/crates/verity-db/src/lib.rs
@@ -57,7 +57,9 @@ pub mod schema;
 pub mod votes;
 pub mod writer;
 
-pub use backend::{Durability, MemoryBackend, RocksBackend, StorageBackend, WriteBatch};
+pub use backend::{
+    Durability, MemoryBackend, RocksBackend, RocksReader, StorageBackend, StorageReader, WriteBatch,
+};
 pub use column::ColumnFamily;
 pub use diff::{SNAPSHOT_INTERVAL_SLOTS, StateDiff};
 pub use error::{IdentityMismatch, StorageError};

--- a/crates/verity-db/src/read.rs
+++ b/crates/verity-db/src/read.rs
@@ -10,7 +10,7 @@ use libssz::SszDecode;
 use verity_types::primitives::{Bytes32, Slot, ValidatorIndex};
 use verity_types::{AttestationData, BlockBody, BlockHeader, MultiMessageAggregate, State};
 
-use crate::backend::StorageBackend;
+use crate::backend::StorageReader;
 use crate::column::ColumnFamily;
 use crate::diff::StateDiff;
 use crate::error::StorageError;
@@ -28,7 +28,7 @@ pub struct ForkChoiceEntry {
     pub parent_root: Bytes32,
 }
 
-impl<B: StorageBackend> Repository<B> {
+impl<B: StorageReader> Repository<B> {
     /// The header of a processed block.
     ///
     /// # Errors

--- a/crates/verity-db/src/reconstruct.rs
+++ b/crates/verity-db/src/reconstruct.rs
@@ -16,7 +16,7 @@ use verity_types::primitives::{Bytes32, ZERO_HASH};
 use verity_types::state::HistoricalBlockHashes;
 use verity_types::{BlockHeader, State};
 
-use crate::backend::StorageBackend;
+use crate::backend::StorageReader;
 use crate::column::ColumnFamily;
 use crate::diff::{SNAPSHOT_INTERVAL_SLOTS, StateDiff};
 use crate::error::StorageError;
@@ -24,7 +24,7 @@ use crate::key;
 use crate::merkle::hash_tree_root;
 use crate::repository::Repository;
 
-impl<B: StorageBackend> Repository<B> {
+impl<B: StorageReader> Repository<B> {
     /// The state a block produced, rebuilt from stored data.
     ///
     /// Returns the snapshot directly when the block is a snapshot base; otherwise walks back

--- a/crates/verity-db/src/repository.rs
+++ b/crates/verity-db/src/repository.rs
@@ -13,7 +13,7 @@ use libssz::{SszDecode, SszEncode};
 use verity_types::Checkpoint;
 use verity_types::primitives::{Bytes32, Interval, Slot};
 
-use crate::backend::{Durability, Rows, StorageBackend, WriteBatch};
+use crate::backend::{Durability, Rows, StorageBackend, StorageReader, WriteBatch};
 use crate::column::ColumnFamily;
 use crate::error::{IdentityMismatch, StorageError};
 use crate::metadata::MetadataKey;
@@ -24,13 +24,19 @@ use crate::schema::{Identity, SCHEMA_VERSION, ssz_schema_digest};
 /// Reads borrow shared and writes borrow unique, so the one-writer-per-database rule of
 /// `docs/design/storage.md` is carried by ownership: P2P, RPC, and validator duties can hold
 /// a `&Repository` and read, and only the chain writer can hold the `&mut` that commits.
+///
+/// Across tasks the same rule is carried by the backend's type. Everything in this file and
+/// in `read.rs` needs only [`StorageReader`], so a repository over a read-only handle — what
+/// the range-sync responder holds — compiles with the read half of the API and nothing else;
+/// the committing half lives in `writer.rs` and `retention.rs` behind
+/// [`crate::StorageBackend`].
 #[derive(Debug)]
-pub struct Repository<B: StorageBackend> {
+pub struct Repository<B> {
     backend: B,
     identity: Identity,
 }
 
-impl<B: StorageBackend> Repository<B> {
+impl<B: StorageReader> Repository<B> {
     /// Opens `backend` as the repository of the chain described by `identity`.
     ///
     /// An empty database — one carrying none of the four identity values — opens and waits
@@ -163,18 +169,6 @@ impl<B: StorageBackend> Repository<B> {
         self.backend.range(table, start, end)
     }
 
-    /// Applies a batch. The only path by which anything becomes durable.
-    pub(crate) fn commit(
-        &mut self,
-        batch: WriteBatch,
-        durability: Durability,
-    ) -> Result<(), StorageError> {
-        if batch.is_empty() {
-            return Ok(());
-        }
-        self.backend.write(batch, durability)
-    }
-
     // --- Metadata -------------------------------------------------------------------------
 
     fn raw_metadata(&self, key: MetadataKey) -> Result<Option<Vec<u8>>, StorageError> {
@@ -261,6 +255,20 @@ impl<B: StorageBackend> Repository<B> {
         Ok(self
             .metadata::<u64>(MetadataKey::LastProcessedInterval)?
             .map(Interval))
+    }
+}
+
+impl<B: StorageBackend> Repository<B> {
+    /// Applies a batch. The only path by which anything becomes durable.
+    pub(crate) fn commit(
+        &mut self,
+        batch: WriteBatch,
+        durability: Durability,
+    ) -> Result<(), StorageError> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+        self.backend.write(batch, durability)
     }
 }
 

--- a/crates/verity-db/src/retention.rs
+++ b/crates/verity-db/src/retention.rs
@@ -15,7 +15,7 @@
 use verity_types::Checkpoint;
 use verity_types::primitives::{Bytes32, Slot};
 
-use crate::backend::{Durability, StorageBackend, WriteBatch};
+use crate::backend::{Durability, StorageBackend, StorageReader, WriteBatch};
 use crate::column::ColumnFamily;
 use crate::error::StorageError;
 use crate::key;
@@ -127,7 +127,11 @@ impl<B: StorageBackend> Repository<B> {
             cursor = header.parent_root;
         }
     }
+}
 
+/// The serving window, which a reader answers as readily as the writer does: the range-sync
+/// responder runs in its own task, over a read-only handle on the same database.
+impl<B: StorageReader> Repository<B> {
     /// The lowest slot this node will answer a `BlocksByRange` request from.
     ///
     /// It is the higher of the spec's sliding four-hour floor and the first slot this node

--- a/crates/verity-node/Cargo.toml
+++ b/crates/verity-node/Cargo.toml
@@ -34,9 +34,12 @@ verity-types.workspace = true
 verity-validator.workspace = true
 
 # `serde_json` reads the leanSpec fixture files; consensus values never travel as JSON.
+# `tracing-subscriber` is what makes `RUST_LOG` work in these harnesses: a library installs no
+# subscriber, so without it an end-to-end test that misbehaves is silent.
 [dev-dependencies]
 serde_json.workspace = true
 tempfile.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/verity-node/Cargo.toml
+++ b/crates/verity-node/Cargo.toml
@@ -13,10 +13,15 @@ publish = false
 # components are joined, which is why it is the only crate that depends on all of them.
 #
 # `serde_norway` and `hex` read the cross-client genesis and validator-assignment files;
-# `libssz` decodes gossip payloads, which arrive as raw bytes by design.
+# `libssz` decodes gossip payloads, which arrive as raw bytes by design. `reqwest` and `rand`
+# belong to the sync service alone: the checkpoint-sync fetch and score-weighted peer
+# selection respectively (`docs/design/sync.md`).
 [dependencies]
 hex.workspace = true
 libssz.workspace = true
+rand.workspace = true
+reqwest.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_norway.workspace = true
 tokio.workspace = true
@@ -28,7 +33,9 @@ verity-p2p.workspace = true
 verity-types.workspace = true
 verity-validator.workspace = true
 
+# `serde_json` reads the leanSpec fixture files; consensus values never travel as JSON.
 [dev-dependencies]
+serde_json.workspace = true
 tempfile.workspace = true
 
 [lints]

--- a/crates/verity-node/src/chain.rs
+++ b/crates/verity-node/src/chain.rs
@@ -100,6 +100,17 @@ impl<B: StorageBackend> ChainTask<B> {
     /// each stopped producer drops its sender, and this loop ends once all three are gone.
     /// Duty products are drained to the end — they are never dropped, shutdown included.
     pub async fn run(mut self) {
+        // The clock's current interval is already in the watch when this task starts, and
+        // `changed()` below waits for the *next* one. Consuming it here is what stops a node
+        // that starts mid-chain from spending its first interval believing it is still at
+        // genesis: for those few hundred milliseconds every block the sync service fetches is
+        // ahead of the store's own clock, and a block refused as too far in the future is
+        // gone — nothing re-requests it, because it failed after the verification stage
+        // rather than in it.
+        let start = *self.clock.borrow_and_update();
+        self.on_clock(start).await;
+        self.publish();
+
         let mut clock_open = true;
         let mut local_open = true;
         let mut network_open = true;

--- a/crates/verity-node/src/error.rs
+++ b/crates/verity-node/src/error.rs
@@ -11,7 +11,10 @@ use std::path::PathBuf;
 use verity_chain::RejectionReason;
 use verity_db::StorageError;
 use verity_p2p::BuildError;
+use verity_types::Slot;
 use verity_validator::DutyError;
+
+use crate::sync::checkpoint::CheckpointError;
 
 /// A configuration file the node cannot start from.
 #[derive(Debug)]
@@ -93,6 +96,20 @@ pub enum NodeError {
     /// Validator keys could not be loaded, which is always fatal
     /// (`docs/design/key-management.md`, Decision 2).
     Validator(DutyError),
+    /// A checkpoint start was asked for and could not be completed.
+    ///
+    /// Fatal by design: falling back to genesis or to a stale database would start the node
+    /// from an anchor the operator did not choose (`docs/design/sync.md`, Decision 1).
+    Checkpoint(CheckpointError),
+    /// A checkpoint start was asked for on a directory that already holds a chain.
+    ///
+    /// The two anchors cannot both be true, and neither may be picked silently: resuming
+    /// would ignore the flag, and anchoring would leave a hole below the checkpoint. The
+    /// operator points the node at an empty directory, or drops the flag.
+    CheckpointOverPopulated {
+        /// The slot of the anchor that was fetched.
+        slot: Slot,
+    },
 }
 
 impl fmt::Display for NodeError {
@@ -111,6 +128,14 @@ impl fmt::Display for NodeError {
             }
             Self::Network(error) => write!(f, "network: {error}"),
             Self::Validator(error) => write!(f, "{error}"),
+            Self::Checkpoint(error) => write!(f, "{error}"),
+            Self::CheckpointOverPopulated { slot } => write!(
+                f,
+                "checkpoint sync was asked for at slot {}, but this data directory already \
+                 holds a chain; point --data-dir at an empty directory or drop \
+                 --checkpoint-sync-url",
+                slot.0
+            ),
         }
     }
 }
@@ -144,5 +169,11 @@ impl From<BuildError> for NodeError {
 impl From<DutyError> for NodeError {
     fn from(error: DutyError) -> Self {
         Self::Validator(error)
+    }
+}
+
+impl From<CheckpointError> for NodeError {
+    fn from(error: CheckpointError) -> Self {
+        Self::Checkpoint(error)
     }
 }

--- a/crates/verity-node/src/lib.rs
+++ b/crates/verity-node/src/lib.rs
@@ -14,12 +14,17 @@
 //! ```text
 //!            ┌─ network task ─┐  raw bytes   ┌─ verification ─┐  Verified*   ┌─ chain ─┐
 //!  peers ───▶│ topic + dedup  │─────────────▶│ decode, verify │─────────────▶│  single │
-//!            └────────────────┘   try_send   └────────────────┘   (③)        │  writer │
-//!                    ▲                               ▲                       └────┬────┘
-//!                    │ publish                       │ Arc<ChainView>             │
-//!            ┌───────┴────────┐                      │                            │
-//!            │ product relay  │◀── duties (②) ───────┴────────────────────────────┘
-//!            └────────────────┘                  watch: Arc<ChainView>
+//!            └───┬───┬────────┘   try_send   └───────┬────────┘   (③)        │  writer │
+//!                │   │                ▲              │ gaps                  └────┬────┘
+//!                │   │ block requests │ fetched      ▼                            │
+//!                │   ▼                │ blocks   ┌─ sync ─┐  requests              │
+//!                │  ┌── responder ──┐ └──────────│ state  │──────────▶ peers       │
+//!                │  │ read-only DB  │            │ peers  │                        │
+//!                │  └───────────────┘            └────────┘  synced ──▶ duties     │
+//!                │ publish                            ▲                            │
+//!            ┌───┴────────────┐                       │ watch: Arc<ChainView>      │
+//!            │ product relay  │◀── duties (②) ────────┴────────────────────────────┘
+//!            └────────────────┘
 //!                                          ▲
 //!                                    clock (①) ── one ticker, two consumers
 //! ```
@@ -41,6 +46,7 @@ pub mod config;
 pub mod error;
 pub mod network;
 pub mod store_open;
+pub mod sync;
 pub mod verification;
 
 use std::path::PathBuf;
@@ -58,7 +64,12 @@ use verity_validator::{DutyService, Keyring, Prover};
 
 use crate::chain::{Aggregator, ChainTask};
 use crate::error::NodeError;
-use crate::network::{ATTESTATION_SUBNET, BridgeCounters, NetworkBridge, ProductRelay};
+use crate::network::{
+    ATTESTATION_SUBNET, BridgeChannels, BridgeCounters, NetworkBridge, ProductRelay,
+};
+use crate::sync::checkpoint::CheckpointAnchor;
+use crate::sync::responder::BlockResponder;
+use crate::sync::{SyncCounters, SyncService};
 use crate::verification::{StageCounters, VerificationStage};
 
 pub use config::{ASSIGNMENT_FILE_NAME, GenesisFile, assigned_validators};
@@ -84,6 +95,23 @@ const GOSSIP_CAPACITY: usize = 256;
 /// How many items may wait on a state that is not in view yet.
 const PENDING_CAPACITY: usize = 256;
 
+/// How many gap signals may queue for the sync service.
+///
+/// Sized to match the pending buffer: one signal per parked item is the worst case, and the
+/// sender sheds rather than waits, because a full queue means the sync service is already
+/// busy closing gaps and the next park raises the same one again.
+const GAP_CAPACITY: usize = PENDING_CAPACITY;
+
+/// How many inbound block requests may queue for the responder.
+///
+/// Small on purpose. One request is up to 1,024 blocks of proof-bearing history off disk, so
+/// a deep queue would only turn a burst into timeouts on the peers' side; past this depth the
+/// bridge answers `SERVER_ERROR` at once.
+const BLOCK_REQUEST_CAPACITY: usize = 32;
+
+/// How many connection changes may queue for the sync service.
+const PEER_EVENT_CAPACITY: usize = 64;
+
 /// Everything a node needs to start.
 #[derive(Debug)]
 pub struct NodeConfig {
@@ -105,11 +133,18 @@ pub struct NodeConfig {
     pub key_directory: Option<PathBuf>,
     /// Whether this node runs the interval-2 aggregation round.
     pub is_aggregator: bool,
+    /// Base URL to fetch a finalized anchor from instead of replaying from genesis.
+    ///
+    /// Present means a checkpoint start, and that path has no fallbacks: a fetch or
+    /// verification failure stops the node (`docs/design/sync.md`, Decision 1).
+    pub checkpoint_sync_url: Option<String>,
 }
 
 /// A running node, and the handles that stop it.
 pub struct Node {
     view: watch::Receiver<Arc<ChainView>>,
+    synced: watch::Receiver<bool>,
+    listening: watch::Receiver<Vec<Multiaddr>>,
     peer_id: PeerId,
     network: Option<verity_p2p::NetworkHandle>,
     ticker: JoinHandle<()>,
@@ -117,6 +152,7 @@ pub struct Node {
     draining: Vec<JoinHandle<()>>,
     stage_counters: Arc<StageCounters>,
     bridge_counters: Arc<BridgeCounters>,
+    sync_counters: Arc<SyncCounters>,
 }
 
 impl Node {
@@ -137,14 +173,23 @@ impl Node {
             generate_genesis(config.genesis.genesis_time, config.genesis.to_validators()?);
         let clock = SlotClock::new(config.genesis.genesis_time);
 
+        // Before the database, because a checkpoint start that cannot be completed must stop
+        // the node without having written an anchor of any kind.
+        let checkpoint = fetch_checkpoint(&config, &genesis_state).await?;
+
         // The store carries one validator index, which is only ever used to attribute the
         // node's own votes; the keyring below is what actually decides which duties run.
         let backend = RocksBackend::open(&config.data_directory)?;
+        // Taken before the backend moves into the writer: this is the same open database,
+        // and it is the only handle the responder ever gets.
+        let reader = backend.reader();
         let (repository, store) = store_open::open(
             backend,
             &genesis_state,
+            checkpoint.as_ref(),
             config.validator_indices.first().copied(),
         )?;
+        let served = Arc::new(store_open::open_reader(reader, &genesis_state)?);
 
         let keyring = load_keys(&config)?;
         let prover = Prover::new();
@@ -158,6 +203,9 @@ impl Node {
         let (local, local_stream) = mpsc::channel(PRODUCT_CAPACITY);
         let (verified, verified_stream) = mpsc::channel(GOSSIP_CAPACITY);
         let (raw_gossip, raw_gossip_stream) = mpsc::channel(GOSSIP_CAPACITY);
+        let (gaps, gap_stream) = mpsc::channel(GAP_CAPACITY);
+        let (block_requests, block_request_stream) = mpsc::channel(BLOCK_REQUEST_CAPACITY);
+        let (peer_events, peer_event_stream) = mpsc::channel(PEER_EVENT_CAPACITY);
 
         let aggregator = config.is_aggregator.then(|| Aggregator {
             prover: prover.clone(),
@@ -177,16 +225,34 @@ impl Node {
 
         let stage_counters = Arc::new(StageCounters::default());
         let bridge_counters = Arc::new(BridgeCounters::default());
+        let sync_counters = Arc::new(SyncCounters::default());
 
+        let (listening, bound) = watch::channel(Vec::new());
         let bridge = tokio::spawn(
             NetworkBridge::new(
                 events,
-                raw_gossip,
+                BridgeChannels {
+                    gossip: raw_gossip.clone(),
+                    blocks: block_requests,
+                    peers: peer_events,
+                    listening,
+                },
                 handle.clone(),
                 view.clone(),
                 Arc::clone(&bridge_counters),
             )
             .run(),
+        );
+
+        // Fetched blocks re-enter on the same channel gossip arrives on, so the sync path has
+        // no side door into the chain task.
+        let (sync, synced) = SyncService::new(
+            handle.clone(),
+            view.clone(),
+            gap_stream,
+            peer_event_stream,
+            raw_gossip,
+            Arc::clone(&sync_counters),
         );
 
         // Order matters only in one place: the chain task is spawned last so that every
@@ -195,11 +261,23 @@ impl Node {
         let draining = vec![
             tokio::spawn(DutyService::new(keyring, prover, products, view.clone(), ticks).run()),
             tokio::spawn(ProductRelay::new(product_stream, local, handle.clone()).run()),
+            tokio::spawn(sync.run()),
+            tokio::spawn(
+                BlockResponder::new(
+                    served,
+                    view.clone(),
+                    block_request_stream,
+                    handle.clone(),
+                    Arc::clone(&sync_counters),
+                )
+                .run(),
+            ),
             tokio::spawn(
                 VerificationStage::new(
                     raw_gossip_stream,
                     verified,
                     view.clone(),
+                    gaps,
                     PENDING_CAPACITY,
                     Arc::clone(&stage_counters),
                 )
@@ -212,6 +290,8 @@ impl Node {
 
         Ok(Self {
             view,
+            synced,
+            listening: bound,
             peer_id,
             network: Some(handle),
             ticker,
@@ -219,6 +299,7 @@ impl Node {
             draining,
             stage_counters,
             bridge_counters,
+            sync_counters,
         })
     }
 
@@ -234,6 +315,28 @@ impl Node {
         self.peer_id
     }
 
+    /// The addresses the network service actually bound.
+    ///
+    /// Empty until the swarm reports its first listener. With port 0 in the configuration
+    /// this is the only place the bound port appears, so a caller that needs a dialable
+    /// address — an operator, or a second node in a test — reads it here rather than from a
+    /// log line.
+    #[must_use]
+    pub fn listen_addresses(&self) -> Vec<Multiaddr> {
+        self.listening.borrow().clone()
+    }
+
+    /// Whether the node considers itself caught up with the network.
+    ///
+    /// `false` covers both "behind" and "has not met the network yet". It is an observation
+    /// for operators, not the validator duty gate — a node alone at genesis reports `false`
+    /// here and still proposes, because it is not behind anything (`docs/design/sync.md`,
+    /// Decision 1).
+    #[must_use]
+    pub fn is_synced(&self) -> bool {
+        *self.synced.borrow()
+    }
+
     /// What the verification stage discarded.
     #[must_use]
     pub fn stage_counters(&self) -> &StageCounters {
@@ -244,6 +347,12 @@ impl Node {
     #[must_use]
     pub fn bridge_counters(&self) -> &BridgeCounters {
         &self.bridge_counters
+    }
+
+    /// What sync fetched, and what it served.
+    #[must_use]
+    pub fn sync_counters(&self) -> &SyncCounters {
+        &self.sync_counters
     }
 
     /// Stops the node, and waits for the work already in flight to finish.
@@ -263,6 +372,23 @@ impl Node {
         }
         tracing::info!("node stopped");
     }
+}
+
+/// Fetches the checkpoint anchor when the operator asked for one.
+///
+/// Verified against the local genesis file before it is returned, so a failure here has
+/// written nothing and started nothing (`docs/design/sync.md`, Decision 1).
+async fn fetch_checkpoint(
+    config: &NodeConfig,
+    genesis_state: &verity_types::State,
+) -> Result<Option<CheckpointAnchor>, NodeError> {
+    let Some(url) = &config.checkpoint_sync_url else {
+        return Ok(None);
+    };
+    tracing::info!(%url, "starting from a fetched checkpoint, not from genesis");
+    Ok(Some(
+        sync::checkpoint::fetch_anchor(url, genesis_state).await?,
+    ))
 }
 
 /// Loads the keys this node signs with, or none when it is configured to follow.

--- a/crates/verity-node/src/lib.rs
+++ b/crates/verity-node/src/lib.rs
@@ -317,13 +317,21 @@ impl Node {
 
     /// The addresses the network service actually bound.
     ///
-    /// Empty until the swarm reports its first listener. With port 0 in the configuration
-    /// this is the only place the bound port appears, so a caller that needs a dialable
-    /// address — an operator, or a second node in a test — reads it here rather than from a
-    /// log line.
+    /// Empty until the swarm reports its first listener, which happens shortly *after*
+    /// `start` returns: binding is synchronous but the address arrives as an event. A caller
+    /// that needs a dialable address should await [`Node::listening`] rather than read this
+    /// once. With port 0 in the configuration this is the only place the bound port appears,
+    /// so it is read here rather than from a log line.
     #[must_use]
     pub fn listen_addresses(&self) -> Vec<Multiaddr> {
         self.listening.borrow().clone()
+    }
+
+    /// The channel the bound addresses are published on, for a caller that has to wait for
+    /// one.
+    #[must_use]
+    pub fn listening(&self) -> watch::Receiver<Vec<Multiaddr>> {
+        self.listening.clone()
     }
 
     /// Whether the node considers itself caught up with the network.

--- a/crates/verity-node/src/network.rs
+++ b/crates/verity-node/src/network.rs
@@ -2,7 +2,9 @@
 //!
 //! [`NetworkBridge`] carries gossip inward: raw bytes to the verification stage, and nothing
 //! else — no decode, no crypto, so the swarm's own liveness never waits on a proof. It also
-//! answers the one request this node can answer from a snapshot.
+//! sorts the rest of the event stream to the task that owns each concern: the status
+//! handshake it answers itself from the snapshot, block requests go to the responder, and
+//! connection changes go to the sync service.
 //!
 //! [`ProductRelay`] carries this node's own duty products outward, and inward to the chain
 //! task, from the single channel the validator client sends on.
@@ -18,6 +20,7 @@ use verity_p2p::{ErrorCode, GossipKind, NetworkEvent, NetworkHandle, Request, Re
 use verity_types::SubnetId;
 use verity_validator::LocalProduct;
 
+use crate::sync::{BlockRequest, BlockRequestKind, PeerEvent};
 use crate::verification::GossipPayload;
 
 /// The subnet this node's votes are published on.
@@ -42,10 +45,28 @@ impl BridgeCounters {
     }
 }
 
+/// Where the bridge sorts the event stream to.
+///
+/// One value rather than four parameters, because they are one thing: the set of tasks the
+/// wire is fanned out to, decided once when the node is wired.
+pub struct BridgeChannels {
+    /// Raw gossip payloads, to the verification stage.
+    pub gossip: mpsc::Sender<GossipPayload>,
+    /// Inbound block requests, to the responder.
+    pub blocks: mpsc::Sender<BlockRequest>,
+    /// Connection changes, to the sync service.
+    pub peers: mpsc::Sender<PeerEvent>,
+    /// The addresses the swarm bound, published for whoever needs a dialable one.
+    pub listening: watch::Sender<Vec<verity_p2p::Multiaddr>>,
+}
+
 /// Drains the network task's event stream.
 pub struct NetworkBridge {
     events: mpsc::Receiver<NetworkEvent>,
     inbound: mpsc::Sender<GossipPayload>,
+    blocks: mpsc::Sender<BlockRequest>,
+    peers: mpsc::Sender<PeerEvent>,
+    listening: watch::Sender<Vec<verity_p2p::Multiaddr>>,
     handle: NetworkHandle,
     view: watch::Receiver<Arc<ChainView>>,
     counters: Arc<BridgeCounters>,
@@ -56,14 +77,17 @@ impl NetworkBridge {
     #[must_use = "a bridge does nothing until it is run"]
     pub fn new(
         events: mpsc::Receiver<NetworkEvent>,
-        inbound: mpsc::Sender<GossipPayload>,
+        channels: BridgeChannels,
         handle: NetworkHandle,
         view: watch::Receiver<Arc<ChainView>>,
         counters: Arc<BridgeCounters>,
     ) -> Self {
         Self {
             events,
-            inbound,
+            inbound: channels.gossip,
+            blocks: channels.blocks,
+            peers: channels.peers,
+            listening: channels.listening,
             handle,
             view,
             counters,
@@ -83,17 +107,33 @@ impl NetworkBridge {
                     request,
                     channel,
                 } => {
-                    let response = self.answer(&request);
-                    if self.handle.respond(channel, response).await.is_err() {
+                    if !self.dispatch(peer, request, channel).await {
                         break;
                     }
-                    tracing::trace!(%peer, "answered a request");
                 }
                 NetworkEvent::NewListenAddr(address) => {
                     tracing::info!(%address, "listening");
+                    // Published rather than only logged: with port 0 in the configuration
+                    // this event is the only place the bound port exists.
+                    self.listening.send_modify(|bound| bound.push(address));
                 }
-                NetworkEvent::PeerConnected(peer) => tracing::info!(%peer, "peer connected"),
-                NetworkEvent::PeerDisconnected(peer) => tracing::info!(%peer, "peer disconnected"),
+                NetworkEvent::PeerConnected(peer) => {
+                    tracing::info!(%peer, "peer connected");
+                    if self.peers.send(PeerEvent::Connected(peer)).await.is_err() {
+                        break;
+                    }
+                }
+                NetworkEvent::PeerDisconnected(peer) => {
+                    tracing::info!(%peer, "peer disconnected");
+                    if self
+                        .peers
+                        .send(PeerEvent::Disconnected(peer))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
             }
         }
     }
@@ -112,28 +152,65 @@ impl NetworkBridge {
         }
     }
 
-    /// Answers a peer's request.
+    /// Sends one inbound request to whoever owns the data it asks for.
     ///
-    /// Status is answerable from the snapshot alone. The two block protocols are not: a
-    /// response chunk is a `SignedBlock`, proof included, and the proofs live in the database
-    /// behind the chain task's single writer. Serving them — with the retention window and
-    /// the refusal floor that go with it — arrives with the sync service
-    /// (`docs/design/sync.md`). Until then this node refuses them in the protocol's own
-    /// terms rather than leaving the peer to time out.
-    fn answer(&self, request: &Request) -> Response {
-        match request {
+    /// Status is answerable from the snapshot alone, so it is answered here and costs the
+    /// bridge nothing. A block request is hundreds of megabytes of disk read in the worst
+    /// case, so it goes to the responder's own task — by `try_send`, because a bridge that
+    /// waits for the responder is a bridge that stops draining gossip. A full queue is
+    /// answered `SERVER_ERROR` at once: telling a peer this node is saturated is better than
+    /// letting its request time out.
+    ///
+    /// Returns whether the bridge can carry on.
+    async fn dispatch(
+        &self,
+        peer: verity_p2p::PeerId,
+        request: Request,
+        channel: verity_p2p::ResponseChannel,
+    ) -> bool {
+        let kind = match request {
             Request::Status(_) => {
-                let view = self.view.borrow();
-                Response::Status(Status {
-                    finalized: view.latest_finalized(),
-                    head: view.head_checkpoint(),
-                })
+                let response = Response::Status(status_of(&self.view));
+                let answered = self.handle.respond(channel, response).await.is_ok();
+                tracing::trace!(%peer, "answered a status handshake");
+                return answered;
             }
-            Request::BlocksByRoot(_) | Request::BlocksByRange(_) => Response::Error {
-                code: ErrorCode::ResourceUnavailable,
-                message: "this node does not serve blocks yet".to_string(),
-            },
+            Request::BlocksByRoot(roots) => BlockRequestKind::ByRoot(roots),
+            Request::BlocksByRange(range) => BlockRequestKind::ByRange(range),
+        };
+
+        let Err(returned) = self.blocks.try_send(BlockRequest {
+            peer,
+            kind,
+            channel,
+        }) else {
+            return true;
+        };
+
+        match returned {
+            mpsc::error::TrySendError::Full(request) => {
+                let response = Response::Error {
+                    code: ErrorCode::ServerError,
+                    message: "the block responder is saturated".to_string(),
+                };
+                self.handle.respond(request.channel, response).await.is_ok()
+            }
+            // The responder is gone, which means the node is shutting down.
+            mpsc::error::TrySendError::Closed(_) => false,
         }
+    }
+}
+
+/// This node's checkpoints, as a peer sees them.
+///
+/// One function rather than one per caller: the bridge answers handshakes with it and the
+/// sync service opens them with it, and a `Status` that differed between the two would be
+/// this node describing itself two ways.
+pub fn status_of(view: &watch::Receiver<Arc<ChainView>>) -> Status {
+    let view = view.borrow();
+    Status {
+        finalized: view.latest_finalized(),
+        head: view.head_checkpoint(),
     }
 }
 

--- a/crates/verity-node/src/store_open.rs
+++ b/crates/verity-node/src/store_open.rs
@@ -1,10 +1,15 @@
 //! Getting from a directory on disk to a fork-choice store.
 //!
-//! Two paths, and which one runs is decided by the database, not by a flag: a directory with
-//! no identity values is a new node and gets an anchor written; one that carries them is a
-//! restart and gets its chain read back. A directory that disagrees with the configured chain
-//! stops the node — it belongs to another chain, fork, or schema, and nothing local can tell
-//! which one the operator meant (`docs/design/storage.md`).
+//! Three paths, and `docs/design/sync.md`'s Decision 1 makes them mutually exclusive: a
+//! fetched checkpoint anchor is used when the operator asked for one, a directory carrying
+//! identity values is a restart and gets its chain read back, and an empty directory is a new
+//! node anchored on genesis. A directory that disagrees with the configured chain stops the
+//! node — it belongs to another chain, fork, or schema, and nothing local can tell which one
+//! the operator meant (`docs/design/storage.md`).
+//!
+//! The checkpoint path has no fallbacks by design. A populated directory is not silently
+//! resumed and genesis is not silently substituted: both would start the node from an anchor
+//! the operator did not ask for, and choosing a different anchor is an operator's decision.
 //!
 //! # What a restart rebuilds
 //!
@@ -19,11 +24,12 @@
 //! canonical by definition, so a restart resumes on the chain it was following.
 
 use verity_chain::{Store, hash_tree_root, intervals_at_slot_start, on_block};
-use verity_db::{AnchorCommit, Identity, Repository, StorageBackend, stored_header};
+use verity_db::{AnchorCommit, Identity, Repository, StorageBackend, StorageReader, stored_header};
 use verity_types::primitives::ZERO_HASH;
 use verity_types::{Block, BlockBody, BlockHeader, Bytes32, Slot, State, ValidatorIndex};
 
 use crate::error::NodeError;
+use crate::sync::checkpoint::CheckpointAnchor;
 
 /// The protocol fork this build speaks.
 ///
@@ -35,21 +41,38 @@ pub const FORK_VERSION: u64 = 0;
 
 /// Opens the repository for a chain and produces the store to run it from.
 ///
+/// `checkpoint` is the anchor a `--checkpoint-sync-url` start fetched, and its presence is
+/// what selects the checkpoint path.
+///
 /// # Errors
 ///
 /// [`NodeError::Storage`] when the directory belongs to another chain or cannot be written,
-/// [`NodeError::Restore`] when the stored chain does not rebuild into a valid store, and
-/// [`NodeError::IncompleteChain`] when a block the canonical index names is not fully stored.
+/// [`NodeError::Restore`] when the stored chain does not rebuild into a valid store,
+/// [`NodeError::IncompleteChain`] when a block the canonical index names is not fully stored,
+/// and [`NodeError::CheckpointOverPopulated`] when a checkpoint start is asked for on a
+/// directory that already holds a chain.
 pub fn open<B: StorageBackend>(
     backend: B,
     genesis_state: &State,
+    checkpoint: Option<&CheckpointAnchor>,
     validator_index: Option<ValidatorIndex>,
 ) -> Result<(Repository<B>, Store), NodeError> {
-    let identity = Identity {
-        chain_fingerprint: hash_tree_root(genesis_state),
-        fork_version: FORK_VERSION,
-    };
-    let mut repository = Repository::open(backend, identity)?;
+    let mut repository = Repository::open(backend, identity_for(genesis_state))?;
+
+    if let Some(anchor) = checkpoint {
+        if repository.is_populated()? {
+            return Err(NodeError::CheckpointOverPopulated {
+                slot: anchor.state.slot,
+            });
+        }
+        let store = anchor_on_checkpoint(&mut repository, anchor, validator_index)?;
+        tracing::info!(
+            anchor = %root_prefix(store.head),
+            slot = anchor.state.slot.0,
+            "anchored a new database on a fetched checkpoint"
+        );
+        return Ok((repository, store));
+    }
 
     if repository.is_populated()? {
         let store = restore(&repository, validator_index)?;
@@ -69,6 +92,61 @@ pub fn open<B: StorageBackend>(
         );
         Ok((repository, store))
     }
+}
+
+/// Opens a second, read-only view of a database the writer has already opened.
+///
+/// The identity is derived exactly as [`open`] derives it, so a reader is subject to the same
+/// refusal a writer is: a directory belonging to another chain does not open, whichever
+/// handle asks. Nothing is written here — the type says so.
+///
+/// # Errors
+///
+/// [`NodeError::Storage`] when the directory belongs to another chain.
+pub fn open_reader<B: StorageReader>(
+    backend: B,
+    genesis_state: &State,
+) -> Result<Repository<B>, NodeError> {
+    Ok(Repository::open(backend, identity_for(genesis_state))?)
+}
+
+/// The identity a directory must agree with to be this chain's.
+///
+/// Computed in one place because the writer and the reader have to derive it identically:
+/// a reader that computed it differently would open a directory the writer would refuse.
+fn identity_for(genesis_state: &State) -> Identity {
+    Identity {
+        chain_fingerprint: hash_tree_root(genesis_state),
+        fork_version: FORK_VERSION,
+    }
+}
+
+/// Writes a fetched checkpoint as the anchor and starts a store on it.
+///
+/// The anchor's body is stored alongside it, so this node can serve the anchor block itself
+/// over `BlocksByRoot`. Its proof is not: no proof was fetched, none is needed to run, and
+/// `served_from_slot` is what tells a peer that history below here is not on offer.
+fn anchor_on_checkpoint<B: StorageBackend>(
+    repository: &mut Repository<B>,
+    anchor: &CheckpointAnchor,
+    validator_index: Option<ValidatorIndex>,
+) -> Result<Store, NodeError> {
+    let block_root = hash_tree_root(&anchor.block.block);
+
+    repository.commit_anchor(&AnchorCommit {
+        block_root,
+        state: &anchor.state,
+        body: Some(&anchor.block.block.body),
+        // Nothing below the anchor was ever fetched, so range service starts here rather
+        // than at slot zero: advertising lower would promise history this node cannot serve.
+        served_from_slot: anchor.state.slot,
+    })?;
+
+    Ok(Store::new(
+        &anchor.state,
+        &anchor.block.block,
+        validator_index,
+    )?)
 }
 
 /// Writes the genesis anchor and starts a store on it.
@@ -94,7 +172,7 @@ fn anchor_on_genesis<B: StorageBackend>(
 }
 
 /// Rebuilds the store from the stored finalized checkpoint and the canonical chain above it.
-fn restore<B: StorageBackend>(
+fn restore<B: StorageReader>(
     repository: &Repository<B>,
     validator_index: Option<ValidatorIndex>,
 ) -> Result<Store, NodeError> {
@@ -139,7 +217,7 @@ fn restore<B: StorageBackend>(
 }
 
 /// Replays the canonical blocks between the anchor and the stored head.
-fn replay_canonical<B: StorageBackend>(
+fn replay_canonical<B: StorageReader>(
     repository: &Repository<B>,
     store: &mut Store,
     anchor_slot: Slot,
@@ -162,7 +240,7 @@ fn replay_canonical<B: StorageBackend>(
 }
 
 /// Reads a block back out of the two tables it is split across.
-fn stored_block<B: StorageBackend>(
+fn stored_block<B: StorageReader>(
     repository: &Repository<B>,
     root: Bytes32,
 ) -> Result<Block, NodeError> {
@@ -177,8 +255,9 @@ fn stored_block<B: StorageBackend>(
 ///
 /// Every header field is a block field, and a container's root is unchanged by carrying the
 /// body whole instead of its root — which is why the two forms are interchangeable and why
-/// the writer stores only the header.
-fn block_from(header: &BlockHeader, body: BlockBody) -> Block {
+/// the writer stores only the header. Shared with the range-sync responder, which reassembles
+/// the same two rows into the chunks it serves.
+pub(crate) fn block_from(header: &BlockHeader, body: BlockBody) -> Block {
     Block {
         slot: header.slot,
         proposer_index: header.proposer_index,
@@ -188,7 +267,8 @@ fn block_from(header: &BlockHeader, body: BlockBody) -> Block {
     }
 }
 
-fn root_prefix(root: Bytes32) -> String {
+/// The first four bytes of a root, hex, for a log line or an error message.
+pub(crate) fn root_prefix(root: Bytes32) -> String {
     root.iter()
         .take(4)
         .map(|byte| format!("{byte:02x}"))
@@ -198,10 +278,15 @@ fn root_prefix(root: Bytes32) -> String {
 #[cfg(test)]
 mod tests {
     use verity_chain::{generate_genesis, hash_tree_root};
-    use verity_db::MemoryBackend;
-    use verity_types::{Slot, Validator, ValidatorIndex, Validators};
+    use verity_db::{MemoryBackend, stored_header};
+    use verity_types::{
+        BlockBody, MultiMessageAggregate, SignedBlock, Slot, Validator, ValidatorIndex, Validators,
+    };
 
-    use super::open;
+    use crate::error::NodeError;
+    use crate::sync::checkpoint::CheckpointAnchor;
+
+    use super::{block_from, open};
 
     fn genesis(count: u64) -> verity_types::State {
         let mut validators = Validators::default();
@@ -221,7 +306,8 @@ mod tests {
     #[test]
     fn should_anchor_an_empty_database_on_genesis() {
         let state = genesis(4);
-        let (repository, store) = open(MemoryBackend::default(), &state, None).expect("a new node");
+        let (repository, store) =
+            open(MemoryBackend::default(), &state, None, None).expect("a new node");
 
         assert_eq!(store.current_slot(), Slot(0));
         assert_eq!(store.latest_finalized.slot, Slot(0));
@@ -232,21 +318,68 @@ mod tests {
     #[test]
     fn should_refuse_a_database_belonging_to_another_chain() {
         let state = genesis(4);
-        let (repository, _) = open(MemoryBackend::default(), &state, None).expect("a new node");
+        let (repository, _) =
+            open(MemoryBackend::default(), &state, None, None).expect("a new node");
         let backend = repository.backend().clone();
 
         let other = genesis(5);
         assert_ne!(hash_tree_root(&other), hash_tree_root(&state));
-        assert!(open(backend, &other, None).is_err());
+        assert!(open(backend, &other, None, None).is_err());
+    }
+
+    /// An anchor pair shaped the way a fetched one is: the block the state's header names.
+    fn checkpoint(base: &verity_types::State, slot: u64) -> CheckpointAnchor {
+        let mut state = base.clone();
+        state.slot = Slot(slot);
+        state.latest_block_header.slot = Slot(slot);
+        CheckpointAnchor {
+            block: SignedBlock {
+                block: block_from(&stored_header(&state), BlockBody::default()),
+                proof: MultiMessageAggregate::default(),
+            },
+            state,
+        }
+    }
+
+    #[test]
+    fn should_anchor_an_empty_database_on_a_fetched_checkpoint() {
+        let state = genesis(4);
+        let anchor = checkpoint(&state, 512);
+        let (repository, store) = open(MemoryBackend::default(), &state, Some(&anchor), None)
+            .expect("a checkpoint start");
+
+        assert_eq!(store.latest_finalized.slot, Slot(512));
+        // Range service starts at the anchor: nothing below it was ever fetched.
+        assert_eq!(
+            repository.served_from_slot().expect("metadata"),
+            Some(Slot(512))
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_checkpoint_start_on_a_database_that_already_holds_a_chain() {
+        let state = genesis(4);
+        let (repository, _) =
+            open(MemoryBackend::default(), &state, None, None).expect("a new node");
+        let backend = repository.backend().clone();
+
+        // Neither anchor may be picked silently: resuming would ignore the operator's flag,
+        // and anchoring would leave a hole below the checkpoint.
+        let anchor = checkpoint(&state, 512);
+        assert!(matches!(
+            open(backend, &state, Some(&anchor), None),
+            Err(NodeError::CheckpointOverPopulated { slot: Slot(512) })
+        ));
     }
 
     #[test]
     fn should_resume_from_its_own_anchor_when_reopened() {
         let state = genesis(4);
-        let (repository, first) = open(MemoryBackend::default(), &state, None).expect("a new node");
+        let (repository, first) =
+            open(MemoryBackend::default(), &state, None, None).expect("a new node");
         let backend = repository.backend().clone();
 
-        let (_, second) = open(backend, &state, None).expect("a restart");
+        let (_, second) = open(backend, &state, None, None).expect("a restart");
         assert_eq!(second.head, first.head);
         assert_eq!(second.latest_finalized, first.latest_finalized);
     }

--- a/crates/verity-node/src/sync/checkpoint.rs
+++ b/crates/verity-node/src/sync/checkpoint.rs
@@ -1,0 +1,509 @@
+//! Checkpoint entry: adopting a recent finalized state instead of replaying from genesis.
+//!
+//! `docs/design/sync.md`, Decision 1. Replaying from genesis means verifying every aggregate
+//! proof the chain ever carried — 155–236 KB each, one per block — so a node joining a
+//! running network fetches the finalized state and its block over HTTP and starts there.
+//!
+//! # The trust this buys, and what pays for it
+//!
+//! A genesis start trusts nobody. A checkpoint start trusts whoever answers the URL, so the
+//! anchor is verified at the strictest depth surveyed before it is written: it must belong to
+//! the chain the local genesis file describes, be internally consistent, and be the block the
+//! state itself names as final. Two failure classes, and they are handled differently:
+//! transient ones (timeouts, refused connections, 5xx) are retried within a bounded budget,
+//! and definitive ones (any 4xx, an SSZ decode failure, any verification check) end it at
+//! once.
+//!
+//! When the budget runs out or a definitive failure occurs, the node **fails closed and
+//! exits**. It never falls back to genesis or to a stale database: starting from a different
+//! anchor than the operator asked for is an operator's decision, never an automatic one.
+//!
+//! Endpoints and the state-structure check transcribe leanSpec
+//! `src/lean_spec/node/sync/checkpoint_sync.py`, read at commit `8603fa63`.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use libssz::SszDecode;
+use verity_chain::hash_tree_root;
+use verity_types::config::VALIDATOR_REGISTRY_LIMIT;
+use verity_types::{SignedBlock, State};
+
+/// Beacon-API-shaped path for the finalized state.
+pub const FINALIZED_STATE_ENDPOINT: &str = "/lean/v0/states/finalized";
+/// Path for the signed block that state names as final.
+pub const FINALIZED_BLOCK_ENDPOINT: &str = "/lean/v0/blocks/finalized";
+
+/// Seconds allowed per request. A finalized state runs to tens of megabytes, so the transfer
+/// needs a wide window (leanSpec's own timeout).
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How many times a transient failure is retried before the node gives up and exits.
+pub const MAX_ATTEMPTS: u32 = 5;
+
+/// The first backoff interval. Each further attempt doubles it.
+pub const BACKOFF_BASE: Duration = Duration::from_secs(1);
+
+/// The anchor a checkpoint start begins from.
+#[derive(Debug, Clone)]
+pub struct CheckpointAnchor {
+    /// The finalized state.
+    pub state: State,
+    /// The block that state names as final, with its proof.
+    pub block: SignedBlock,
+}
+
+/// Why a checkpoint start could not happen. Every variant is fatal to startup.
+#[derive(Debug)]
+pub enum CheckpointError {
+    /// The endpoint could not be reached within the retry budget.
+    Unreachable {
+        /// The URL that was tried.
+        url: String,
+        /// How many attempts were made.
+        attempts: u32,
+        /// The last failure seen.
+        reason: String,
+    },
+    /// The server answered, and the answer was wrong. Never retried.
+    Rejected {
+        /// The URL that answered.
+        url: String,
+        /// What was wrong with it.
+        reason: String,
+    },
+    /// The anchor did not pass verification against the local genesis file.
+    Unverified(AnchorFailure),
+}
+
+impl core::fmt::Display for CheckpointError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Unreachable {
+                url,
+                attempts,
+                reason,
+            } => write!(
+                f,
+                "checkpoint sync gave up on {url} after {attempts} attempts: {reason}"
+            ),
+            Self::Rejected { url, reason } => write!(f, "checkpoint sync refused {url}: {reason}"),
+            Self::Unverified(failure) => {
+                write!(f, "the checkpoint anchor is not usable: {failure}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CheckpointError {}
+
+/// The ways a fetched anchor fails verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorFailure {
+    /// The state carries no validators, or more than the registry can hold.
+    UnusableRegistry,
+    /// The state belongs to a chain with a different genesis time.
+    ForeignGenesisTime,
+    /// The state's registry is not the one the local genesis file describes.
+    ForeignRegistry,
+    /// `finalized ≤ justified ≤ state.slot` does not hold.
+    SlotsOutOfOrder,
+    /// The state's own latest block is above the state itself.
+    HeaderAheadOfState,
+    /// The fetched block is not the block the state's own header describes.
+    BlockIsNotTheAnchor,
+    /// The block does not commit to the state that came with it.
+    StateIsNotTheBlocks,
+    /// The state's latest block sits at the finalized slot but is not the finalized block.
+    FinalizedRootMismatch,
+    /// Justified and finalized share a slot but not a root.
+    CheckpointsDisagree,
+}
+
+impl core::fmt::Display for AnchorFailure {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::UnusableRegistry => "the validator registry is empty or over the limit",
+            Self::ForeignGenesisTime => "the genesis time is not this chain's",
+            Self::ForeignRegistry => "the validator registry is not this chain's",
+            Self::SlotsOutOfOrder => "finalized, justified and state slots are out of order",
+            Self::HeaderAheadOfState => "the state's latest block is ahead of the state",
+            Self::BlockIsNotTheAnchor => "the block is not the state's own latest block",
+            Self::StateIsNotTheBlocks => "the block does not commit to this state",
+            Self::FinalizedRootMismatch => "the state's latest block is not the block it finalizes",
+            Self::CheckpointsDisagree => "justified and finalized share a slot but not a root",
+        })
+    }
+}
+
+/// Fetches the finalized state and block from `url` and verifies them against local genesis.
+///
+/// # Errors
+///
+/// [`CheckpointError`] in every case. There is no partial success: a node that asked for a
+/// checkpoint start and cannot have one stops.
+pub async fn fetch_anchor(url: &str, genesis: &State) -> Result<CheckpointAnchor, CheckpointError> {
+    let base = url.trim_end_matches('/');
+    install_crypto_provider();
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|error| CheckpointError::Rejected {
+            url: base.to_string(),
+            reason: error.to_string(),
+        })?;
+
+    let state_bytes = fetch(&client, &format!("{base}{FINALIZED_STATE_ENDPOINT}")).await?;
+    let state = decode::<State>(&state_bytes, base, "state")?;
+    tracing::info!(
+        slot = state.slot.0,
+        bytes = state_bytes.len(),
+        "fetched a finalized state"
+    );
+
+    let block_bytes = fetch(&client, &format!("{base}{FINALIZED_BLOCK_ENDPOINT}")).await?;
+    let block = decode::<SignedBlock>(&block_bytes, base, "block")?;
+    tracing::info!(slot = block.block.slot.0, "fetched the finalized block");
+
+    verify_anchor(&state, &block, genesis).map_err(CheckpointError::Unverified)?;
+    Ok(CheckpointAnchor { state, block })
+}
+
+/// Installs `ring` as the process's rustls provider, once.
+///
+/// reqwest is built with `rustls-no-provider`, so nothing selects a provider on its behalf;
+/// without this the first HTTPS request fails at runtime rather than at build time. `ring` is
+/// the provider libp2p-quic already uses, so this keeps one implementation in the process
+/// instead of adding `aws-lc-rs` and its C toolchain (see the workspace manifest).
+///
+/// A provider installed by someone else wins and this is a no-op: the install is attempted
+/// once and its result deliberately ignored, because "somebody already chose" is success.
+fn install_crypto_provider() {
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+    INSTALLED.get_or_init(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+/// One endpoint, retried while the failures are transient.
+async fn fetch(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, CheckpointError> {
+    let mut backoff = BACKOFF_BASE;
+    let mut last = String::new();
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        match attempt_fetch(client, url).await {
+            Ok(bytes) => return Ok(bytes),
+            Err(Attempt::Definitive(reason)) => {
+                return Err(CheckpointError::Rejected {
+                    url: url.to_string(),
+                    reason,
+                });
+            }
+            Err(Attempt::Transient(reason)) => {
+                tracing::warn!(%url, attempt, %reason, "checkpoint fetch failed; retrying");
+                last = reason;
+                if attempt < MAX_ATTEMPTS {
+                    tokio::time::sleep(backoff).await;
+                    backoff *= 2;
+                }
+            }
+        }
+    }
+
+    Err(CheckpointError::Unreachable {
+        url: url.to_string(),
+        attempts: MAX_ATTEMPTS,
+        reason: last,
+    })
+}
+
+/// One failure of one attempt, classified by whether trying again could help.
+enum Attempt {
+    /// A timeout, a refused connection, or a 5xx: the server may yet answer.
+    Transient(String),
+    /// A 4xx: the server answered, and the answer was that this request is wrong.
+    Definitive(String),
+}
+
+async fn attempt_fetch(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, Attempt> {
+    // The endpoints return raw SSZ, not JSON.
+    let response = client
+        .get(url)
+        .header("Accept", "application/octet-stream")
+        .send()
+        .await
+        .map_err(|error| Attempt::Transient(error.to_string()))?;
+
+    let status = response.status();
+    if status.is_client_error() {
+        return Err(Attempt::Definitive(format!("HTTP {status}")));
+    }
+    if !status.is_success() {
+        return Err(Attempt::Transient(format!("HTTP {status}")));
+    }
+
+    response
+        .bytes()
+        .await
+        .map(|bytes| bytes.to_vec())
+        .map_err(|error| Attempt::Transient(error.to_string()))
+}
+
+/// Decodes a payload, or refuses the server for good.
+fn decode<T: SszDecode>(bytes: &[u8], url: &str, what: &str) -> Result<T, CheckpointError> {
+    T::from_ssz_bytes(bytes).map_err(|_| CheckpointError::Rejected {
+        url: url.to_string(),
+        reason: format!(
+            "the {what} payload is not SSZ this build can read ({} bytes)",
+            bytes.len()
+        ),
+    })
+}
+
+/// leanSpec's own structural check on a downloaded state.
+///
+/// Two invariants, and both are about the registry: a state with no validators cannot drive
+/// fork choice, and one claiming more than the registry holds is an attacker-supplied blob.
+/// Kept as its own function because it is what leanSpec's `sync_test` vectors pin.
+///
+/// Transcribed from leanSpec `node/sync/checkpoint_sync.py::verify_checkpoint_state`.
+#[must_use]
+pub fn verify_checkpoint_state(state: &State) -> bool {
+    let count = state.validators.len();
+    count > 0 && count <= VALIDATOR_REGISTRY_LIMIT
+}
+
+/// The full anchor check: leanSpec's, plus everything that ties the anchor to *this* chain.
+///
+/// # What pairs the block with the state, and what does not
+///
+/// The block is paired with `state.latest_block_header`, not with `state.latest_finalized`.
+/// Those are different things, and only the first pairing is unconditional: a state's
+/// finalized checkpoint names an *ancestor* in the general case, and demanding that the
+/// anchor block be that ancestor is circular — the block commits to this very state, so this
+/// state cannot also be one the block descends from. The finalized root is therefore checked
+/// exactly where it is meaningful: when the state's own latest block sits at the finalized
+/// slot, it must be the finalized block.
+///
+/// The pairing itself is two facts, and each has its own failure: the block *is* the block
+/// the state's header describes (same slot, proposer, parent, and body), and the block
+/// commits to this state (`block.state_root == hash_tree_root(state)`, which is the equality
+/// leanSpec's own state transition asserts when it accepts a block).
+///
+/// Mirrors ethlambda `bin/ethlambda/src/checkpoint_sync.rs`, the strictest of the surveyed
+/// implementations (`docs/design/sync.md`, Decision 1).
+///
+/// # Errors
+///
+/// [`AnchorFailure`] naming the first check that failed.
+pub fn verify_anchor(
+    state: &State,
+    block: &SignedBlock,
+    genesis: &State,
+) -> Result<(), AnchorFailure> {
+    if !verify_checkpoint_state(state) {
+        return Err(AnchorFailure::UnusableRegistry);
+    }
+    if state.config.genesis_time != genesis.config.genesis_time {
+        return Err(AnchorFailure::ForeignGenesisTime);
+    }
+    if state.validators != genesis.validators {
+        return Err(AnchorFailure::ForeignRegistry);
+    }
+    if state.latest_finalized.slot.0 > state.latest_justified.slot.0
+        || state.latest_justified.slot.0 > state.slot.0
+    {
+        return Err(AnchorFailure::SlotsOutOfOrder);
+    }
+    if state.latest_block_header.slot.0 > state.slot.0 {
+        return Err(AnchorFailure::HeaderAheadOfState);
+    }
+    if state.latest_justified.slot == state.latest_finalized.slot
+        && state.latest_justified.root != state.latest_finalized.root
+    {
+        return Err(AnchorFailure::CheckpointsDisagree);
+    }
+
+    let header = &state.latest_block_header;
+    let anchor = &block.block;
+    if anchor.slot != header.slot
+        || anchor.proposer_index != header.proposer_index
+        || anchor.parent_root != header.parent_root
+        || hash_tree_root(&anchor.body) != header.body_root
+    {
+        return Err(AnchorFailure::BlockIsNotTheAnchor);
+    }
+    if anchor.state_root != hash_tree_root(state) {
+        return Err(AnchorFailure::StateIsNotTheBlocks);
+    }
+
+    let block_root = hash_tree_root(anchor);
+    if state.latest_block_header.slot == state.latest_finalized.slot
+        && block_root != state.latest_finalized.root
+    {
+        return Err(AnchorFailure::FinalizedRootMismatch);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use verity_chain::{generate_genesis, hash_tree_root};
+    use verity_db::stored_header;
+    use verity_types::{
+        BlockBody, Checkpoint, MultiMessageAggregate, SignedBlock, Slot, State, Validator,
+        ValidatorIndex, Validators,
+    };
+
+    use crate::store_open::block_from;
+
+    use super::{AnchorFailure, verify_anchor, verify_checkpoint_state};
+
+    fn genesis(count: u64, genesis_time: u64) -> State {
+        let mut validators = Validators::default();
+        for index in 0..count {
+            let seed = index as u8;
+            validators
+                .push(Validator {
+                    attestation_public_key: [seed; 52],
+                    proposal_public_key: [seed.wrapping_add(128); 52],
+                    index: ValidatorIndex(index),
+                })
+                .expect("under the registry limit");
+        }
+        generate_genesis(genesis_time, validators)
+    }
+
+    /// The anchor pair a server would serve: a state, and the block that produced it.
+    ///
+    /// Built the way the chain builds it — the block is the state's own latest header with
+    /// its `state_root` filled in — so nothing here is circular.
+    fn anchor(base: &State, slot: u64, finalized_slot: u64) -> (State, SignedBlock) {
+        let mut state = base.clone();
+        state.slot = Slot(slot);
+        state.latest_block_header.slot = Slot(slot);
+        state.latest_block_header.parent_root = [3u8; 32];
+        // A post-state carries its own header with the state root not yet filled in.
+        state.latest_block_header.state_root = [0u8; 32];
+        state.latest_finalized = Checkpoint {
+            root: [4u8; 32],
+            slot: Slot(finalized_slot),
+        };
+        state.latest_justified = state.latest_finalized;
+
+        let block = SignedBlock {
+            block: block_from(&stored_header(&state), BlockBody::default()),
+            proof: MultiMessageAggregate::default(),
+        };
+        (state, block)
+    }
+
+    #[test]
+    fn should_accept_an_anchor_that_belongs_to_this_chain() {
+        let base = genesis(4, 1_700_000_000);
+        let (state, block) = anchor(&base, 128, 96);
+        assert_eq!(verify_anchor(&state, &block, &base), Ok(()));
+    }
+
+    #[test]
+    fn should_refuse_a_state_from_a_chain_with_another_genesis_time() {
+        let base = genesis(4, 1_700_000_000);
+        let (mut state, block) = anchor(&base, 128, 96);
+        state.config.genesis_time += 1;
+        assert_eq!(
+            verify_anchor(&state, &block, &base),
+            Err(AnchorFailure::ForeignGenesisTime)
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_state_with_another_validator_registry() {
+        let base = genesis(4, 1_700_000_000);
+        let other = genesis(5, 1_700_000_000);
+        let (state, block) = anchor(&other, 128, 96);
+        assert_eq!(
+            verify_anchor(&state, &block, &base),
+            Err(AnchorFailure::ForeignRegistry)
+        );
+    }
+
+    #[test]
+    fn should_refuse_slots_that_are_out_of_order() {
+        let base = genesis(4, 1_700_000_000);
+        let (mut state, block) = anchor(&base, 128, 96);
+        state.latest_finalized.slot = Slot(200);
+        assert_eq!(
+            verify_anchor(&state, &block, &base),
+            Err(AnchorFailure::SlotsOutOfOrder)
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_state_whose_latest_block_is_ahead_of_it() {
+        let base = genesis(4, 1_700_000_000);
+        let (mut state, block) = anchor(&base, 128, 96);
+        state.latest_block_header.slot = Slot(129);
+        assert_eq!(
+            verify_anchor(&state, &block, &base),
+            Err(AnchorFailure::HeaderAheadOfState)
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_block_that_did_not_produce_this_state() {
+        let base = genesis(4, 1_700_000_000);
+        let (state, _) = anchor(&base, 128, 96);
+        let (_, other_block) = anchor(&base, 127, 96);
+        assert_eq!(
+            verify_anchor(&state, &other_block, &base),
+            Err(AnchorFailure::BlockIsNotTheAnchor)
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_block_that_does_not_commit_to_the_state_it_arrived_with() {
+        let base = genesis(4, 1_700_000_000);
+        let (state, mut block) = anchor(&base, 128, 96);
+        block.block.state_root = [8u8; 32];
+        assert_eq!(
+            verify_anchor(&state, &block, &base),
+            Err(AnchorFailure::StateIsNotTheBlocks)
+        );
+    }
+
+    #[test]
+    fn should_check_the_finalized_root_only_at_the_finalized_slot() {
+        let base = genesis(4, 1_700_000_000);
+        // A normal anchor finalizes an ancestor, so the check does not apply and the
+        // arbitrary finalized root is no objection.
+        let (state, block) = anchor(&base, 128, 96);
+        assert_eq!(verify_anchor(&state, &block, &base), Ok(()));
+
+        // Move the finalized checkpoint up to the anchor's own slot, keeping a root that is
+        // not the anchor's: now the state claims this block is final and it is not.
+        let (state, block) = anchor(&base, 128, 128);
+        assert_ne!(state.latest_finalized.root, hash_tree_root(&block.block));
+        assert_eq!(
+            verify_anchor(&state, &block, &base),
+            Err(AnchorFailure::FinalizedRootMismatch)
+        );
+    }
+
+    #[test]
+    fn should_refuse_justified_and_finalized_that_share_a_slot_but_not_a_root() {
+        let base = genesis(4, 1_700_000_000);
+        let (mut state, block) = anchor(&base, 128, 96);
+        state.latest_justified.root = [9u8; 32];
+        assert_eq!(
+            verify_anchor(&state, &block, &base),
+            Err(AnchorFailure::CheckpointsDisagree)
+        );
+    }
+
+    #[test]
+    fn should_refuse_an_empty_registry() {
+        let empty = State::default();
+        assert!(!verify_checkpoint_state(&empty));
+        assert!(verify_checkpoint_state(&genesis(1, 0)));
+    }
+}

--- a/crates/verity-node/src/sync/fetch.rs
+++ b/crates/verity-node/src/sync/fetch.rs
@@ -1,0 +1,446 @@
+//! The fetch pipeline: what to ask for, whom to believe, and what a bad answer costs.
+//!
+//! `docs/design/sync.md`, Decision 2. Two shapes of request, chosen by the size of the gap:
+//! a targeted `BlocksByRoot` for the few slots a fork or a dropped gossip message leaves
+//! behind, and a forward `BlocksByRange` walk for anything a by-root chase cannot close
+//! faster than the chain grows.
+//!
+//! Everything here validates *structure* only — that a response is the shape the request
+//! asked for. Signatures and proofs are the verification stage's job, and fetched blocks
+//! reach it through the same channel gossip does, so there is no side door into the chain
+//! task.
+
+use libssz::SszDecode;
+use verity_chain::hash_tree_root;
+use verity_p2p::{
+    BlocksByRangeRequest, BlocksByRootRequest, ErrorCode, MAX_REQUEST_BLOCKS, NetworkHandle,
+    PeerId, Request, RequestedBlockRoots, Response,
+};
+use verity_types::{Bytes32, SignedBlock, Slot};
+
+use super::peers::Outcome;
+
+/// The largest gap still closed by chasing parents one root at a time.
+///
+/// Beyond a handful of slots a by-root walk cannot close a gap faster than the chain grows,
+/// so the split exists to keep the cheap case cheap rather than to save round trips in the
+/// deep case (zeam's threshold).
+///
+/// This threshold is also what bounds the walk. Each fetched block re-enters the verification
+/// stage and raises the next gap if its own parent is missing, so a chase is a sequence of
+/// one-link steps rather than a loop with a counter — and every step re-asks this question
+/// against the current head, switching to a range walk as soon as the answer changes.
+pub const BY_ROOT_GAP_SLOTS: u64 = 4;
+
+/// A block the verification stage is waiting on, and could not resolve.
+///
+/// The slot is the *waiting child's*, not the awaited block's: the awaited block is known
+/// only by root, and the child's slot is what upper-bounds the head-side edge of the gap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Gap {
+    /// The block root the parked item is waiting for.
+    pub awaited_root: Bytes32,
+    /// The slot of the item that is waiting.
+    pub waiting_slot: Slot,
+}
+
+/// What the sync service decided to ask for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Plan {
+    /// Chase specific parents.
+    ByRoot(Vec<Bytes32>),
+    /// Walk forward from the last connected slot.
+    ByRange(BlocksByRangeRequest),
+}
+
+/// Chooses the request that closes a gap between `head_slot` and `waiting_slot`.
+///
+/// A small gap goes by root, because the missing block is known by root and one round trip
+/// ends it. Anything larger goes by range, forward from the first slot this node does not
+/// have, because a chain of by-root round trips is one block per round trip and a day-long
+/// gap is ~21,600 of them.
+#[must_use]
+pub fn plan_for_gap(head_slot: Slot, gap: Gap) -> Plan {
+    if gap.waiting_slot.0.saturating_sub(head_slot.0) <= BY_ROOT_GAP_SLOTS {
+        Plan::ByRoot(vec![gap.awaited_root])
+    } else {
+        Plan::ByRange(range_from(head_slot, gap.waiting_slot))
+    }
+}
+
+/// The next forward window, from the first slot this node is missing up to `target`.
+///
+/// One batch, never more than [`MAX_REQUEST_BLOCKS`] wide: the pipeline keeps one request in
+/// flight and re-checks its own head against the network before issuing the next.
+#[must_use]
+pub fn range_from(head_slot: Slot, target: Slot) -> BlocksByRangeRequest {
+    let start = head_slot.0.saturating_add(1);
+    let wanted = target.0.saturating_sub(head_slot.0);
+    BlocksByRangeRequest {
+        start_slot: Slot(start),
+        count: wanted.clamp(1, MAX_REQUEST_BLOCKS as u64),
+    }
+}
+
+/// Why a response cannot be used, and what it costs the peer that sent it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FetchFailure {
+    /// The peer answered in the protocol's own terms with a refusal or an error.
+    Refused(ErrorCode),
+    /// The request never produced a response.
+    Transport(String),
+    /// The response was a success carrying content the request did not ask for.
+    Malformed(Violation),
+}
+
+impl FetchFailure {
+    /// What this failure does to the peer's score (`docs/design/sync.md`, Decision 3).
+    ///
+    /// `RESOURCE_UNAVAILABLE` is the one neutral outcome: it is the spec's *legal* answer for
+    /// history below the serving window, and the request is simply re-routed. Malformed
+    /// content inside a success is a plain failure — the peer does serve the protocol, badly
+    /// — and never sets the capability flag.
+    #[must_use]
+    pub const fn outcome(&self) -> Outcome {
+        match self {
+            Self::Refused(ErrorCode::ResourceUnavailable) => Outcome::Neutral,
+            Self::Refused(_) | Self::Malformed(_) => Outcome::Failure,
+            Self::Transport(_) => Outcome::Failure,
+        }
+    }
+}
+
+impl core::fmt::Display for FetchFailure {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Refused(code) => write!(f, "peer refused: {code}"),
+            Self::Transport(error) => write!(f, "{error}"),
+            Self::Malformed(violation) => write!(f, "malformed response: {violation}"),
+        }
+    }
+}
+
+/// The ways a successful response can still fail to answer the request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Violation {
+    /// A chunk is not a `SignedBlock`.
+    Undecodable,
+    /// More chunks than the request could have asked for.
+    TooManyChunks,
+    /// A block's slot falls outside the requested window.
+    OutOfWindow,
+    /// Slots do not ascend strictly, so the response is not a chain segment.
+    NotMonotonic,
+    /// A block was returned whose root was never asked for.
+    Unrequested,
+}
+
+impl core::fmt::Display for Violation {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::Undecodable => "a chunk is not a signed block",
+            Self::TooManyChunks => "more chunks than were requested",
+            Self::OutOfWindow => "a block falls outside the requested window",
+            Self::NotMonotonic => "slots do not ascend",
+            Self::Unrequested => "a block nobody asked for",
+        })
+    }
+}
+
+/// Checks a `BlocksByRange` response against the request that produced it.
+///
+/// A short response is legal — empty slots are absent rather than zero-filled, and a peer may
+/// hold less of the window than it was asked for — so only the three structural properties
+/// are enforced: within the window, strictly ascending, and no more chunks than the window
+/// has slots.
+///
+/// # Errors
+///
+/// [`Violation`] naming the property that failed.
+pub fn validate_range(
+    request: &BlocksByRangeRequest,
+    chunks: &[Vec<u8>],
+) -> Result<Vec<Slot>, Violation> {
+    if chunks.len() as u64 > request.count {
+        return Err(Violation::TooManyChunks);
+    }
+
+    let end = request.start_slot.0.saturating_add(request.count);
+    let mut slots = Vec::with_capacity(chunks.len());
+    let mut previous: Option<u64> = None;
+
+    for chunk in chunks {
+        let block = SignedBlock::from_ssz_bytes(chunk).map_err(|_| Violation::Undecodable)?;
+        let slot = block.block.slot;
+        if slot.0 < request.start_slot.0 || slot.0 >= end {
+            return Err(Violation::OutOfWindow);
+        }
+        if previous.is_some_and(|last| slot.0 <= last) {
+            return Err(Violation::NotMonotonic);
+        }
+        previous = Some(slot.0);
+        slots.push(slot);
+    }
+    Ok(slots)
+}
+
+/// Checks a `BlocksByRoot` response against the roots that were asked for.
+///
+/// Missing roots are skipped silently by the protocol, so a partial response is legal and an
+/// empty one is a legitimate "none of those". What is not legal is a block nobody asked for,
+/// or the same root twice.
+///
+/// # Errors
+///
+/// [`Violation`] naming the property that failed.
+pub fn validate_by_root(
+    requested: &[Bytes32],
+    chunks: &[Vec<u8>],
+) -> Result<Vec<Bytes32>, Violation> {
+    if chunks.len() > requested.len() {
+        return Err(Violation::TooManyChunks);
+    }
+
+    let mut seen = Vec::with_capacity(chunks.len());
+    for chunk in chunks {
+        let block = SignedBlock::from_ssz_bytes(chunk).map_err(|_| Violation::Undecodable)?;
+        let root = hash_tree_root(&block.block);
+        if !requested.contains(&root) || seen.contains(&root) {
+            return Err(Violation::Unrequested);
+        }
+        seen.push(root);
+    }
+    Ok(seen)
+}
+
+/// Asks one peer for a slot range, and returns the chunks only if they answer the request.
+///
+/// # Errors
+///
+/// [`FetchFailure`] carrying the outcome the peer's score is moved by.
+pub async fn fetch_range(
+    handle: &NetworkHandle,
+    peer: PeerId,
+    request: BlocksByRangeRequest,
+) -> Result<Vec<Vec<u8>>, FetchFailure> {
+    let chunks = blocks(handle, peer, Request::BlocksByRange(request)).await?;
+    validate_range(&request, &chunks).map_err(FetchFailure::Malformed)?;
+    Ok(chunks)
+}
+
+/// Asks one peer for specific blocks by root.
+///
+/// # Errors
+///
+/// [`FetchFailure`] carrying the outcome the peer's score is moved by, including
+/// [`Violation::TooManyChunks`] when more roots are asked for than the protocol allows.
+pub async fn fetch_by_root(
+    handle: &NetworkHandle,
+    peer: PeerId,
+    roots: Vec<Bytes32>,
+) -> Result<Vec<Vec<u8>>, FetchFailure> {
+    let list = RequestedBlockRoots::try_from(roots.clone())
+        .map_err(|_| FetchFailure::Malformed(Violation::TooManyChunks))?;
+    let chunks = blocks(
+        handle,
+        peer,
+        Request::BlocksByRoot(BlocksByRootRequest { roots: list }),
+    )
+    .await?;
+    validate_by_root(&roots, &chunks).map_err(FetchFailure::Malformed)?;
+    Ok(chunks)
+}
+
+/// The half of a block request that is the same for both protocols.
+async fn blocks(
+    handle: &NetworkHandle,
+    peer: PeerId,
+    request: Request,
+) -> Result<Vec<Vec<u8>>, FetchFailure> {
+    match handle.request(peer, request).await {
+        Ok(Response::Blocks(chunks)) => Ok(chunks),
+        Ok(Response::Error { code, message }) => {
+            tracing::debug!(%peer, %code, %message, "peer refused a block request");
+            Err(FetchFailure::Refused(code))
+        }
+        // A status payload on a block protocol is the peer answering a question nobody asked.
+        Ok(Response::Status(_)) => Err(FetchFailure::Malformed(Violation::Undecodable)),
+        Err(error) => Err(FetchFailure::Transport(error.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libssz::SszEncode;
+    use verity_chain::hash_tree_root;
+    use verity_p2p::{BlocksByRangeRequest, ErrorCode, MAX_REQUEST_BLOCKS};
+    use verity_types::{Block, MultiMessageAggregate, SignedBlock, Slot};
+
+    use super::{
+        BY_ROOT_GAP_SLOTS, FetchFailure, Gap, Plan, Violation, plan_for_gap, range_from,
+        validate_by_root, validate_range,
+    };
+    use crate::sync::peers::Outcome;
+
+    fn block_at(slot: u64) -> SignedBlock {
+        SignedBlock {
+            block: Block {
+                slot: Slot(slot),
+                ..Block::default()
+            },
+            proof: MultiMessageAggregate::default(),
+        }
+    }
+
+    fn chunk(slot: u64) -> Vec<u8> {
+        block_at(slot).to_ssz()
+    }
+
+    #[test]
+    fn should_chase_a_small_gap_by_root() {
+        let gap = Gap {
+            awaited_root: [7u8; 32],
+            waiting_slot: Slot(10 + BY_ROOT_GAP_SLOTS),
+        };
+        assert_eq!(plan_for_gap(Slot(10), gap), Plan::ByRoot(vec![[7u8; 32]]));
+    }
+
+    #[test]
+    fn should_walk_a_large_gap_by_range_from_the_first_missing_slot() {
+        let gap = Gap {
+            awaited_root: [7u8; 32],
+            waiting_slot: Slot(5_000),
+        };
+        let Plan::ByRange(request) = plan_for_gap(Slot(10), gap) else {
+            panic!("a deep gap is a range walk");
+        };
+        assert_eq!(request.start_slot, Slot(11));
+        assert_eq!(request.count, MAX_REQUEST_BLOCKS as u64);
+    }
+
+    #[test]
+    fn should_never_ask_for_a_window_of_zero_slots() {
+        let request = range_from(Slot(40), Slot(40));
+        assert_eq!(request.start_slot, Slot(41));
+        assert_eq!(request.count, 1);
+    }
+
+    #[test]
+    fn should_accept_a_short_response_inside_the_window() {
+        let request = BlocksByRangeRequest {
+            start_slot: Slot(10),
+            count: 8,
+        };
+        let chunks = vec![chunk(10), chunk(12), chunk(17)];
+        assert_eq!(
+            validate_range(&request, &chunks).expect("a legal partial response"),
+            vec![Slot(10), Slot(12), Slot(17)]
+        );
+    }
+
+    #[test]
+    fn should_reject_a_block_outside_the_requested_window() {
+        let request = BlocksByRangeRequest {
+            start_slot: Slot(10),
+            count: 4,
+        };
+        assert_eq!(
+            validate_range(&request, &[chunk(14)]),
+            Err(Violation::OutOfWindow)
+        );
+        assert_eq!(
+            validate_range(&request, &[chunk(9)]),
+            Err(Violation::OutOfWindow)
+        );
+    }
+
+    #[test]
+    fn should_reject_slots_that_do_not_ascend() {
+        let request = BlocksByRangeRequest {
+            start_slot: Slot(10),
+            count: 8,
+        };
+        assert_eq!(
+            validate_range(&request, &[chunk(12), chunk(11)]),
+            Err(Violation::NotMonotonic)
+        );
+        assert_eq!(
+            validate_range(&request, &[chunk(12), chunk(12)]),
+            Err(Violation::NotMonotonic)
+        );
+    }
+
+    #[test]
+    fn should_reject_more_chunks_than_the_window_holds() {
+        let request = BlocksByRangeRequest {
+            start_slot: Slot(10),
+            count: 1,
+        };
+        assert_eq!(
+            validate_range(&request, &[chunk(10), chunk(11)]),
+            Err(Violation::TooManyChunks)
+        );
+    }
+
+    #[test]
+    fn should_reject_a_chunk_that_is_not_a_block() {
+        let request = BlocksByRangeRequest {
+            start_slot: Slot(10),
+            count: 4,
+        };
+        assert_eq!(
+            validate_range(&request, &[vec![0xff; 3]]),
+            Err(Violation::Undecodable)
+        );
+    }
+
+    #[test]
+    fn should_accept_a_by_root_response_missing_some_roots() {
+        let present = block_at(31);
+        let requested = vec![hash_tree_root(&present.block), [9u8; 32]];
+        assert_eq!(
+            validate_by_root(&requested, &[present.to_ssz()]).expect("a legal partial response"),
+            vec![requested[0]]
+        );
+        assert_eq!(validate_by_root(&requested, &[]), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn should_reject_a_by_root_response_carrying_a_block_nobody_asked_for() {
+        let requested = vec![[9u8; 32]];
+        assert_eq!(
+            validate_by_root(&requested, &[chunk(31)]),
+            Err(Violation::Unrequested)
+        );
+    }
+
+    #[test]
+    fn should_reject_the_same_root_twice() {
+        let present = block_at(31);
+        let requested = vec![hash_tree_root(&present.block), [9u8; 32]];
+        assert_eq!(
+            validate_by_root(&requested, &[present.to_ssz(), present.to_ssz()]),
+            Err(Violation::Unrequested)
+        );
+    }
+
+    #[test]
+    fn should_treat_a_legal_refusal_as_neutral_and_everything_else_as_a_failure() {
+        assert_eq!(
+            FetchFailure::Refused(ErrorCode::ResourceUnavailable).outcome(),
+            Outcome::Neutral
+        );
+        assert_eq!(
+            FetchFailure::Refused(ErrorCode::ServerError).outcome(),
+            Outcome::Failure
+        );
+        assert_eq!(
+            FetchFailure::Malformed(Violation::NotMonotonic).outcome(),
+            Outcome::Failure
+        );
+        assert_eq!(
+            FetchFailure::Transport("timed out".to_string()).outcome(),
+            Outcome::Failure
+        );
+    }
+}

--- a/crates/verity-node/src/sync/mod.rs
+++ b/crates/verity-node/src/sync/mod.rs
@@ -1,0 +1,327 @@
+//! The sync service: where this node is relative to the network, and how it catches up.
+//!
+//! `docs/design/sync.md`. Four things live here, and the split between them is the design:
+//!
+//! - [`state`] — the three-state machine and the median-of-peers trigger. Pure.
+//! - [`peers`] — what each peer claims, how reliably it answers, who gets asked next. Pure.
+//! - [`fetch`] — which request closes a gap, and whether an answer is the shape that was
+//!   asked for.
+//! - [`responder`] — the serving side, answering other nodes out of this node's database.
+//! - [`checkpoint`] — the HTTP entry that lets a node start above genesis.
+//!
+//! This file is the task that drives them: one sequential loop over peer changes, gap
+//! signals, the status refresh, and new snapshots.
+//!
+//! # One request at a time
+//!
+//! The loop awaits each request it issues rather than running a window of them. That is
+//! `docs/design/sync.md`'s "one batch in flight" taken literally, and it is what keeps the
+//! service a small sequential machine — the property `docs/design/concurrency.md` asks of
+//! every task that is not the network edge. A batch is up to `MAX_REQUEST_BLOCKS` blocks, so
+//! the throughput ceiling is a round trip per 1,024 slots, not per slot.
+//!
+//! # Fetched blocks are not privileged
+//!
+//! Everything this service fetches goes into the verification stage's own inbox, the one
+//! gossip arrives on. There is no side door into the chain task: the `Verified*` invariant of
+//! `docs/design/concurrency.md` holds for the sync path with no exceptions.
+
+pub mod checkpoint;
+pub mod fetch;
+pub mod peers;
+pub mod responder;
+pub mod state;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use tokio::sync::{mpsc, watch};
+
+use verity_chain::ChainView;
+use verity_p2p::{GossipKind, NetworkHandle, PeerId, Request, Response};
+use verity_types::Slot;
+use verity_types::config::SECONDS_PER_SLOT;
+
+use crate::network::status_of;
+use crate::verification::GossipPayload;
+
+use self::fetch::{FetchFailure, Gap, Plan};
+use self::peers::{Outcome, PeerTable};
+use self::state::SyncMachine;
+
+pub use self::responder::{BlockRequest, BlockRequestKind, BlockResponder};
+pub use self::state::SyncState;
+
+/// How often the status handshake is re-exchanged with every connected peer.
+///
+/// The trigger is re-checked on every status update, so this interval is what "evaluated
+/// continuously" costs on the wire: an 80-byte round trip per peer per four slots. The
+/// once-per-connection handshake other clients use is the named counterexample — a node that
+/// falls behind on a stable connection never notices.
+pub const STATUS_REFRESH: Duration = Duration::from_secs(4 * SECONDS_PER_SLOT);
+
+/// What sync did, on both sides of it.
+///
+/// The client side and the serving side are counted separately because they are separate
+/// claims: that this node closed a gap by asking, and that it answered someone else's ask.
+/// Both are otherwise invisible — a fetched block is indistinguishable from a gossiped one
+/// once it is in the store, which is exactly what the end-to-end test needs to tell apart.
+#[derive(Debug, Default)]
+pub struct SyncCounters {
+    fetched: AtomicU64,
+    served_requests: AtomicU64,
+    served_blocks: AtomicU64,
+}
+
+impl SyncCounters {
+    /// Blocks this node obtained by asking a peer for them, rather than by gossip.
+    pub fn fetched(&self) -> u64 {
+        self.fetched.load(Ordering::Relaxed)
+    }
+
+    /// Block requests this node answered, refusals included.
+    pub fn served_requests(&self) -> u64 {
+        self.served_requests.load(Ordering::Relaxed)
+    }
+
+    /// Blocks this node handed to peers across those requests.
+    pub fn served_blocks(&self) -> u64 {
+        self.served_blocks.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn record_fetched(&self, blocks: usize) {
+        self.fetched.fetch_add(blocks as u64, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_served(&self, blocks: usize) {
+        self.served_requests.fetch_add(1, Ordering::Relaxed);
+        self.served_blocks
+            .fetch_add(blocks as u64, Ordering::Relaxed);
+    }
+}
+
+/// A connection change, as the network bridge reports it.
+#[derive(Debug, Clone, Copy)]
+pub enum PeerEvent {
+    /// First connection to a peer established.
+    Connected(PeerId),
+    /// Last connection to a peer closed.
+    Disconnected(PeerId),
+}
+
+/// The task that decides whether this node is caught up, and closes the gap when it is not.
+pub struct SyncService {
+    handle: NetworkHandle,
+    view: watch::Receiver<Arc<ChainView>>,
+    gaps: mpsc::Receiver<Gap>,
+    peer_events: mpsc::Receiver<PeerEvent>,
+    blocks: mpsc::Sender<GossipPayload>,
+    synced: watch::Sender<bool>,
+    counters: Arc<SyncCounters>,
+    peers: PeerTable,
+    machine: SyncMachine,
+}
+
+impl SyncService {
+    /// Wires the service to the network, the snapshot channel, and the verification stage.
+    ///
+    /// Returns the service and a `watch` carrying whether the node is caught up. That is an
+    /// observation, not the duty gate: duties turn on head-versus-clock lag in
+    /// `verity-validator` (`docs/design/sync.md`, Decision 1).
+    #[must_use = "a service does nothing until it is run"]
+    pub fn new(
+        handle: NetworkHandle,
+        view: watch::Receiver<Arc<ChainView>>,
+        gaps: mpsc::Receiver<Gap>,
+        peer_events: mpsc::Receiver<PeerEvent>,
+        blocks: mpsc::Sender<GossipPayload>,
+        counters: Arc<SyncCounters>,
+    ) -> (Self, watch::Receiver<bool>) {
+        let (synced, gate) = watch::channel(false);
+        (
+            Self {
+                handle,
+                view,
+                gaps,
+                peer_events,
+                blocks,
+                synced,
+                counters,
+                peers: PeerTable::new(),
+                machine: SyncMachine::new(),
+            },
+            gate,
+        )
+    }
+
+    /// Runs until the network bridge and the verification stage are both gone.
+    pub async fn run(mut self) {
+        let mut refresh = tokio::time::interval(STATUS_REFRESH);
+        refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            let carry_on = tokio::select! {
+                biased;
+
+                event = self.peer_events.recv() => match event {
+                    Some(event) => self.on_peer_event(event).await,
+                    None => false,
+                },
+
+                gap = self.gaps.recv() => match gap {
+                    Some(gap) => self.on_gap(gap).await,
+                    None => false,
+                },
+
+                _ = refresh.tick() => self.refresh_status().await,
+
+                changed = self.view.changed() => {
+                    if changed.is_err() {
+                        false
+                    } else {
+                        self.reevaluate().await
+                    }
+                },
+            };
+
+            if !carry_on {
+                break;
+            }
+        }
+        tracing::debug!(state = %self.machine.state(), "sync service stopping");
+    }
+
+    /// A peer arrived or left. A new peer is handshaked at once rather than at the next
+    /// refresh: it is the fastest this node can learn it is behind.
+    async fn on_peer_event(&mut self, event: PeerEvent) -> bool {
+        match event {
+            PeerEvent::Connected(peer) => {
+                self.peers.connected(peer);
+                self.exchange_status(peer).await;
+            }
+            PeerEvent::Disconnected(peer) => self.peers.disconnected(&peer),
+        }
+        self.reevaluate().await
+    }
+
+    /// Re-exchanges status with every connected peer.
+    async fn refresh_status(&mut self) -> bool {
+        for peer in self.peers.connected_peers() {
+            self.exchange_status(peer).await;
+        }
+        self.reevaluate().await
+    }
+
+    /// One status handshake, and what it does to the peer's standing.
+    async fn exchange_status(&mut self, peer: PeerId) {
+        let ours = status_of(&self.view);
+        self.peers.begin_request(&peer);
+        let outcome = match self.handle.request(peer, Request::Status(ours)).await {
+            Ok(Response::Status(theirs)) => {
+                self.peers.observe_status(peer, theirs);
+                Outcome::Success
+            }
+            Ok(Response::Error { code, .. }) => {
+                tracing::debug!(%peer, %code, "peer refused the status handshake");
+                Outcome::Failure
+            }
+            Ok(Response::Blocks(_)) => Outcome::Failure,
+            Err(error) => {
+                tracing::debug!(%peer, %error, "status handshake failed");
+                Outcome::of_request_error(&error)
+            }
+        };
+        self.peers.finish_request(&peer, outcome, Instant::now());
+    }
+
+    /// The verification stage could not resolve an item's ancestry.
+    async fn on_gap(&mut self, gap: Gap) -> bool {
+        let plan = fetch::plan_for_gap(self.head_slot(), gap);
+        self.execute(plan).await
+    }
+
+    /// Re-runs the trigger, publishes the gate, and issues the next batch while behind.
+    ///
+    /// This is the one place the machine moves. It runs on every input the trigger depends
+    /// on — a status update, a connection change, a new snapshot — which is what makes the
+    /// condition continuously evaluated rather than checked once per connection.
+    async fn reevaluate(&mut self) -> bool {
+        let head = self.head_slot();
+        let state = self
+            .machine
+            .observe(head, self.peers.network_finalized_slot());
+        self.synced.send_replace(state.is_caught_up());
+
+        if state != SyncState::Syncing {
+            return true;
+        }
+
+        // Pagination terminates on the same condition the machine watches: after each batch
+        // the loop comes back here with a new snapshot and asks again.
+        let Some(target) = self.peers.highest_claimed_head() else {
+            return true;
+        };
+        if target.0 <= head.0 {
+            return true;
+        }
+        self.execute(Plan::ByRange(fetch::range_from(head, target)))
+            .await
+    }
+
+    /// Issues one request and feeds whatever comes back into the verification stage.
+    async fn execute(&mut self, plan: Plan) -> bool {
+        let Some(peer) = self.peers.select_for_blocks(Instant::now()) else {
+            return true;
+        };
+
+        self.peers.begin_request(&peer);
+        let fetched = match plan {
+            Plan::ByRoot(roots) => fetch::fetch_by_root(&self.handle, peer, roots).await,
+            Plan::ByRange(request) => fetch::fetch_range(&self.handle, peer, request).await,
+        };
+
+        match fetched {
+            Ok(chunks) => {
+                self.peers
+                    .finish_request(&peer, Outcome::Success, Instant::now());
+                self.forward(chunks).await
+            }
+            Err(failure) => {
+                self.report(&peer, &failure);
+                true
+            }
+        }
+    }
+
+    /// Hands fetched blocks to the verification stage, on the channel gossip uses.
+    ///
+    /// The send awaits rather than shedding: unlike gossip, nothing else is going to deliver
+    /// these blocks, and the backpressure is what stops a range walk from outrunning
+    /// verification.
+    async fn forward(&self, chunks: Vec<Vec<u8>>) -> bool {
+        self.counters.record_fetched(chunks.len());
+        for payload in chunks {
+            let block = GossipPayload {
+                kind: GossipKind::Block,
+                payload,
+            };
+            if self.blocks.send(block).await.is_err() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Scores a failed request and says why, once.
+    fn report(&mut self, peer: &PeerId, failure: &FetchFailure) {
+        let outcome = failure.outcome();
+        self.peers.finish_request(peer, outcome, Instant::now());
+        tracing::debug!(%peer, %failure, score = ?self.peers.score(peer), "block request failed");
+    }
+
+    /// The slot of this node's head block, which is what the trigger compares.
+    fn head_slot(&self) -> Slot {
+        self.view.borrow().head_checkpoint().slot
+    }
+}

--- a/crates/verity-node/src/sync/peers.rs
+++ b/crates/verity-node/src/sync/peers.rs
@@ -1,0 +1,382 @@
+//! Peer management: what each peer claims, how reliably it answers, and who gets asked next.
+//!
+//! `docs/design/sync.md`, Decision 3. The spec is silent on scoring, disconnects and limits,
+//! so this is deliberately minimal policy over the one implemented precedent: a
+//! request-reliability score, weighted selection that never fully excludes a peer, and no
+//! bans at all. Deprioritization is the only consequence a peer ever suffers here.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use rand::RngExt;
+use verity_p2p::{PeerId, RequestError, Status};
+use verity_types::Slot;
+
+use super::state::median_finalized;
+
+/// Score a peer starts at, and the midpoint of the range.
+pub const INITIAL_SCORE: i32 = 100;
+/// What a completed request is worth.
+pub const SUCCESS_REWARD: i32 = 10;
+/// What a failed one costs. Twice the reward, so a failing peer loses weight faster than it
+/// earns it.
+pub const FAILURE_PENALTY: i32 = 20;
+/// The score floor. A peer at the floor is still selectable — exclusion on a devnet-sized
+/// peer set is a direct liveness cut.
+pub const MIN_SCORE: i32 = 0;
+/// The score ceiling.
+pub const MAX_SCORE: i32 = 200;
+
+/// How many requests may be outstanding to one peer at a time.
+pub const MAX_CONCURRENT_REQUESTS: usize = 2;
+
+/// How long a peer stays flagged as not speaking a block protocol.
+///
+/// The flag has exactly one trigger — libp2p protocol negotiation failing — and a TTL so a
+/// peer that gains the protocol on its next release is not excluded forever.
+pub const CAPABILITY_TTL: Duration = Duration::from_secs(600);
+
+/// What one request outcome does to a peer's standing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The peer answered, and the answer was usable.
+    Success,
+    /// The peer timed out, disconnected, errored, or served malformed content inside a
+    /// success. All four are the same consequence: it does serve the protocol, badly.
+    Failure,
+    /// `RESOURCE_UNAVAILABLE`: the spec's legal answer for history below the serving window.
+    /// No score change; the request is re-routed to another peer.
+    Neutral,
+    /// The peer does not speak the protocol at all. The one thing that sets the capability
+    /// flag, and it is never set by anything response-shaped.
+    Unsupported,
+}
+
+impl Outcome {
+    /// How a transport-level failure scores.
+    #[must_use]
+    pub const fn of_request_error(error: &RequestError) -> Self {
+        match error {
+            RequestError::UnsupportedProtocol => Self::Unsupported,
+            _ => Self::Failure,
+        }
+    }
+}
+
+/// One peer, as the sync service sees it.
+#[derive(Debug)]
+struct Peer {
+    /// The peer's last claimed checkpoints, absent until it answers a handshake.
+    status: Option<Status>,
+    score: i32,
+    in_flight: usize,
+    /// When the capability flag lapses, absent when the peer is not flagged.
+    unsupported_until: Option<Instant>,
+}
+
+impl Peer {
+    const fn new() -> Self {
+        Self {
+            status: None,
+            score: INITIAL_SCORE,
+            in_flight: 0,
+            unsupported_until: None,
+        }
+    }
+
+    fn serves_blocks(&self, now: Instant) -> bool {
+        self.unsupported_until.is_none_or(|until| now >= until)
+    }
+
+    /// Selection weight. Never zero: the floor peer keeps one share.
+    const fn weight(&self) -> u32 {
+        (self.score + 1) as u32
+    }
+}
+
+/// Every connected peer, with what it claims and how well it has answered.
+#[derive(Debug, Default)]
+pub struct PeerTable {
+    peers: HashMap<PeerId, Peer>,
+}
+
+impl PeerTable {
+    /// An empty table.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records a new connection. A reconnecting peer starts over at [`INITIAL_SCORE`]:
+    /// nothing here survives a disconnect, because nothing here is a punishment.
+    pub fn connected(&mut self, peer: PeerId) {
+        self.peers.insert(peer, Peer::new());
+    }
+
+    /// Forgets a peer.
+    pub fn disconnected(&mut self, peer: &PeerId) {
+        self.peers.remove(peer);
+    }
+
+    /// Records what a peer claims about its own chain.
+    pub fn observe_status(&mut self, peer: PeerId, status: Status) {
+        self.peers.entry(peer).or_insert_with(Peer::new).status = Some(status);
+    }
+
+    /// Every connected peer, whether or not it has answered a handshake yet.
+    #[must_use]
+    pub fn connected_peers(&self) -> Vec<PeerId> {
+        self.peers.keys().copied().collect()
+    }
+
+    /// Whether no peer is connected.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+
+    /// The network's finalized slot as the connected peers claim it.
+    #[must_use]
+    pub fn network_finalized_slot(&self) -> Option<Slot> {
+        median_finalized(
+            self.peers
+                .values()
+                .filter_map(|peer| peer.status.map(|status| status.finalized.slot))
+                .collect(),
+        )
+    }
+
+    /// The highest head any peer claims, which is how far a range walk may usefully run.
+    #[must_use]
+    pub fn highest_claimed_head(&self) -> Option<Slot> {
+        self.peers
+            .values()
+            .filter_map(|peer| peer.status.map(|status| status.head.slot))
+            .max_by_key(|slot| slot.0)
+    }
+
+    /// Picks a peer to ask for blocks, by score-weighted random selection.
+    ///
+    /// Peers at the concurrency limit and peers whose capability flag is still live are out
+    /// of the draw; everyone else is in it, including a peer sitting at the score floor.
+    #[must_use]
+    pub fn select_for_blocks(&self, now: Instant) -> Option<PeerId> {
+        let eligible =
+            |peer: &Peer| peer.in_flight < MAX_CONCURRENT_REQUESTS && peer.serves_blocks(now);
+
+        // Two passes over the table rather than one pass into a `Vec`: the draw needs the
+        // total before it can pick a ticket, and the table is a devnet's worth of peers.
+        let total: u32 = self
+            .peers
+            .values()
+            .filter(|peer| eligible(peer))
+            .map(Peer::weight)
+            .sum();
+        if total == 0 {
+            return None;
+        }
+
+        let mut ticket = rand::rng().random_range(0..total);
+        for (id, peer) in self.peers.iter().filter(|(_, peer)| eligible(peer)) {
+            let weight = peer.weight();
+            if ticket < weight {
+                return Some(*id);
+            }
+            ticket -= weight;
+        }
+        None
+    }
+
+    /// Marks a request as outstanding against a peer.
+    pub fn begin_request(&mut self, peer: &PeerId) {
+        if let Some(entry) = self.peers.get_mut(peer) {
+            entry.in_flight += 1;
+        }
+    }
+
+    /// Records how a request ended, and moves the peer's score accordingly.
+    pub fn finish_request(&mut self, peer: &PeerId, outcome: Outcome, now: Instant) {
+        let Some(entry) = self.peers.get_mut(peer) else {
+            return;
+        };
+        entry.in_flight = entry.in_flight.saturating_sub(1);
+
+        let delta = match outcome {
+            Outcome::Success => SUCCESS_REWARD,
+            Outcome::Failure | Outcome::Unsupported => -FAILURE_PENALTY,
+            Outcome::Neutral => 0,
+        };
+        entry.score = (entry.score + delta).clamp(MIN_SCORE, MAX_SCORE);
+
+        if outcome == Outcome::Unsupported {
+            entry.unsupported_until = Some(now + CAPABILITY_TTL);
+        }
+    }
+
+    /// A peer's score, for tests and for the operator's log line.
+    #[must_use]
+    pub fn score(&self, peer: &PeerId) -> Option<i32> {
+        self.peers.get(peer).map(|entry| entry.score)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use verity_p2p::{PeerId, RequestError, Status};
+    use verity_types::{Checkpoint, Slot};
+
+    use super::{
+        CAPABILITY_TTL, INITIAL_SCORE, MAX_CONCURRENT_REQUESTS, MAX_SCORE, MIN_SCORE, Outcome,
+        PeerTable,
+    };
+
+    fn status(finalized: u64, head: u64) -> Status {
+        Status {
+            finalized: Checkpoint {
+                root: [1u8; 32],
+                slot: Slot(finalized),
+            },
+            head: Checkpoint {
+                root: [2u8; 32],
+                slot: Slot(head),
+            },
+        }
+    }
+
+    #[test]
+    fn should_reward_success_less_than_it_punishes_failure() {
+        let peer = PeerId::random();
+        let mut table = PeerTable::new();
+        table.connected(peer);
+        let now = Instant::now();
+
+        table.begin_request(&peer);
+        table.finish_request(&peer, Outcome::Success, now);
+        assert_eq!(table.score(&peer), Some(INITIAL_SCORE + 10));
+
+        table.begin_request(&peer);
+        table.finish_request(&peer, Outcome::Failure, now);
+        assert_eq!(table.score(&peer), Some(INITIAL_SCORE - 10));
+    }
+
+    #[test]
+    fn should_leave_the_score_alone_when_the_peer_refuses_history_it_may_refuse() {
+        let peer = PeerId::random();
+        let mut table = PeerTable::new();
+        table.connected(peer);
+
+        table.begin_request(&peer);
+        table.finish_request(&peer, Outcome::Neutral, Instant::now());
+        assert_eq!(table.score(&peer), Some(INITIAL_SCORE));
+    }
+
+    #[test]
+    fn should_clamp_the_score_to_its_range() {
+        let peer = PeerId::random();
+        let mut table = PeerTable::new();
+        table.connected(peer);
+        let now = Instant::now();
+
+        for _ in 0..50 {
+            table.finish_request(&peer, Outcome::Success, now);
+        }
+        assert_eq!(table.score(&peer), Some(MAX_SCORE));
+
+        for _ in 0..50 {
+            table.finish_request(&peer, Outcome::Failure, now);
+        }
+        assert_eq!(table.score(&peer), Some(MIN_SCORE));
+    }
+
+    #[test]
+    fn should_keep_selecting_a_peer_sitting_at_the_score_floor() {
+        let peer = PeerId::random();
+        let mut table = PeerTable::new();
+        table.connected(peer);
+        let now = Instant::now();
+        for _ in 0..50 {
+            table.finish_request(&peer, Outcome::Failure, now);
+        }
+        assert_eq!(table.score(&peer), Some(MIN_SCORE));
+        assert_eq!(table.select_for_blocks(now), Some(peer));
+    }
+
+    #[test]
+    fn should_flag_only_a_peer_that_does_not_speak_the_protocol() {
+        let peer = PeerId::random();
+        let mut table = PeerTable::new();
+        table.connected(peer);
+        let now = Instant::now();
+
+        table.finish_request(
+            &peer,
+            Outcome::of_request_error(&RequestError::Timeout),
+            now,
+        );
+        assert_eq!(table.select_for_blocks(now), Some(peer));
+
+        table.finish_request(
+            &peer,
+            Outcome::of_request_error(&RequestError::UnsupportedProtocol),
+            now,
+        );
+        assert_eq!(table.select_for_blocks(now), None);
+    }
+
+    #[test]
+    fn should_let_the_capability_flag_lapse() {
+        let peer = PeerId::random();
+        let mut table = PeerTable::new();
+        table.connected(peer);
+        let now = Instant::now();
+
+        table.finish_request(&peer, Outcome::Unsupported, now);
+        assert_eq!(table.select_for_blocks(now), None);
+        assert_eq!(
+            table.select_for_blocks(now + CAPABILITY_TTL + Duration::from_secs(1)),
+            Some(peer)
+        );
+    }
+
+    #[test]
+    fn should_stop_selecting_a_peer_at_its_concurrency_limit() {
+        let peer = PeerId::random();
+        let mut table = PeerTable::new();
+        table.connected(peer);
+        let now = Instant::now();
+
+        for _ in 0..MAX_CONCURRENT_REQUESTS {
+            table.begin_request(&peer);
+        }
+        assert_eq!(table.select_for_blocks(now), None);
+
+        table.finish_request(&peer, Outcome::Success, now);
+        assert_eq!(table.select_for_blocks(now), Some(peer));
+    }
+
+    #[test]
+    fn should_report_the_median_of_what_peers_claim() {
+        let mut table = PeerTable::new();
+        for (index, finalized) in [10u64, 20, 30, 40].into_iter().enumerate() {
+            let peer = PeerId::random();
+            table.connected(peer);
+            table.observe_status(peer, status(finalized, finalized + index as u64));
+        }
+        assert_eq!(table.network_finalized_slot(), Some(Slot(20)));
+        assert_eq!(table.highest_claimed_head(), Some(Slot(43)));
+    }
+
+    #[test]
+    fn should_forget_a_peer_that_disconnects() {
+        let peer = PeerId::random();
+        let mut table = PeerTable::new();
+        table.connected(peer);
+        table.observe_status(peer, status(10, 12));
+        table.disconnected(&peer);
+
+        assert!(table.is_empty());
+        assert_eq!(table.network_finalized_slot(), None);
+    }
+}

--- a/crates/verity-node/src/sync/responder.rs
+++ b/crates/verity-node/src/sync/responder.rs
@@ -1,0 +1,250 @@
+//! The serving side: answering another node's block requests out of this node's database.
+//!
+//! leanSpec's one MUST for the ReqResp suite is here — a responder serves `BlocksByRange`
+//! over the sliding `MIN_SLOTS_FOR_BLOCK_REQUESTS` window, and answers `RESOURCE_UNAVAILABLE`
+//! below it rather than with a short response. The window itself, and the floor a
+//! checkpoint-synced node advertises instead of slot zero, are `verity-db`'s
+//! (`docs/design/storage.md`); this module is the protocol face of them.
+//!
+//! # Why it is a task of its own
+//!
+//! A full window is 1,024 blocks, and a block carries an aggregate proof of 155–236 KB. One
+//! answered request can therefore be hundreds of megabytes off disk, which is not work that
+//! may happen on the chain writer's thread — nor on the network bridge, which has to keep
+//! draining gossip. The responder reads through a read-only handle on the same open database
+//! (`verity-db`'s [`StorageReader`]), so it neither blocks the writer nor can write itself.
+
+use std::sync::Arc;
+
+use libssz::SszEncode;
+use tokio::sync::{mpsc, watch};
+
+use verity_chain::ChainView;
+use verity_db::{Repository, StorageError, StorageReader};
+use verity_p2p::{
+    BlocksByRangeRequest, BlocksByRootRequest, ErrorCode, MAX_REQUEST_BLOCKS, NetworkHandle,
+    PeerId, Response, ResponseChannel,
+};
+use verity_types::{Bytes32, SignedBlock, Slot};
+
+use crate::store_open::{block_from, root_prefix};
+use crate::sync::SyncCounters;
+
+/// A block request taken off the network bridge, with the channel its answer goes back on.
+///
+/// Only the two block protocols reach here. Status is answered from the snapshot on the
+/// bridge itself, so there is no third variant and no impossible case to handle.
+#[derive(Debug)]
+pub struct BlockRequest {
+    /// The peer that asked.
+    pub peer: PeerId,
+    /// What it asked for.
+    pub kind: BlockRequestKind,
+    /// Where the answer goes.
+    pub channel: ResponseChannel,
+}
+
+/// The two block protocols.
+#[derive(Debug)]
+pub enum BlockRequestKind {
+    /// Specific blocks, by root.
+    ByRoot(BlocksByRootRequest),
+    /// A contiguous slot range.
+    ByRange(BlocksByRangeRequest),
+}
+
+/// Serves block requests from the database, one at a time.
+pub struct BlockResponder<B> {
+    repository: Arc<Repository<B>>,
+    view: watch::Receiver<Arc<ChainView>>,
+    requests: mpsc::Receiver<BlockRequest>,
+    handle: NetworkHandle,
+    counters: Arc<SyncCounters>,
+}
+
+impl<B: StorageReader + Send + Sync + 'static> BlockResponder<B> {
+    /// Wires the responder to its read-only database handle and the bridge's request stream.
+    #[must_use = "a responder does nothing until it is run"]
+    pub fn new(
+        repository: Arc<Repository<B>>,
+        view: watch::Receiver<Arc<ChainView>>,
+        requests: mpsc::Receiver<BlockRequest>,
+        handle: NetworkHandle,
+        counters: Arc<SyncCounters>,
+    ) -> Self {
+        Self {
+            repository,
+            view,
+            requests,
+            handle,
+            counters,
+        }
+    }
+
+    /// Answers requests until the bridge stops forwarding them.
+    ///
+    /// Requests are served one at a time on purpose: the point of the separate task is to
+    /// keep large reads off the writer and off the gossip path, not to let a peer open as
+    /// many concurrent disk walks as it likes.
+    pub async fn run(mut self) {
+        while let Some(BlockRequest {
+            peer,
+            kind,
+            channel,
+        }) = self.requests.recv().await
+        {
+            let current_slot = self.view.borrow().slot();
+            let repository = Arc::clone(&self.repository);
+
+            // Off the async threads: this is disk I/O measured in hundreds of megabytes. A
+            // join error means the blocking pool is gone, which only happens as the runtime
+            // shuts down.
+            let read =
+                tokio::task::spawn_blocking(move || answer(&repository, current_slot, &kind));
+            let Ok(response) = read.await else {
+                break;
+            };
+
+            self.counters.record_served(match &response {
+                Response::Blocks(chunks) => chunks.len(),
+                // A refusal is a served request that carried no blocks.
+                _ => 0,
+            });
+            if self.handle.respond(channel, response).await.is_err() {
+                break;
+            }
+            tracing::trace!(%peer, "served a block request");
+        }
+    }
+}
+
+/// Builds the answer to one block request.
+///
+/// # Panics
+///
+/// Never: every storage failure becomes a `SERVER_ERROR` response, because a peer's malformed
+/// or unlucky request is not a reason to stop a consensus node.
+#[must_use]
+pub fn answer<B: StorageReader>(
+    repository: &Repository<B>,
+    current_slot: Slot,
+    request: &BlockRequestKind,
+) -> Response {
+    let outcome = match request {
+        BlockRequestKind::ByRange(range) => serve_range(repository, current_slot, *range),
+        BlockRequestKind::ByRoot(roots) => serve_roots(repository, roots),
+    };
+
+    match outcome {
+        Ok(response) => response,
+        Err(error) => {
+            tracing::warn!(%error, "a block request could not be served");
+            Response::Error {
+                code: ErrorCode::ServerError,
+                message: "the block store could not be read".to_string(),
+            }
+        }
+    }
+}
+
+/// Answers a `BlocksByRange`, or refuses it in the protocol's own terms.
+fn serve_range<B: StorageReader>(
+    repository: &Repository<B>,
+    current_slot: Slot,
+    request: BlocksByRangeRequest,
+) -> Result<Response, StorageError> {
+    if request.count == 0 || request.count > MAX_REQUEST_BLOCKS as u64 {
+        return Ok(Response::Error {
+            code: ErrorCode::InvalidRequest,
+            message: format!("count must be 1..={MAX_REQUEST_BLOCKS}"),
+        });
+    }
+
+    // The one MUST: below the advertised floor a responder refuses rather than answering
+    // short, so a peer can tell "I do not keep that history" from "there were no blocks".
+    if !repository.can_serve_range(current_slot, request.start_slot)? {
+        let floor = repository.range_service_floor(current_slot)?;
+        return Ok(Response::Error {
+            code: ErrorCode::ResourceUnavailable,
+            message: format!("history below slot {} is not served", floor.0),
+        });
+    }
+
+    let end = Slot(request.start_slot.0.saturating_add(request.count));
+    let anchor = anchor_slot(repository)?;
+    let mut chunks = Vec::new();
+    for (slot, root) in repository.canonical_range(request.start_slot, end)? {
+        if let Some(block) = stored_signed_block(repository, slot, root, anchor)? {
+            chunks.push(block.to_ssz());
+        }
+    }
+    Ok(Response::Blocks(chunks))
+}
+
+/// Answers a `BlocksByRoot`. Roots this node does not hold are skipped silently.
+fn serve_roots<B: StorageReader>(
+    repository: &Repository<B>,
+    request: &BlocksByRootRequest,
+) -> Result<Response, StorageError> {
+    let anchor = anchor_slot(repository)?;
+    let mut chunks = Vec::new();
+    for root in request.roots.iter() {
+        let Some(header) = repository.block_header(*root)? else {
+            continue;
+        };
+        if let Some(block) = stored_signed_block(repository, header.slot, *root, anchor)? {
+            chunks.push(block.to_ssz());
+        }
+    }
+    Ok(Response::Blocks(chunks))
+}
+
+/// Reassembles a stored block and its proof into the chunk a response carries.
+///
+/// `None` means the block is not servable rather than that the database is damaged, and there
+/// is exactly one such block: the anchor. A genesis or checkpoint anchor is adopted from
+/// configuration rather than received over the wire, so no proof was ever stored with it, and
+/// no peer needs one. Above the anchor a missing part *is* damage — the read is inside the
+/// window this node advertises — and the error propagates into a `SERVER_ERROR` rather than
+/// a hole in the response.
+fn stored_signed_block<B: StorageReader>(
+    repository: &Repository<B>,
+    slot: Slot,
+    root: Bytes32,
+    anchor: Slot,
+) -> Result<Option<SignedBlock>, StorageError> {
+    let (Some(header), Some(body)) = (repository.block_header(root)?, repository.block_body(root)?)
+    else {
+        return incomplete(slot, root, anchor, "block");
+    };
+    let Some(proof) = repository.block_proof(slot, root)? else {
+        return incomplete(slot, root, anchor, "proof");
+    };
+
+    Ok(Some(SignedBlock {
+        block: block_from(&header, body),
+        proof,
+    }))
+}
+
+/// The first slot this node holds proof-bearing history for.
+fn anchor_slot<B: StorageReader>(repository: &Repository<B>) -> Result<Slot, StorageError> {
+    Ok(repository.served_from_slot()?.unwrap_or(Slot(0)))
+}
+
+/// Decides whether a missing part is the anchor's absence or the database's damage.
+fn incomplete(
+    slot: Slot,
+    root: Bytes32,
+    anchor: Slot,
+    missing: &str,
+) -> Result<Option<SignedBlock>, StorageError> {
+    if slot.0 <= anchor.0 {
+        return Ok(None);
+    }
+    Err(StorageError::Backend(format!(
+        "canonical block at slot {} is missing its {missing} ({})",
+        slot.0,
+        root_prefix(root)
+    )))
+}

--- a/crates/verity-node/src/sync/state.rs
+++ b/crates/verity-node/src/sync/state.rs
@@ -1,0 +1,181 @@
+//! The sync mode lifecycle: three states, one trigger, evaluated continuously.
+//!
+//! `docs/design/sync.md`, Decision 1. The whole of the machine is here, deliberately without
+//! I/O: it is fed a head slot and what peers claim, and it answers with a state. Everything
+//! that decides *when* to feed it lives in [`crate::sync`].
+
+use verity_types::Slot;
+
+/// Where a node is relative to the network.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncState {
+    /// Nothing is known yet: no peer has answered a status handshake.
+    Idle,
+    /// The node is behind, or has not yet confirmed that it is not.
+    Syncing,
+    /// The node's head is at or above what the network claims is final.
+    Synced,
+}
+
+impl SyncState {
+    /// Whether this node considers itself caught up with the network.
+    ///
+    /// Observability, not a gate. Validator duties turn on head-versus-clock lag, which is a
+    /// different question and lives in `verity-validator` — see `docs/design/sync.md`,
+    /// Decision 1, on why a peer-derived state cannot answer "is this node's view stale".
+    #[must_use]
+    pub const fn is_caught_up(self) -> bool {
+        matches!(self, Self::Synced)
+    }
+}
+
+impl core::fmt::Display for SyncState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::Idle => "idle",
+            Self::Syncing => "syncing",
+            Self::Synced => "synced",
+        })
+    }
+}
+
+/// The state machine itself.
+#[derive(Debug, Default)]
+pub struct SyncMachine {
+    state: Option<SyncState>,
+}
+
+impl SyncMachine {
+    /// A machine that has heard from nobody yet.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { state: None }
+    }
+
+    /// The current state.
+    #[must_use]
+    pub fn state(&self) -> SyncState {
+        self.state.unwrap_or(SyncState::Idle)
+    }
+
+    /// Re-evaluates the trigger against one observation, and answers with the new state.
+    ///
+    /// `network_finalized` is the median of connected peers' claimed finalized slots, or
+    /// `None` while no peer has answered. With no peers there is no network to be behind, so
+    /// the state does not move — a node alone on a segment stays where it is rather than
+    /// declaring itself synced against nothing.
+    ///
+    /// The one transition that does not exist is `IDLE → SYNCED`: a node that has just met
+    /// the network passes through `SYNCING` even when it turns out to be caught up already.
+    /// The reference node's guard, kept, and it costs one further observation — which arrives
+    /// on the next status refresh or the next snapshot, not on a timer of its own.
+    pub fn observe(&mut self, head_slot: Slot, network_finalized: Option<Slot>) -> SyncState {
+        let Some(network_finalized) = network_finalized else {
+            return self.state();
+        };
+
+        let behind = head_slot.0 < network_finalized.0;
+        let next = match (self.state, behind) {
+            (None, _) => SyncState::Syncing,
+            (Some(SyncState::Syncing), false) => SyncState::Synced,
+            (Some(SyncState::Synced), true) => SyncState::Syncing,
+            (Some(current), _) => current,
+        };
+
+        if self.state != Some(next) {
+            tracing::info!(
+                from = %self.state(),
+                to = %next,
+                head = head_slot.0,
+                network_finalized = network_finalized.0,
+                "sync state changed"
+            );
+        }
+        self.state = Some(next);
+        next
+    }
+}
+
+/// The network's finalized slot: the median of what peers claim.
+///
+/// The median is what "majority vote" means here — no minority of lying peers can move it
+/// outside the range the honest peers occupy. For an even count the lower middle value is
+/// taken, which is the conservative choice: it under-states the network rather than holding
+/// the node in `SYNCING` against a claim nobody can serve.
+#[must_use]
+pub fn median_finalized(mut claims: Vec<Slot>) -> Option<Slot> {
+    if claims.is_empty() {
+        return None;
+    }
+    claims.sort_unstable_by_key(|slot| slot.0);
+    Some(claims[(claims.len() - 1) / 2])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SyncMachine, SyncState, median_finalized};
+    use verity_types::Slot;
+
+    #[test]
+    fn should_take_the_lower_middle_claim_when_the_peer_count_is_even() {
+        let claims = vec![Slot(10), Slot(20), Slot(30), Slot(40)];
+        assert_eq!(median_finalized(claims), Some(Slot(20)));
+    }
+
+    #[test]
+    fn should_take_the_middle_claim_when_the_peer_count_is_odd() {
+        let claims = vec![Slot(30), Slot(10), Slot(20)];
+        assert_eq!(median_finalized(claims), Some(Slot(20)));
+    }
+
+    #[test]
+    fn should_ignore_a_single_lying_peer_in_a_healthy_set() {
+        let honest = vec![Slot(100), Slot(101), Slot(100)];
+        let mut lying = honest.clone();
+        lying.push(Slot(9_000_000));
+        // The liar moves the median by at most one honest position, never outside the set.
+        assert!(median_finalized(lying).expect("a median").0 <= 101);
+    }
+
+    #[test]
+    fn should_answer_none_when_no_peer_has_claimed_anything() {
+        assert_eq!(median_finalized(Vec::new()), None);
+    }
+
+    #[test]
+    fn should_stay_idle_while_no_peer_has_answered() {
+        let mut machine = SyncMachine::new();
+        assert_eq!(machine.observe(Slot(0), None), SyncState::Idle);
+        assert!(!machine.state().is_caught_up());
+    }
+
+    #[test]
+    fn should_never_shortcut_from_idle_to_synced() {
+        let mut machine = SyncMachine::new();
+        // Caught up on the very first observation, and still not synced.
+        assert_eq!(
+            machine.observe(Slot(50), Some(Slot(50))),
+            SyncState::Syncing
+        );
+        assert_eq!(machine.observe(Slot(50), Some(Slot(50))), SyncState::Synced);
+    }
+
+    #[test]
+    fn should_demote_to_syncing_when_a_gap_reappears() {
+        let mut machine = SyncMachine::new();
+        machine.observe(Slot(50), Some(Slot(50)));
+        assert_eq!(machine.observe(Slot(50), Some(Slot(50))), SyncState::Synced);
+        assert_eq!(
+            machine.observe(Slot(50), Some(Slot(120))),
+            SyncState::Syncing
+        );
+    }
+
+    #[test]
+    fn should_hold_its_state_when_every_peer_disconnects() {
+        let mut machine = SyncMachine::new();
+        machine.observe(Slot(50), Some(Slot(50)));
+        machine.observe(Slot(50), Some(Slot(50)));
+        assert_eq!(machine.observe(Slot(50), None), SyncState::Synced);
+    }
+}

--- a/crates/verity-node/src/verification.rs
+++ b/crates/verity-node/src/verification.rs
@@ -24,8 +24,13 @@
 //! them is punished, because gossipsub forwards before anyone verifies and the peer that
 //! delivered it may be an honest relay (`docs/design/sync.md`, Decision 3).
 //!
-//! Overflow evicts the oldest arrival, silently. Nothing re-requests it: an evicted block is
-//! what range sync is for, and an evicted vote comes back inside an aggregate or a block.
+//! Overflow evicts the oldest arrival. Both parking and eviction emit a gap signal — the
+//! root the item was waiting for, and the waiting item's own slot — to the sync service,
+//! which is the concrete mechanism behind `docs/design/concurrency.md`'s "range sync closes
+//! the gap when the chain notices the missing ancestry" (`docs/design/sync.md`, Decision 2).
+//! The noticing happens here, where an unknown parent is first discovered, not in the chain
+//! task. The signal is a `try_send` on a bounded channel: a full channel means the sync
+//! service is already busy closing gaps, and the next park re-raises the same one.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -40,9 +45,11 @@ use verity_crypto::containers::SignedAttestation;
 use verity_p2p::GossipKind;
 use verity_types::{
     AttestationData, Block, Bytes32, MultiMessageAggregate, SignedAggregatedAttestation,
-    SignedBlock, ValidatorIndex, Validators,
+    SignedBlock, Slot, ValidatorIndex, Validators,
 };
 use verity_validator::proofs;
+
+use crate::sync::fetch::Gap;
 
 /// A block whose proof has been checked against the registry its parent fixed.
 ///
@@ -204,6 +211,27 @@ impl Decoded {
             Self::Aggregate(signed) => signed.data.target.root,
         }
     }
+
+    /// The waiting item's own slot, which upper-bounds the head-side edge of the gap.
+    ///
+    /// The awaited block is known only by root, so its slot is exactly what this node does
+    /// not have; the child's slot is the nearest bound available and is what decides whether
+    /// the gap is chased by root or walked by range.
+    const fn slot(&self) -> Slot {
+        match self {
+            Self::Block(signed) => signed.block.slot,
+            Self::Attestation(signed) => signed.data.slot,
+            Self::Aggregate(signed) => signed.data.slot,
+        }
+    }
+
+    /// The gap this item's arrival reveals.
+    const fn gap(&self) -> Gap {
+        Gap {
+            awaited_root: self.awaited_root(),
+            waiting_slot: self.slot(),
+        }
+    }
 }
 
 /// The verification stage: decode, resolve, verify, forward.
@@ -211,6 +239,7 @@ pub struct VerificationStage {
     inbound: mpsc::Receiver<GossipPayload>,
     verified: mpsc::Sender<Verified>,
     view: watch::Receiver<Arc<ChainView>>,
+    gaps: mpsc::Sender<Gap>,
     pending: VecDeque<Decoded>,
     pending_capacity: usize,
     counters: Arc<StageCounters>,
@@ -223,6 +252,7 @@ impl VerificationStage {
         inbound: mpsc::Receiver<GossipPayload>,
         verified: mpsc::Sender<Verified>,
         view: watch::Receiver<Arc<ChainView>>,
+        gaps: mpsc::Sender<Gap>,
         pending_capacity: usize,
         counters: Arc<StageCounters>,
     ) -> Self {
@@ -230,6 +260,7 @@ impl VerificationStage {
             inbound,
             verified,
             view,
+            gaps,
             pending: VecDeque::with_capacity(pending_capacity),
             pending_capacity,
             counters,
@@ -344,12 +375,26 @@ impl VerificationStage {
     }
 
     /// Parks an item, evicting the oldest arrival when the buffer is full.
+    ///
+    /// Both the arriving item and any item displaced to make room for it raise a gap signal:
+    /// the arrival because nothing has been asked for yet, and the eviction because what was
+    /// asked for is now the only way that item comes back.
     fn park(&mut self, decoded: Decoded) {
-        if self.pending.len() >= self.pending_capacity {
-            self.pending.pop_front();
+        if self.pending.len() >= self.pending_capacity
+            && let Some(evicted) = self.pending.pop_front()
+        {
             self.counters.evicted.fetch_add(1, Ordering::Relaxed);
+            self.signal_gap(&evicted);
         }
+        self.signal_gap(&decoded);
         self.pending.push_back(decoded);
+    }
+
+    /// Tells the sync service about a missing ancestor, if it is listening and not saturated.
+    fn signal_gap(&self, decoded: &Decoded) {
+        if self.gaps.try_send(decoded.gap()).is_err() {
+            tracing::trace!("a gap signal was dropped; the next park raises it again");
+        }
     }
 
     fn reject(&self, kind: &GossipKind, failure: VerificationFailure) {

--- a/crates/verity-node/tests/catch_up.rs
+++ b/crates/verity-node/tests/catch_up.rs
@@ -70,7 +70,11 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
         keypair: Keypair::generate_secp256k1(),
         validator_indices: vec![ValidatorIndex(0)],
         key_directory: Some(key_base.join("hash-sig-keys")),
-        is_aggregator: true,
+        // Not an aggregator, deliberately. The interval-2 round is a zk proof per slot and
+        // has nothing to do with what this test claims; leaving it on made the producer prove
+        // continuously underneath the follower's catch-up, and the two together do not fit in
+        // a CI runner's memory. `single_node.rs` covers the aggregating path.
+        is_aggregator: false,
         checkpoint_sync_url: None,
     })
     .await

--- a/crates/verity-node/tests/catch_up.rs
+++ b/crates/verity-node/tests/catch_up.rs
@@ -149,13 +149,9 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
 
     assert!(
         caught_up.is_ok(),
-        "the follower never imported the producer's block at slot {}; its head is at slot {}",
+        "the follower never reached the producer's slot {}; its head is at slot {}",
         target.slot.0,
         reached.slot.0
-    );
-    assert!(
-        reached.slot.0 >= target.slot.0,
-        "the follower holds the block but its head is behind it"
     );
 
     // Arriving is not the claim; arriving *by asking* is. Gossipsub keeps a short history and

--- a/crates/verity-node/tests/catch_up.rs
+++ b/crates/verity-node/tests/catch_up.rs
@@ -1,10 +1,24 @@
-//! Two nodes, one gap: does a node that starts late reach the chain the first one built?
+//! One gap, three nodes' worth of work: does a node that starts late reach the chain that was
+//! built before it existed?
 //!
 //! This is the only test that exercises both halves of sync at once, and it exercises them
-//! against each other. For B to catch up, A has to answer block requests out of its own
-//! database — the responder — and B has to notice the gap, ask for what it is missing, and
-//! feed the answers through its verification stage — the client. Neither half can pass this
-//! alone, and neither is reachable from a unit test.
+//! against each other. For the follower to catch up, the server has to answer block requests
+//! out of a database — the responder — and the follower has to notice the gap, ask for what
+//! it is missing, and feed the answers through its verification stage — the client. Neither
+//! half can pass this alone, and neither is reachable from a unit test.
+//!
+//! # Why the chain is built by a node that is then shut down
+//!
+//! The producer holds validator keys, so it proves: a block proof per slot it proposes in.
+//! Leaving it running underneath the follower's catch-up means proving and verifying
+//! concurrently in one process for as long as the catch-up takes — which on a four-core CI
+//! runner is where this test spent 75 minutes and most of its memory.
+//!
+//! Nothing about the claim needs it. Serving is a database read, so the server is started on
+//! the producer's data directory *without keys*: it restores the chain, answers requests, and
+//! proves nothing. That also makes the test stricter than it was — the blocks the follower
+//! receives come out of persisted history through a restart, not out of the memory of the
+//! node that just made them.
 //!
 //! # Gated, and slow on purpose
 //!
@@ -21,11 +35,15 @@ use verity_node::{GenesisFile, Multiaddr, Node, NodeConfig, identity::Keypair};
 use verity_types::ValidatorIndex;
 use verity_types::config::SECONDS_PER_SLOT;
 
-/// How long the pair is given to build a chain and then close the gap.
+/// How long the producer is given to put a block on the chain.
 ///
-/// Bounded by proving on A's side and by verification on B's: every block B accepts costs it
-/// the same aggregate-proof check a gossiped block would.
-const BUDGET: Duration = Duration::from_secs(900);
+/// Bounded by proving: one block proof is seconds of zk work, more on a slow machine.
+const BUILD_BUDGET: Duration = Duration::from_secs(900);
+
+/// How long the follower is given to close the gap once it has a server to ask.
+///
+/// Bounded by verification, not by proving: nothing in this phase produces a block.
+const CATCH_UP_BUDGET: Duration = Duration::from_secs(300);
 
 /// How many blocks A puts on the chain before B is started.
 ///
@@ -38,6 +56,7 @@ const GAP_BLOCKS: u64 = 1;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn should_catch_up_to_a_running_node_when_started_after_it() {
+    common::init_logging();
     let Some(keys) = common::test_keys() else {
         eprintln!("skipping: set VERITY_TEST_KEYS to run the catch-up test");
         return;
@@ -60,20 +79,20 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
     let (genesis_path, key_base) = common::write_configuration(root.path(), &keys, genesis_time);
     let genesis = GenesisFile::read(&genesis_path).expect("the genesis file");
 
-    // A is the whole validator set: it proposes every slot it can sign for.
+    let chain_directory = root.path().join("chain-db");
+
+    // The producer is the whole validator set, and it exists only to put history on disk.
     let producer = Node::start(NodeConfig {
         genesis: genesis.clone(),
-        data_directory: root.path().join("producer-db"),
+        data_directory: chain_directory.clone(),
         listen: "/ip4/127.0.0.1/udp/0/quic-v1".parse().expect("an address"),
         bootnodes: Vec::new(),
         network_name: "00000000".to_string(),
         keypair: Keypair::generate_secp256k1(),
         validator_indices: vec![ValidatorIndex(0)],
         key_directory: Some(key_base.join("hash-sig-keys")),
-        // Not an aggregator, deliberately. The interval-2 round is a zk proof per slot and
-        // has nothing to do with what this test claims; leaving it on made the producer prove
-        // continuously underneath the follower's catch-up, and the two together do not fit in
-        // a CI runner's memory. `single_node.rs` covers the aggregating path.
+        // Not an aggregator: the interval-2 round is another zk proof per slot and has
+        // nothing to do with what this test claims. `single_node.rs` covers that path.
         is_aggregator: false,
         checkpoint_sync_url: None,
     })
@@ -82,11 +101,24 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
 
     // Let a gap open before the follower exists. Everything below this point is history the
     // follower can only get by asking for it: gossip carries the current slot, not the past.
+    //
+    // The wait does not end at the head: it ends one tick later. A block is made durable by
+    // its own commit, but the head pointer and the canonical index that a restart reads back
+    // are written by the interval tick that follows it. Stopping in between leaves a database
+    // holding the block and still pointing at genesis — correct, and useless to serve from.
     let mut producer_view = producer.view();
-    let built = tokio::time::timeout(BUDGET, async {
+    let built = tokio::time::timeout(BUILD_BUDGET, async {
+        let mut head_seen_at = None;
         loop {
-            if producer_view.borrow_and_update().head_checkpoint().slot.0 >= GAP_BLOCKS {
-                return;
+            {
+                let view = producer_view.borrow_and_update();
+                match head_seen_at {
+                    None if view.head_checkpoint().slot.0 >= GAP_BLOCKS => {
+                        head_seen_at = Some(view.time());
+                    }
+                    Some(interval) if view.time().0 > interval.0 => return,
+                    _ => {}
+                }
             }
             producer_view
                 .changed()
@@ -97,14 +129,41 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
     .await;
     assert!(
         built.is_ok(),
-        "the producer did not reach slot {GAP_BLOCKS} within {BUDGET:?}; it is at slot {}",
+        "the producer did not reach slot {GAP_BLOCKS} within {BUILD_BUDGET:?}; it is at slot {}",
         producer_view.borrow().head_checkpoint().slot.0
     );
 
     let target = producer_view.borrow().head_checkpoint();
-    let bootnode = dialable(&producer);
+    drop(producer_view);
+    // The database has the chain now, and the keys have done their job. Everything after this
+    // point is reads.
+    producer.shutdown().await;
 
-    // B holds no keys: it follows, and everything it ends up with came from A.
+    // The server: the producer's history, no keys, nothing to prove.
+    let server = Node::start(NodeConfig {
+        genesis: genesis.clone(),
+        data_directory: chain_directory,
+        listen: "/ip4/127.0.0.1/udp/0/quic-v1".parse().expect("an address"),
+        bootnodes: Vec::new(),
+        network_name: "00000000".to_string(),
+        keypair: Keypair::generate_secp256k1(),
+        validator_indices: Vec::new(),
+        key_directory: None,
+        is_aggregator: false,
+        checkpoint_sync_url: None,
+    })
+    .await
+    .expect("the server starts on the producer's database");
+    assert_eq!(
+        server.view().borrow().head_checkpoint().slot,
+        target.slot,
+        "the server restored a different head than the producer left"
+    );
+
+    let bootnode = dialable(&server).await;
+
+    // The follower holds no keys: it follows, and everything it ends up with came from the
+    // server.
     let follower = Node::start(NodeConfig {
         genesis,
         data_directory: root.path().join("follower-db"),
@@ -121,7 +180,7 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
     .expect("the follower starts");
 
     let mut follower_view = follower.view();
-    let caught_up = tokio::time::timeout(BUDGET, async {
+    let caught_up = tokio::time::timeout(CATCH_UP_BUDGET, async {
         loop {
             if follower_view
                 .borrow_and_update()
@@ -141,11 +200,11 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
     let reached = follower_view.borrow().head_checkpoint();
     let fetched = follower.sync_counters().fetched();
     let (served_requests, served_blocks) = {
-        let counters = producer.sync_counters();
+        let counters = server.sync_counters();
         (counters.served_requests(), counters.served_blocks())
     };
     follower.shutdown().await;
-    producer.shutdown().await;
+    server.shutdown().await;
 
     assert!(
         caught_up.is_ok(),
@@ -165,18 +224,26 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
     );
     assert!(
         served_blocks > 0,
-        "the producer answered {served_requests} block request(s) and served no blocks"
+        "the server answered {served_requests} block request(s) and served no blocks"
     );
 }
 
-/// The producer's bound address, with its peer id appended so it can be dialled.
-fn dialable(producer: &Node) -> Multiaddr {
-    let address = producer
-        .listen_addresses()
-        .into_iter()
-        .next()
-        .expect("the producer is listening");
+/// A node's bound address, with its peer id appended so it can be dialled.
+///
+/// Awaited rather than read: binding happens during `start`, but the address it produced
+/// arrives on the event stream a moment later.
+async fn dialable(node: &Node) -> Multiaddr {
+    let mut listening = node.listening();
+    let address = loop {
+        if let Some(address) = listening.borrow_and_update().first().cloned() {
+            break address;
+        }
+        listening
+            .changed()
+            .await
+            .expect("the network bridge is running");
+    };
     address
-        .with_p2p(producer.peer_id())
+        .with_p2p(node.peer_id())
         .expect("an address with a peer id")
 }

--- a/crates/verity-node/tests/catch_up.rs
+++ b/crates/verity-node/tests/catch_up.rs
@@ -1,0 +1,178 @@
+//! Two nodes, one gap: does a node that starts late reach the chain the first one built?
+//!
+//! This is the only test that exercises both halves of sync at once, and it exercises them
+//! against each other. For B to catch up, A has to answer block requests out of its own
+//! database — the responder — and B has to notice the gap, ask for what it is missing, and
+//! feed the answers through its verification stage — the client. Neither half can pass this
+//! alone, and neither is reachable from a unit test.
+//!
+//! # Gated, and slow on purpose
+//!
+//! Like `single_node.rs`, and for the same reason: production-scheme keys are 33.5 MB each
+//! and a block proof is seconds of zk proving. `VERITY_TEST_KEYS` supplies the keys
+//! (<https://github.com/leanEthereum/leansig-test-keys>, `prod_scheme.tar.gz`, sha256-pinned
+//! in `crates/verity-crypto/test-keys.sha256`); with the variable unset the test returns.
+
+mod common;
+
+use std::time::Duration;
+
+use verity_node::{GenesisFile, Multiaddr, Node, NodeConfig, identity::Keypair};
+use verity_types::ValidatorIndex;
+use verity_types::config::SECONDS_PER_SLOT;
+
+/// How long the pair is given to build a chain and then close the gap.
+///
+/// Bounded by proving on A's side and by verification on B's: every block B accepts costs it
+/// the same aggregate-proof check a gossiped block would.
+const BUDGET: Duration = Duration::from_secs(900);
+
+/// How many blocks A puts on the chain before B is started.
+///
+/// Two rather than one, so B has to walk more than a single parent link to get home.
+const GAP_BLOCKS: u64 = 2;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn should_catch_up_to_a_running_node_when_started_after_it() {
+    let Some(keys) = common::test_keys() else {
+        eprintln!("skipping: set VERITY_TEST_KEYS to run the catch-up test");
+        return;
+    };
+
+    let first_signable = keys
+        .iter()
+        .map(|key| key.secret.prepared_interval().start)
+        .max()
+        .expect("two keys");
+    let target_slot = first_signable + 1;
+    assert!(
+        target_slot < 16,
+        "the supplied keys are prepared from slot {first_signable}; \
+         starting a chain there would ask the nodes to tick through {target_slot} slots"
+    );
+
+    let root = tempfile::tempdir().expect("a temporary directory");
+    let genesis_time = common::now_seconds() - target_slot * SECONDS_PER_SLOT;
+    let (genesis_path, key_base) = common::write_configuration(root.path(), &keys, genesis_time);
+    let genesis = GenesisFile::read(&genesis_path).expect("the genesis file");
+
+    // A is the whole validator set: it proposes every slot it can sign for.
+    let producer = Node::start(NodeConfig {
+        genesis: genesis.clone(),
+        data_directory: root.path().join("producer-db"),
+        listen: "/ip4/127.0.0.1/udp/0/quic-v1".parse().expect("an address"),
+        bootnodes: Vec::new(),
+        network_name: "00000000".to_string(),
+        keypair: Keypair::generate_secp256k1(),
+        validator_indices: vec![ValidatorIndex(0)],
+        key_directory: Some(key_base.join("hash-sig-keys")),
+        is_aggregator: true,
+        checkpoint_sync_url: None,
+    })
+    .await
+    .expect("the producer starts");
+
+    // Let a gap open before the follower exists. Everything below this point is history the
+    // follower can only get by asking for it: gossip carries the current slot, not the past.
+    let mut producer_view = producer.view();
+    let built = tokio::time::timeout(BUDGET, async {
+        loop {
+            if producer_view.borrow_and_update().head_checkpoint().slot.0 >= GAP_BLOCKS {
+                return;
+            }
+            producer_view
+                .changed()
+                .await
+                .expect("the producer's chain task is running");
+        }
+    })
+    .await;
+    assert!(
+        built.is_ok(),
+        "the producer did not reach slot {GAP_BLOCKS} within {BUDGET:?}; it is at slot {}",
+        producer_view.borrow().head_checkpoint().slot.0
+    );
+
+    let target = producer_view.borrow().head_checkpoint();
+    let bootnode = dialable(&producer);
+
+    // B holds no keys: it follows, and everything it ends up with came from A.
+    let follower = Node::start(NodeConfig {
+        genesis,
+        data_directory: root.path().join("follower-db"),
+        listen: "/ip4/127.0.0.1/udp/0/quic-v1".parse().expect("an address"),
+        bootnodes: vec![bootnode],
+        network_name: "00000000".to_string(),
+        keypair: Keypair::generate_secp256k1(),
+        validator_indices: Vec::new(),
+        key_directory: None,
+        is_aggregator: false,
+        checkpoint_sync_url: None,
+    })
+    .await
+    .expect("the follower starts");
+
+    let mut follower_view = follower.view();
+    let caught_up = tokio::time::timeout(BUDGET, async {
+        loop {
+            if follower_view
+                .borrow_and_update()
+                .block(target.root)
+                .is_some()
+            {
+                return;
+            }
+            follower_view
+                .changed()
+                .await
+                .expect("the follower's chain task is running");
+        }
+    })
+    .await;
+
+    let reached = follower_view.borrow().head_checkpoint();
+    let fetched = follower.sync_counters().fetched();
+    let (served_requests, served_blocks) = {
+        let counters = producer.sync_counters();
+        (counters.served_requests(), counters.served_blocks())
+    };
+    follower.shutdown().await;
+    producer.shutdown().await;
+
+    assert!(
+        caught_up.is_ok(),
+        "the follower never imported the producer's block at slot {}; its head is at slot {}",
+        target.slot.0,
+        reached.slot.0
+    );
+    assert!(
+        reached.slot.0 >= target.slot.0,
+        "the follower holds the block but its head is behind it"
+    );
+
+    // Arriving is not the claim; arriving *by asking* is. Gossipsub keeps a short history and
+    // answers IWANT out of it, so a block that merely turned up could have come from the mesh
+    // cache rather than from a request — and then this test would be checking gossip, not
+    // sync. The two counters are what separate them, one per side of the exchange.
+    assert!(
+        fetched > 0,
+        "the follower's head reached the target without fetching anything: \
+         this run exercised gossip, not sync"
+    );
+    assert!(
+        served_blocks > 0,
+        "the producer answered {served_requests} block request(s) and served no blocks"
+    );
+}
+
+/// The producer's bound address, with its peer id appended so it can be dialled.
+fn dialable(producer: &Node) -> Multiaddr {
+    let address = producer
+        .listen_addresses()
+        .into_iter()
+        .next()
+        .expect("the producer is listening");
+    address
+        .with_p2p(producer.peer_id())
+        .expect("an address with a peer id")
+}

--- a/crates/verity-node/tests/catch_up.rs
+++ b/crates/verity-node/tests/catch_up.rs
@@ -29,8 +29,12 @@ const BUDGET: Duration = Duration::from_secs(900);
 
 /// How many blocks A puts on the chain before B is started.
 ///
-/// Two rather than one, so B has to walk more than a single parent link to get home.
-const GAP_BLOCKS: u64 = 2;
+/// One, and the reason is the cost of the second. A proposal is bounded by the slots its XMSS
+/// key is prepared for; going past that window makes the producer advance the key first, which
+/// is minutes of work and dominated this test's CI time by an order of magnitude. One block is
+/// enough for the claim: it exists before B does, so B can only have it by asking, and the
+/// counters at the end say whether it did.
+const GAP_BLOCKS: u64 = 1;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn should_catch_up_to_a_running_node_when_started_after_it() {

--- a/crates/verity-node/tests/common/mod.rs
+++ b/crates/verity-node/tests/common/mod.rs
@@ -14,6 +14,19 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use verity_crypto::SecretKey;
 use verity_crypto::containers::PublicKey;
 
+/// Installs a log subscriber when `RUST_LOG` asks for one.
+///
+/// A library installs none, so without this an end-to-end test that misbehaves says nothing
+/// about why. Idempotent: a second call in the same process is a no-op.
+pub fn init_logging() {
+    if std::env::var_os("RUST_LOG").is_some() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .try_init();
+    }
+}
+
 /// A key pair as `leansig-test-keys` ships it.
 pub struct TestKey {
     pub public: PublicKey,

--- a/crates/verity-node/tests/common/mod.rs
+++ b/crates/verity-node/tests/common/mod.rs
@@ -1,0 +1,149 @@
+//! What the two end-to-end node tests both need: production-scheme keys, and the
+//! cross-client configuration files a node starts from.
+//!
+//! Both harnesses are gated on `VERITY_TEST_KEYS` and both write lean-quickstart's layout,
+//! so the loading and the file writing live here rather than in each test. Every integration
+//! test binary compiles this module separately, hence the blanket `dead_code` allowance.
+
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use verity_crypto::SecretKey;
+use verity_crypto::containers::PublicKey;
+
+/// A key pair as `leansig-test-keys` ships it.
+pub struct TestKey {
+    pub public: PublicKey,
+    pub secret: SecretKey,
+}
+
+/// Loads the first two key files in `VERITY_TEST_KEYS`, or `None` when the gate is off.
+pub fn test_keys() -> Option<Vec<TestKey>> {
+    let directory = PathBuf::from(std::env::var_os("VERITY_TEST_KEYS")?);
+    assert!(
+        directory.is_dir(),
+        "VERITY_TEST_KEYS is set but {} is not a directory",
+        directory.display()
+    );
+
+    let mut files: Vec<PathBuf> = fs::read_dir(&directory)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", directory.display()))
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "json")
+        })
+        .collect();
+    files.sort();
+    assert!(
+        files.len() >= 2,
+        "{} holds {} key files, needed 2",
+        directory.display(),
+        files.len()
+    );
+
+    Some(files.iter().take(2).map(read_key).collect())
+}
+
+pub fn read_key(path: &PathBuf) -> TestKey {
+    let text = fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
+
+    // The file is `{"attestation_keypair": {"public_key": "0x..", "secret_key": "0x.."}}`;
+    // reaching into it by hand keeps this test from taking a JSON dependency for two fields.
+    let public = from_hex(field(&text, "public_key"));
+    let secret = from_hex(field(&text, "secret_key"));
+
+    TestKey {
+        public: PublicKey::from_bytes52(&public.as_slice().try_into().expect("52 bytes"))
+            .expect("the public key parses"),
+        secret: SecretKey::from_ssz_bytes(&secret).expect("the secret key parses"),
+    }
+}
+
+/// The quoted value of `"<name>": "..."`, from a file this test knows the shape of.
+///
+/// The generator writes the hex bare, with no `0x`, so the value is taken by its quotes
+/// rather than by a prefix.
+pub fn field<'a>(text: &'a str, name: &str) -> &'a str {
+    let after = text
+        .split_once(&format!("\"{name}\""))
+        .unwrap_or_else(|| panic!("no {name} in the key file"))
+        .1;
+    let after = after.split_once(':').expect("a key/value separator").1;
+    let start = after.find('"').expect("an opening quote") + 1;
+    let rest = &after[start..];
+    let end = rest.find('"').expect("a closing quote");
+    &rest[..end]
+}
+
+pub fn from_hex(text: &str) -> Vec<u8> {
+    let text = text.strip_prefix("0x").unwrap_or(text);
+    (0..text.len())
+        .step_by(2)
+        .map(|index| u8::from_str_radix(&text[index..index + 2], 16).expect("hex"))
+        .collect()
+}
+
+/// Writes the genesis file, the assignment, and the key directory a node starts from.
+///
+/// The layout is lean-quickstart's, because that is the layout the loader reads: a
+/// `hash-sig-keys/` directory with a manifest declaring both roles, and file names derived
+/// from the validator index and the role.
+pub fn write_configuration(root: &Path, keys: &[TestKey], genesis_time: u64) -> (PathBuf, PathBuf) {
+    let key_base = root.join("keys");
+    let key_directory = key_base.join("hash-sig-keys");
+    fs::create_dir_all(&key_directory).expect("the key directory");
+
+    let attestation = hex(&keys[0].public.to_bytes52());
+    let proposal = hex(&keys[1].public.to_bytes52());
+
+    let genesis_path = root.join("genesis.yaml");
+    fs::write(
+        &genesis_path,
+        format!(
+            "GENESIS_TIME: {genesis_time}\nGENESIS_VALIDATORS:\n  - attestation_public_key: \"0x{attestation}\"\n    proposal_public_key: \"0x{proposal}\"\n"
+        ),
+    )
+    .expect("the genesis file");
+
+    fs::write(key_base.join("validators.yaml"), "verity_0:\n  - 0\n").expect("the assignment file");
+
+    fs::write(
+        key_directory.join("validator-keys-manifest.yaml"),
+        format!(
+            "validators:\n  - attester_key_pubkey_hex: \"0x{attestation}\"\n    proposer_key_pubkey_hex: \"0x{proposal}\"\n"
+        ),
+    )
+    .expect("the key manifest");
+
+    for (role, key) in [("attester", &keys[0]), ("proposer", &keys[1])] {
+        fs::write(
+            key_directory.join(format!("validator_0_{role}_key_pk.ssz")),
+            key.public.to_bytes52(),
+        )
+        .expect("a public key file");
+        fs::write(
+            key_directory.join(format!("validator_0_{role}_key_sk.ssz")),
+            key.secret.to_ssz_bytes(),
+        )
+        .expect("a secret key file");
+    }
+
+    (genesis_path, key_base)
+}
+
+pub fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+pub fn now_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("a clock after 1970")
+        .as_secs()
+}

--- a/crates/verity-node/tests/single_node.rs
+++ b/crates/verity-node/tests/single_node.rs
@@ -18,13 +18,11 @@
 //! cryptography, so validator 0 is given key 0 for attesting and key 1 for proposing — two
 //! distinct keys, which is what the loader insists on.
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+mod common;
 
-use verity_crypto::SecretKey;
-use verity_crypto::containers::PublicKey;
-use verity_node::{Node, NodeConfig, config::GenesisFile, identity::Keypair};
+use std::time::Duration;
+
+use verity_node::{GenesisFile, Node, NodeConfig, identity::Keypair};
 use verity_types::config::SECONDS_PER_SLOT;
 
 /// How long the node is given to produce, prove, and import its first block.
@@ -33,143 +31,9 @@ use verity_types::config::SECONDS_PER_SLOT;
 /// two slowest things in the run, and both happen once here.
 const BUDGET: Duration = Duration::from_secs(600);
 
-/// A key pair as `leansig-test-keys` ships it.
-struct TestKey {
-    public: PublicKey,
-    secret: SecretKey,
-}
-
-/// Loads the first two key files in `VERITY_TEST_KEYS`, or `None` when the gate is off.
-fn test_keys() -> Option<Vec<TestKey>> {
-    let directory = PathBuf::from(std::env::var_os("VERITY_TEST_KEYS")?);
-    assert!(
-        directory.is_dir(),
-        "VERITY_TEST_KEYS is set but {} is not a directory",
-        directory.display()
-    );
-
-    let mut files: Vec<PathBuf> = fs::read_dir(&directory)
-        .unwrap_or_else(|error| panic!("cannot read {}: {error}", directory.display()))
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| {
-            path.extension()
-                .is_some_and(|extension| extension == "json")
-        })
-        .collect();
-    files.sort();
-    assert!(
-        files.len() >= 2,
-        "{} holds {} key files, needed 2",
-        directory.display(),
-        files.len()
-    );
-
-    Some(files.iter().take(2).map(read_key).collect())
-}
-
-fn read_key(path: &PathBuf) -> TestKey {
-    let text = fs::read_to_string(path)
-        .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
-
-    // The file is `{"attestation_keypair": {"public_key": "0x..", "secret_key": "0x.."}}`;
-    // reaching into it by hand keeps this test from taking a JSON dependency for two fields.
-    let public = from_hex(field(&text, "public_key"));
-    let secret = from_hex(field(&text, "secret_key"));
-
-    TestKey {
-        public: PublicKey::from_bytes52(&public.as_slice().try_into().expect("52 bytes"))
-            .expect("the public key parses"),
-        secret: SecretKey::from_ssz_bytes(&secret).expect("the secret key parses"),
-    }
-}
-
-/// The quoted value of `"<name>": "..."`, from a file this test knows the shape of.
-///
-/// The generator writes the hex bare, with no `0x`, so the value is taken by its quotes
-/// rather than by a prefix.
-fn field<'a>(text: &'a str, name: &str) -> &'a str {
-    let after = text
-        .split_once(&format!("\"{name}\""))
-        .unwrap_or_else(|| panic!("no {name} in the key file"))
-        .1;
-    let after = after.split_once(':').expect("a key/value separator").1;
-    let start = after.find('"').expect("an opening quote") + 1;
-    let rest = &after[start..];
-    let end = rest.find('"').expect("a closing quote");
-    &rest[..end]
-}
-
-fn from_hex(text: &str) -> Vec<u8> {
-    let text = text.strip_prefix("0x").unwrap_or(text);
-    (0..text.len())
-        .step_by(2)
-        .map(|index| u8::from_str_radix(&text[index..index + 2], 16).expect("hex"))
-        .collect()
-}
-
-/// Writes the genesis file, the assignment, and the key directory a node starts from.
-///
-/// The layout is lean-quickstart's, because that is the layout the loader reads: a
-/// `hash-sig-keys/` directory with a manifest declaring both roles, and file names derived
-/// from the validator index and the role.
-fn write_configuration(root: &Path, keys: &[TestKey], genesis_time: u64) -> (PathBuf, PathBuf) {
-    let key_base = root.join("keys");
-    let key_directory = key_base.join("hash-sig-keys");
-    fs::create_dir_all(&key_directory).expect("the key directory");
-
-    let attestation = hex(&keys[0].public.to_bytes52());
-    let proposal = hex(&keys[1].public.to_bytes52());
-
-    let genesis_path = root.join("genesis.yaml");
-    fs::write(
-        &genesis_path,
-        format!(
-            "GENESIS_TIME: {genesis_time}\nGENESIS_VALIDATORS:\n  - attestation_public_key: \"0x{attestation}\"\n    proposal_public_key: \"0x{proposal}\"\n"
-        ),
-    )
-    .expect("the genesis file");
-
-    fs::write(key_base.join("validators.yaml"), "verity_0:\n  - 0\n").expect("the assignment file");
-
-    fs::write(
-        key_directory.join("validator-keys-manifest.yaml"),
-        format!(
-            "validators:\n  - attester_key_pubkey_hex: \"0x{attestation}\"\n    proposer_key_pubkey_hex: \"0x{proposal}\"\n"
-        ),
-    )
-    .expect("the key manifest");
-
-    for (role, key) in [("attester", &keys[0]), ("proposer", &keys[1])] {
-        fs::write(
-            key_directory.join(format!("validator_0_{role}_key_pk.ssz")),
-            key.public.to_bytes52(),
-        )
-        .expect("a public key file");
-        fs::write(
-            key_directory.join(format!("validator_0_{role}_key_sk.ssz")),
-            key.secret.to_ssz_bytes(),
-        )
-        .expect("a secret key file");
-    }
-
-    (genesis_path, key_base)
-}
-
-fn hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
-}
-
-fn now_seconds() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("a clock after 1970")
-        .as_secs()
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn should_advance_the_head_past_genesis_when_a_node_runs_its_own_validator() {
-    let Some(keys) = test_keys() else {
+    let Some(keys) = common::test_keys() else {
         eprintln!("skipping: set VERITY_TEST_KEYS to run the single-node end-to-end test");
         return;
     };
@@ -190,8 +54,8 @@ async fn should_advance_the_head_past_genesis_when_a_node_runs_its_own_validator
     );
 
     let root = tempfile::tempdir().expect("a temporary directory");
-    let genesis_time = now_seconds() - target_slot * SECONDS_PER_SLOT;
-    let (genesis_path, key_base) = write_configuration(root.path(), &keys, genesis_time);
+    let genesis_time = common::now_seconds() - target_slot * SECONDS_PER_SLOT;
+    let (genesis_path, key_base) = common::write_configuration(root.path(), &keys, genesis_time);
 
     let node = Node::start(NodeConfig {
         genesis: GenesisFile::read(&genesis_path).expect("the genesis file"),
@@ -205,6 +69,7 @@ async fn should_advance_the_head_past_genesis_when_a_node_runs_its_own_validator
         validator_indices: vec![verity_types::ValidatorIndex(0)],
         key_directory: Some(key_base.join("hash-sig-keys")),
         is_aggregator: true,
+        checkpoint_sync_url: None,
     })
     .await
     .expect("the node starts");

--- a/crates/verity-node/tests/sync_fixtures.rs
+++ b/crates/verity-node/tests/sync_fixtures.rs
@@ -1,0 +1,158 @@
+//! Conformance against leanSpec's sync vectors.
+//!
+//! Source: leanSpec `tests/consensus/lstar/sync/`, filled into the
+//! `fixtures-prod-scheme.tar.gz` release asset that `crates/verity-types/fixtures.sha256`
+//! pins. The `sync_test` format is the only conformance coverage the sync layer has — the
+//! state machine, batching, peer selection and scoring are all unspecified — and what it
+//! pins is exactly one function: the structural verdict on a downloaded checkpoint state.
+//!
+//! The state arrives as SSZ hex rather than as a JSON object, which is the point: the vector
+//! asks a client to decode the same bytes and reach the same verdict.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use libssz::SszDecode;
+use serde::Deserialize;
+use verity_node::sync::checkpoint::verify_checkpoint_state;
+use verity_types::State;
+
+/// The leanSpec suites that emit `sync_test` vectors.
+const SUITES: [&str; 2] = ["test_checkpoint_verify", "test_checkpoint_verify_advanced"];
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    operation: Operation,
+    output: Output,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+enum Operation {
+    VerifyCheckpoint {
+        num_validators: u64,
+        #[serde(default)]
+        anchor_slot: u64,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Output {
+    /// The verdict `verify_checkpoint_state` must reproduce.
+    valid: bool,
+    /// The state the verdict was reached on, SSZ, `0x`-prefixed.
+    state_bytes: String,
+    validator_count: u64,
+}
+
+#[test]
+fn should_match_leanspec_checkpoint_verification_vectors_when_fixtures_are_present() {
+    let Some(root) = std::env::var_os("VERITY_FIXTURES").map(PathBuf::from) else {
+        eprintln!("skipping: set VERITY_FIXTURES to run leanSpec sync vectors");
+        return;
+    };
+
+    let files: Vec<PathBuf> = SUITES
+        .iter()
+        .flat_map(|suite| collect_suite_json(&root, suite))
+        .collect();
+    assert!(
+        !files.is_empty(),
+        "no JSON under {} (expected **/{{{}}}/*.json)",
+        root.display(),
+        SUITES.join(",")
+    );
+
+    let mut failures = Vec::new();
+    let mut checked = 0usize;
+
+    for path in &files {
+        let text = fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("{}: read error: {error}", path.display()));
+        let cases: std::collections::BTreeMap<String, Case> = serde_json::from_str(&text)
+            .unwrap_or_else(|error| panic!("{}: json: {error}", path.display()));
+
+        for (id, case) in cases {
+            let bytes = unhex(&case.output.state_bytes)
+                .unwrap_or_else(|error| panic!("{id}: state bytes: {error}"));
+            let state = State::from_ssz_bytes(&bytes).unwrap_or_else(|error| {
+                panic!("{id}: the vector's state does not decode: {error:?}")
+            });
+
+            // The vector echoes both inputs; checking them makes a mismatched or re-ordered
+            // vector fail here rather than as an unexplained verdict disagreement.
+            let Operation::VerifyCheckpoint {
+                num_validators,
+                anchor_slot,
+            } = case.operation;
+            assert_eq!(num_validators, case.output.validator_count, "{id}: inputs");
+            assert_eq!(state.slot.0, anchor_slot, "{id}: anchor slot");
+            assert_eq!(
+                state.validators.len() as u64,
+                case.output.validator_count,
+                "{id}: registry size"
+            );
+
+            let verdict = verify_checkpoint_state(&state);
+            if verdict != case.output.valid {
+                failures.push(format!(
+                    "{id}: got {verdict}, expected {}",
+                    case.output.valid
+                ));
+            }
+            checked += 1;
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} case(s) disagree:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+    assert!(checked > 0, "the suites held no cases");
+}
+
+/// Every `*.json` under a directory named `suite`, anywhere in the tree.
+fn collect_suite_json(root: &Path, suite: &str) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    walk(root, suite, &mut out);
+    out.sort();
+    out
+}
+
+fn walk(dir: &Path, suite: &str, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, suite, out);
+            continue;
+        }
+        let is_json = path.extension().is_some_and(|ext| ext == "json");
+        let in_suite = path.components().any(|part| part.as_os_str() == suite);
+        if is_json && in_suite {
+            out.push(path);
+        }
+    }
+}
+
+fn unhex(text: &str) -> Result<Vec<u8>, String> {
+    let body = text
+        .strip_prefix("0x")
+        .ok_or_else(|| format!("{text}: missing 0x prefix"))?;
+    (0..body.len())
+        .step_by(2)
+        .map(|index| {
+            u8::from_str_radix(&body[index..index + 2], 16)
+                .map_err(|error| format!("byte {index}: {error}"))
+        })
+        .collect()
+}

--- a/crates/verity-types/fixtures.sha256
+++ b/crates/verity-types/fixtures.sha256
@@ -1,1 +1,1 @@
-351fb8d035c2b016519d71a2fb658939be04162f056c6300a1425aa1d4185026  fixtures-prod-scheme.tar.gz
+21d9de7056b4e658031dc09e50c0e9dc1b0206089253258ce69ecff01154d4bd  fixtures-prod-scheme.tar.gz

--- a/crates/verity-validator/src/duties.rs
+++ b/crates/verity-validator/src/duties.rs
@@ -52,6 +52,22 @@ use crate::prover::Prover;
 /// longer be re-reached by this loop.
 const ATTESTED_SLOT_RETENTION: u64 = 4;
 
+/// Head lag, in slots, beyond which duties stop: this node's view is stale.
+///
+/// leanSpec `node/validator/constants.py::SYNC_LAG_THRESHOLD`, the same value ethlambda uses
+/// in `crates/blockchain/src/sync_status.rs`. See [`DutyService::serves_duties`].
+const DUTY_LAG_THRESHOLD: u64 = 4;
+
+/// Lag of the freshest block *seen* beyond which the network, not this node, is the one that
+/// stopped — and duties keep running so the chain can recover.
+///
+/// leanSpec `NETWORK_STALL_THRESHOLD`, likewise shared with ethlambda.
+const NETWORK_STALL_THRESHOLD: u64 = 8;
+
+/// Recovery band that stops the gate flapping at the threshold: once closed it reopens at
+/// `DUTY_LAG_THRESHOLD - DUTY_LAG_HYSTERESIS`.
+const DUTY_LAG_HYSTERESIS: u64 = 2;
+
 /// The validator client: keys, the duties they owe, and the products they yield.
 pub struct DutyService {
     keyring: Keyring,
@@ -59,6 +75,8 @@ pub struct DutyService {
     products: mpsc::Sender<LocalProduct>,
     view: watch::Receiver<Arc<ChainView>>,
     ticks: watch::Receiver<Interval>,
+    /// The lag gate. See [`DutyService::serves_duties`].
+    gate: LagGate,
     attested: BTreeSet<Slot>,
     advancing: AdvancesInFlight,
 }
@@ -83,6 +101,7 @@ impl DutyService {
             products,
             view,
             ticks,
+            gate: LagGate::default(),
             attested: BTreeSet::new(),
             advancing: AdvancesInFlight::default(),
         }
@@ -119,8 +138,46 @@ impl DutyService {
 
         while self.ticks.changed().await.is_ok() {
             let interval = *self.ticks.borrow_and_update();
+            if !self.serves_duties(slot_of(interval)) {
+                continue;
+            }
             self.on_interval(interval).await;
         }
+    }
+
+    /// Whether duties may run for `slot`: the third serving gate.
+    ///
+    /// # Why lag and not the sync state
+    ///
+    /// A validator that signs while behind votes for a stale head and spends a one-time XMSS
+    /// signature to do it, and unlike a missed duty that spend is not recoverable
+    /// (`docs/design/key-management.md`). What the gate must answer is therefore "is this
+    /// node's view stale", and the honest measure of that is the node's own head against the
+    /// wall clock — not whether it has peers. A node alone at genesis is not behind anything;
+    /// a node with fifty peers and a head twenty slots old is.
+    ///
+    /// This is what every surveyed client does. leanSpec
+    /// (`node/validator/service.py::_is_synced_for_duties`), ethlambda
+    /// (`crates/blockchain/src/sync_status.rs`) and ream (`chain/lean/src/service.rs`) all
+    /// gate on head-versus-clock lag and none of them consults a peer count; the three
+    /// constants below are leanSpec's and ethlambda's, which agree exactly.
+    ///
+    /// # The stall override, and why it is not optional
+    ///
+    /// If every node stops signing whenever it is behind, a network that pauses can never
+    /// restart: every node is behind, so nobody proposes, so every node stays behind. The
+    /// freshest block this node has *seen* separates the two cases. Blocks reach the store
+    /// only after verification, so a stale maximum is authenticated evidence that the network
+    /// is not producing, and the gate opens rather than closing.
+    ///
+    /// The hysteresis band is what stops the gate flapping around the threshold: once closed
+    /// it reopens at `DUTY_LAG_THRESHOLD - DUTY_LAG_HYSTERESIS`, not at the threshold itself.
+    fn serves_duties(&mut self, slot: Slot) -> bool {
+        let view = self.view.borrow();
+        let head_slot = view.head_checkpoint().slot;
+        let max_seen = view.max_known_block_slot();
+        drop(view);
+        self.gate.admits(slot, head_slot, max_seen)
     }
 
     /// Brings every key far enough forward to sign for `slot`, off the async threads.
@@ -301,6 +358,47 @@ impl DutyService {
 }
 
 /// The slot an interval count since genesis falls in.
+/// The duty gate's decision, separated from the service so it can be exercised directly.
+///
+/// One bit of state — whether the gate is currently closed — which is what makes the
+/// hysteresis band expressible: reopening asks a different question from closing.
+#[derive(Debug, Default)]
+struct LagGate {
+    closed: bool,
+}
+
+impl LagGate {
+    /// Whether duties may run, given the wall-clock slot, this node's head, and the freshest
+    /// block it has seen from anyone.
+    fn admits(&mut self, slot: Slot, head_slot: Slot, max_seen: Slot) -> bool {
+        // Saturating, both of them: a head ahead of the wall clock is local clock drift, not
+        // a reason to trust a chain from the future.
+        let head_lag = slot.0.saturating_sub(head_slot.0);
+        let network_lag = slot.0.saturating_sub(max_seen.0);
+        let was_closed = self.closed;
+
+        self.closed = if network_lag > NETWORK_STALL_THRESHOLD {
+            false
+        } else if self.closed {
+            head_lag > DUTY_LAG_THRESHOLD - DUTY_LAG_HYSTERESIS
+        } else {
+            head_lag > DUTY_LAG_THRESHOLD
+        };
+
+        if self.closed != was_closed {
+            tracing::info!(
+                slot = slot.0,
+                head_slot = head_slot.0,
+                head_lag,
+                network_lag,
+                closed = self.closed,
+                "validator duty gate changed"
+            );
+        }
+        !self.closed
+    }
+}
+
 const fn slot_of(interval: Interval) -> Slot {
     Slot(interval.0 / INTERVALS_PER_SLOT)
 }
@@ -351,5 +449,68 @@ impl BlockProofJob {
         )?);
 
         proofs::to_multi_container(&merge_single_message_proofs(components)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use verity_types::Slot;
+
+    use super::{DUTY_LAG_THRESHOLD, LagGate, NETWORK_STALL_THRESHOLD};
+
+    /// A node whose head keeps up with the clock, which is also the case of a node alone on
+    /// the network at genesis: nothing is behind anything.
+    #[test]
+    fn should_serve_duties_while_the_head_keeps_up() {
+        let mut gate = LagGate::default();
+        for lag in 0..=DUTY_LAG_THRESHOLD {
+            let slot = Slot(100 + lag);
+            assert!(
+                gate.admits(slot, Slot(100), slot),
+                "lag {lag} is within the threshold"
+            );
+        }
+    }
+
+    #[test]
+    fn should_serve_duties_with_no_peers_at_genesis() {
+        let mut gate = LagGate::default();
+        assert!(gate.admits(Slot(0), Slot(0), Slot(0)));
+    }
+
+    #[test]
+    fn should_stop_signing_once_the_head_falls_behind() {
+        let mut gate = LagGate::default();
+        let slot = Slot(100 + DUTY_LAG_THRESHOLD + 1);
+        assert!(!gate.admits(slot, Slot(100), slot));
+    }
+
+    #[test]
+    fn should_reopen_only_below_the_hysteresis_band() {
+        let mut gate = LagGate::default();
+        // Close it.
+        assert!(!gate.admits(Slot(110), Slot(100), Slot(110)));
+        // Three slots behind: inside the threshold, but not yet inside the band.
+        assert!(!gate.admits(Slot(103), Slot(100), Slot(103)));
+        // Two slots behind: the band, so the gate reopens.
+        assert!(gate.admits(Slot(102), Slot(100), Slot(102)));
+    }
+
+    /// A network-wide stall is the case the gate must not make worse: if every node stopped
+    /// signing because every node is behind, nothing would ever propose again.
+    #[test]
+    fn should_keep_signing_when_the_network_itself_has_stopped() {
+        let mut gate = LagGate::default();
+        let slot = Slot(100 + NETWORK_STALL_THRESHOLD + 1);
+        // The head is far behind the clock, but so is the freshest block anyone has produced.
+        assert!(gate.admits(slot, Slot(100), Slot(100)));
+    }
+
+    /// The same lag, with the network visibly producing, is this node's problem.
+    #[test]
+    fn should_stop_signing_when_the_network_moves_and_this_node_does_not() {
+        let mut gate = LagGate::default();
+        let slot = Slot(100 + NETWORK_STALL_THRESHOLD + 1);
+        assert!(!gate.admits(slot, Slot(100), slot));
     }
 }

--- a/crates/verity/src/main.rs
+++ b/crates/verity/src/main.rs
@@ -8,6 +8,11 @@
 //! `--data-dir`, because Verity persists what the reference node keeps in memory, and
 //! `--network-name`, because the topic segment is a caller string with no computation behind
 //! it yet.
+//!
+//! Sync has exactly one flag, `--checkpoint-sync-url`, and that is deliberate: every other
+//! number the sync service uses is a constant in the code, because `docs/design/sync.md` puts
+//! the thresholds outside the design's commitments. An operator can choose where the node
+//! starts; the rate at which it catches up is not a choice the wire format leaves open.
 
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -58,6 +63,11 @@ struct Args {
     #[arg(long)]
     is_aggregator: bool,
 
+    /// Base URL of a node to fetch the finalized anchor from, instead of replaying from
+    /// genesis. A fetch or verification failure stops the node; there is no fallback.
+    #[arg(long, value_name = "URL")]
+    checkpoint_sync_url: Option<String>,
+
     /// Log at DEBUG instead of INFO.
     #[arg(short, long)]
     verbose: bool,
@@ -103,6 +113,7 @@ async fn run(args: Args) -> Result<(), verity_node::error::NodeError> {
         validator_indices,
         key_directory,
         is_aggregator: args.is_aggregator,
+        checkpoint_sync_url: args.checkpoint_sync_url,
     })
     .await?;
 

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,11 @@ allow = [
     "Unicode-3.0",
     # foldhash, reached through hashbrown and alloy-primitives.
     "Zlib",
+    # webpki-root-certs, reached through rustls-platform-verifier, which reqwest's rustls
+    # feature pulls in whichever provider is selected. The licence covers Mozilla's root
+    # certificate *data* rather than code: permissive, no copyleft, no attribution beyond the
+    # disclaimer.
+    "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.9
 # leanSig declares no `license` field in its manifest, so cargo-deny emits a standing

--- a/docs/design/sync.md
+++ b/docs/design/sync.md
@@ -1,6 +1,6 @@
 ---
 title: Sync Pipeline
-last_updated: 2026-08-26
+last_updated: 2026-09-07
 tags:
   - sync
   - networking
@@ -9,7 +9,9 @@ tags:
 
 # Sync Pipeline
 
-> Status: pre-implementation. Decisions ratified 2026-08-16. This document settles how Verity
+> Status: implemented in `crates/verity-node/src/sync/`. Decisions ratified 2026-08-16;
+> three of them were corrected against the code and the surveyed clients on 2026-09-07 and
+> are marked **Revised** below. This document settles how Verity
 > joins the network and catches up: the sync mode lifecycle, the block-fetch pipeline, and
 > peer management. It plugs into the runtime model of [concurrency.md](concurrency.md) and
 > pays two debts recorded there and in [key-management.md](key-management.md): the mechanism
@@ -80,12 +82,31 @@ Verity adopts the reference node's three-state machine, with the surveyed refine
 - **The condition is evaluated continuously.** Status is re-exchanged periodically rather
   than once per connection, and the trigger is re-checked on every Status update — the
   ethlambda/qlean-mini once-per-connection design is the named counterexample.
-- **Duties require `SYNCED`.** The sync service publishes its state over a small `watch`
-  channel; the validator duty loop reads it as its **third serving gate**, joining the two
-  from [key-management.md](key-management.md) (first `ChainView` observed, keys prepared) —
-  an application of concurrency.md's necessary-not-sufficient rule. A validator that
-  attests while behind broadcasts votes for a stale head and burns one-time signatures
-  (key-management.md) for nothing.
+- **Duties are gated on head lag, not on this state machine.** *(Revised 2026-09-07 — the
+  original text made `SYNCED` the third serving gate.)* The duty gate's job is to answer "is
+  this node's view stale", and the peer-derived state machine answers a different question.
+  A node alone at genesis has met nobody, so it is honestly `IDLE` — but it is not behind
+  anything, and gating on the machine would stop the first node of a devnet from ever
+  proposing. Conversely a node with many peers and a twenty-slot-old head *is* stale.
+  The gate is therefore this node's head against the wall clock, with hysteresis and a
+  network-stall override, and the state machine drives fetching only:
+
+  | | closes duties when | reopens when | override |
+  |---|---|---|---|
+  | value | head lag > 4 slots | head lag ≤ 2 slots | freshest block *seen* lags > 8 slots → duties stay open |
+
+  This is what every surveyed client does and none of them consults a peer count: leanSpec
+  `node/validator/service.py::_is_synced_for_duties`, ethlambda
+  `crates/blockchain/src/sync_status.rs`, and ream `chain/lean/src/service.rs`, whose
+  `unwrap_or(current_head_slot)` makes "no peers" read as "not behind". The three constants
+  above are leanSpec's `SYNC_LAG_THRESHOLD`, `HYSTERESIS_BAND` and `NETWORK_STALL_THRESHOLD`,
+  which ethlambda copies exactly. The stall override is not optional: without it a paused
+  network can never restart, because every node is behind and so no node proposes.
+  It remains the **third serving gate** of the two in [key-management.md](key-management.md)
+  (first `ChainView` observed, keys prepared) — the reason is unchanged, a validator that
+  signs while stale burns one-time signatures (key-management.md) for nothing. Implemented as
+  `LagGate` in `verity-validator`; the sync state stays observable on the node for operators
+  and metrics.
 - **The entry decision tree, exhaustively.** Before the machine starts, the anchor is chosen
   by exactly one of three mutually exclusive paths:
   1. `--checkpoint-sync-url` **given** → checkpoint entry (below). The database and genesis
@@ -96,11 +117,19 @@ Verity adopts the reference node's three-state machine, with the surveyed refine
 - **Checkpoint entry.** Fetch the finalized state and block over HTTP and verify at the
   strictest surveyed depth (ethlambda's): genesis-time match, validator-registry match
   against local genesis config, slot-ordering invariants
-  (`finalized ≤ justified ≤ state slot`), checkpoint-root consistency — meaning
-  (a) `hash_tree_root(anchor_block) == state.latest_finalized.root` (the fetched block *is*
-  the state's finalized block) and (b) when `latest_justified.slot == latest_finalized.slot`
-  their roots are equal — and `hash_tree_root(state) == anchor_block.state_root`. Failures
-  split in two:
+  (`finalized ≤ justified ≤ state slot`), and anchor-pairing consistency. *(Revised
+  2026-09-07: the original text required `hash_tree_root(anchor_block) ==
+  state.latest_finalized.root` unconditionally. That is circular and unsatisfiable — the
+  block commits to this very state, so this state cannot also be one the block descends
+  from — and it is not what ethlambda, the implementation being copied, actually does.)*
+  The pairing is: (a) the fetched block **is** the block the state's own
+  `latest_block_header` describes (same slot, proposer, parent and body root), (b)
+  `hash_tree_root(state) == anchor_block.state_root`, which is the equality leanSpec's state
+  transition itself asserts when it accepts a block, (c) `latest_block_header.slot ≤
+  state.slot`, (d) **when** `latest_block_header.slot == latest_finalized.slot`, that block
+  root equals `latest_finalized.root` — the finalized root is checked exactly where it is
+  meaningful and nowhere else — and (e) when `latest_justified.slot ==
+  latest_finalized.slot`, their roots are equal. Failures split in two:
   **transient fetch failures** (timeout, connection refused, HTTP 5xx) are retried within a
   bounded budget (attempt counts and backoff are tunables); **definitive failures** (SSZ
   decode failure, any verification check failing, HTTP 4xx) exit immediately with no retry.
@@ -158,10 +187,17 @@ flowchart LR
   they are distinct from signature verification, which stays in the stage.
 - **Gossip during SYNCING**: the block topic stays subscribed — gossip blocks are the input
   that reveals the head-side edge of the gap (the reference's `fill_gap_above_head`
-  pattern). Attestation and aggregation processing is **paused** while SYNCING: their
-  target states cannot be resolved yet, so they would only churn the pending buffer and
-  burn aggregate-proof verification CPU on messages that cannot be imported. This is the
-  translation of the reference's `accepts_gossip` gate into the staged pipeline.
+  pattern). Attestations and aggregates whose target state is not in view **park in the
+  verification stage's existing pending buffer** and are retried when a snapshot resolves
+  them. *(Revised 2026-09-07 — the original text said this processing is "paused" while
+  SYNCING.)* Parking is what the staged pipeline already does with any item whose state is
+  missing, so it is the behaviour that costs no code at all: a synced-state gate inside the
+  stage would be an addition, not a saving. It is also what the reference node does —
+  `MAX_PENDING_ATTESTATIONS = 1024` in leanSpec's `node/sync/config.py` is that buffer.
+  The one cost is that blocks and attestations share one bounded buffer, so a catch-up can
+  evict a block waiting on its parent; eviction raises a gap signal like parking does, so
+  the block is re-requested rather than lost. If measurement shows the churn matters, the
+  next step is leanSpec's shape — a separate cap per kind — not a gate.
 
 ## Decision 3 — peer management
 

--- a/docs/src/reference/architecture.md
+++ b/docs/src/reference/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Verity Architecture
-last_updated: 2026-09-02
+last_updated: 2026-09-07
 tags:
   - architecture
   - verification-boundary
@@ -182,9 +182,13 @@ upstream Lean library name per Rust's `-sys` convention.
 - `verity-node` — the runtime that makes those libraries a process: the **single writer**, one task
   owning `Store`, `State` and the repository under one consistency boundary; the verification stage
   in front of it, where `Verified*` values are the only things that can reach it; the interval
-  clock; and the wiring to the network, the database, and validator duties. The consistency
+  clock; the **sync service** — the peer table, the catch-up state machine and the block responder
+  of [sync.md](https://github.com/NyxFoundation/verity/blob/develop/docs/design/sync.md) — and the
+  wiring that joins all of them to the network, the database, and validator duties. The consistency
   boundary lives here because it is a *runtime* property — ownership by one task — while the
-  decisions it applies stay in `verity-chain`.
+  decisions it applies stay in `verity-chain`. The responder reads the same open database as the
+  writer through a read-only handle (`verity-db`'s `StorageReader`), which is how a request for a
+  thousand proof-bearing blocks is served without touching the writer's thread.
 - `verity` (binary) — the executable validators run: argument parsing, log setup, signal handling,
   and the call that starts the node.
 
@@ -196,8 +200,11 @@ upstream Lean library name per Rust's `-sys` convention.
   (formerly leanMultisig) for aggregation and aggregate-proof verification. One capability
   contract, two suppliers behind it.
 - `verity-db` — persistence (Repository): blocks, states, aggregate proofs, and the finalized anchor.
-  Keeps the storage concern out of the single-writer aggregate coordinator. See
-  [Storage engine and retention](#storage-engine-and-retention).
+  Keeps the storage concern out of the single-writer aggregate coordinator. The one-writer rule is
+  carried by the type system in two layers: writes take `&mut self`, and the backend trait splits
+  into `StorageReader` (point and range reads) and `StorageBackend` (those plus `write`), so a
+  reader sharing the writer's open database is a handle with no `write` on it rather than one
+  trusted not to call it. See [Storage engine and retention](#storage-engine-and-retention).
 - `verity-rpc` — HTTP API surface.
 - `verity-metrics` — implementation of the leanMetrics contract.
 


### PR DESCRIPTION
## What

Implements the sync service of [`docs/design/sync.md`](../blob/develop/docs/design/sync.md) in `crates/verity-node/src/sync/`, which is what turns the node runtime from a process that only works if it starts at genesis with everyone else into one that can join a running network.

Before this, gossip was the node's only source of blocks — so a node that arrived late, restarted, or missed a block could never obtain what it had not been present for — and `network.rs` refused every `BlocksByRange` and `BlocksByRoot` with `RESOURCE_UNAVAILABLE`, leaving leanSpec's one MUST for the ReqResp suite unmet.

| file | what it owns |
|---|---|
| `state.rs` | `IDLE → SYNCING → SYNCED`, triggered on the **median** of peers' claimed finalized slots, re-evaluated on every status update and snapshot |
| `peers.rs` | peer table, request-reliability score (100 / +10 / −20 / 0–200), score-weighted selection that never fully excludes a peer |
| `fetch.rs` | small gaps by root, deep gaps by range, one batch in flight; structural validation of every response |
| `responder.rs` | the serving side, over `verity-db`'s retention window — **the MUST** |
| `checkpoint.rs` | `--checkpoint-sync-url`, fail-closed verification against local genesis |

Gaps are noticed where they are first discovered: the verification stage signals the root a parked item awaits. Fetched blocks re-enter through the channel gossip uses, so the `Verified*` invariant holds for the sync path with no exceptions.

## verity-db: `StorageReader`

Serving reads the writer's own database, and one request can be a thousand proof-bearing blocks. The backend trait splits into `StorageReader` (`get`, `range`) and `StorageBackend` (those plus `write`), so the responder holds a handle that **cannot** write rather than one trusted not to. `docs/design/storage.md`'s one-writer rule is now carried across tasks by the type system, not only across owners.

## Three decisions revised against the code

All three are marked **Revised** in `sync.md` with the reasoning:

1. **Duties gate on head-versus-wall-clock lag, not on the sync state.** A node alone at genesis has met nobody and is honestly `IDLE` — but it is not behind anything, and gating on the machine would stop a devnet's first node from ever proposing. leanSpec (`_is_synced_for_duties`), ethlambda (`sync_status.rs`) and ream (`chain/lean/src/service.rs`) all gate on lag and none consults a peer count. Thresholds are leanSpec's (4 / 2 / 8), which ethlambda copies exactly. The network-stall override is not optional: without it a paused network can never restart.
2. **Checkpoint anchor pairing.** The doc required `hash_tree_root(anchor_block) == state.latest_finalized.root` unconditionally. That is circular and unsatisfiable — the block commits to this very state — and is not what ethlambda does. The anchor is paired with the state's own `latest_block_header`; the finalized root is checked only when the header sits at the finalized slot.
3. **Attestations during SYNCING park** in the pending buffer they already parked in, rather than being "paused". Parking is the behaviour that costs no code, and it is what the reference node does (`MAX_PENDING_ATTESTATIONS`).

## Verification

- `cargo test --workspace` — 33 test binaries, 0 failures, including the two gated end-to-end tests run with real production-scheme keys and real zk proofs.
- **`tests/catch_up.rs`** (new): a second node started *after* the first has built a chain reaches it. It asserts not only that the block arrives but that it arrived **by asking** — gossipsub answers IWANT out of a short history, so counters on both sides are what separate sync from gossip.
- **`tests/sync_fixtures.rs`** (new): leanSpec's `sync_test` vectors, validated against fixtures generated from the local leanSpec checkout (6 files, determinism check passed).
- One new dependency, `reqwest`, deliberately on `rustls-no-provider` with `ring` installed as the process provider: reqwest's own `rustls` feature pulls `aws-lc-sys`, a C library needing cmake, and leaves the tree with two crypto providers because libp2p-quic already brought `ring`.
