### PR TITLE
feat: join a lean-quickstart devnet and follow finality with ethlambda and ream

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Only what the Dockerfile copies reaches the build context: the manifests, the toolchain
+# pin, and the crates. Everything else is either regenerated in the image or irrelevant to it.
+*
+!Cargo.toml
+!Cargo.lock
+!rust-toolchain.toml
+!LICENSE
+!crates
+crates/**/target

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,22 +67,32 @@ reading the tooling, and that break interop silently when wrong:
   and `--aggregate-subnet-ids` are checked against it and refused otherwise, never applied.
 - `Dockerfile` builds the image lean-quickstart's docker mode and hive run
   (`ghcr.io/nyxfoundation/verity`); it builds `--locked` for the reasons above.
-- **Running it locally** (what the 2026-09-11 verification did):
-  1. Clone lean-quickstart. Bump the images in `client-cmds/ethlambda-cmd.sh` and
-     `client-cmds/ream-cmd.sh` to `ethlambda:devnet5` / `ream:latest-devnet5` (see next bullet).
-  2. Add `client-cmds/verity-cmd.sh` (six touch points in `docs/adding-a-new-client.md` there). In
-     binary mode it runs `$scriptDir/../verity/target/release/verity`, i.e. a `verity` checkout beside
-     the lean-quickstart checkout; set `VERITY_BINARY=/path/to/verity` to run any other build.
-  3. Add a `verity_0` entry to `local-devnet/genesis/validator-config.yaml`. `privkey` is required
-     (32-byte hex, e.g. `openssl rand -hex 32`); ports must not collide with the entries already in
-     that file — the upstream file uses quic 9001–9010, metrics 8081–8090, api 5051–5060/8086/8087,
-     so `9011` / `8091` / `5061` are free. Trim the file to the nodes you actually run: every entry
-     is a validator, and finality needs two thirds of them online.
-  4. `NETWORK_DIR=local-devnet ./spin-node.sh --node all --generateGenesis --skip-leanpoint --skip-nemo`.
-  5. Verify: `curl http://127.0.0.1:<apiPort>/lean/v0/fork_choice` on every node and compare
-     `finalized.slot` / `finalized.root` (JSON); they must match and advance. `/lean/v0/checkpoints/justified`
-     is the same for justification, and `/metrics` on the metrics port exposes
-     `lean_latest_finalized_slot`. Verity's log prints `imported slot=… finalized=…` per block.
+- **Running it locally** (what the 2026-09-11 verification did; needs docker, yq, curl, jq):
+  1. Clone lean-quickstart. In `client-cmds/ethlambda-cmd.sh` and `client-cmds/ream-cmd.sh` change the
+     image tags to `ethlambda:devnet5` / `ream:latest-devnet5` (see next bullet for why).
+  2. Add `client-cmds/verity-cmd.sh` (six touch points in `docs/adding-a-new-client.md` there; the
+     script is on the `add-verity-client` branch of the local clone until it is upstreamed). Its
+     `node_setup="docker"` runs `ghcr.io/nyxfoundation/verity:latest` — `docker build -t
+     ghcr.io/nyxfoundation/verity:latest .` first, spin-node tolerates a failed pull and runs the local
+     tag. Or set `node_setup="binary"`: it then runs `$scriptDir/../verity/target/release/verity`
+     (a `verity` checkout beside lean-quickstart, `cargo build --release --locked`), or the path in
+     `VERITY_BINARY`.
+  3. Replace the `validators:` list in `local-devnet/genesis/validator-config.yaml` with exactly three
+     entries: the upstream `ethlambda_0` and `ream_0` entries unchanged, plus `verity_0` with
+     `privkey: "<openssl rand -hex 32>"`, `enrFields: {ip: "127.0.0.1", quic: 9011}`, `metricsPort:
+     8091`, `apiPort: 5061`, `isAggregator: false`, `count: 1`. Every entry is a validator and
+     finality needs two thirds of them online, so entries you do not run must go. Each node's REST
+     port is its `apiPort` (upstream: ethlambda_0 8087, ream_0 5052).
+  4. `NETWORK_DIR=local-devnet ./spin-node.sh --node all --generateGenesis --skip-leanpoint --skip-nemo`
+     — `all` is every entry in that file; the two skips leave out the leanpoint and Nemo containers,
+     which need a tooling server. `--attestation-committee-count` and the node key are passed by
+     the script; `--network-name` is left at its default.
+  5. Verify, after two or three minutes (finalized reached slot 42 at 4.5 min in the run above):
+     `for p in 5061 8087 5052; do curl -s http://127.0.0.1:$p/lean/v0/fork_choice | jq -c .finalized; done`
+     prints one `{"slot":N,"root":"0x…"}` per node; they must be identical and `slot` must keep
+     growing. `/lean/v0/checkpoints/justified` is the same shape for justification, and
+     `/metrics` on the metrics port exposes `lean_latest_finalized_slot`. Verity's own log prints
+     `imported slot=… finalized=…` per block.
 - **The latest devnet generation is devnet5** (leanSpec #717 "Aggregated block proof", the
   `SignedBlock { block, proof: MultiMessageAggregate }` shape Verity transcribes). lean-quickstart's
   `client-cmds/*.sh` still pin devnet4 images (`ethlambda:devnet4`, `ream:latest-devnet4`), whose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,56 @@ Owner-ratified ground rules for the first Rust code. Do not re-open these withou
 - **Verification harness**: NOT wired in from day one (no bolero/proptest in the initial scaffold or CI); introduced later per `docs/design/model-check.md`'s tool-to-zone mapping.
 - Known caveat: leanSig internally depends on `ethereum_ssz`, so two SSZ implementations coexist transitively — harmless, but mind type conversions at the signature boundary.
 
+## Devnet interop (2026-09-11)
+
+Verity is started by [lean-quickstart](https://github.com/blockblaz/lean-quickstart) exactly as
+every other client is (`docs/adding-a-new-client.md` there): `--genesis config.yaml`,
+`--bootnodes nodes.yaml` (ENRs), `--node-key <node>.key`, `--validator-keys <genesis dir>`
+(holds `validators.yaml` and `hash-sig-keys/`), `--node-id`, `--listen-port`, `--api-port`,
+`--metrics-port`, `--is-aggregator`, `--checkpoint-sync-url`. Facts that were only found by
+reading the tooling, and that break interop silently when wrong:
+
+- **The gossip topic segment is `12345678`**, leanSpec's `GOSSIP_DIGEST` (`spec/forks/lstar/spec.py`),
+  transcribed as `verity_types::config::GOSSIP_DIGEST` and the `--network-name` default. A node
+  with any other value subscribes to topics nobody publishes on and hears nothing.
+- **The generator spells the genesis keys `attestation_pubkey` / `proposal_pubkey`**, bare hex,
+  where leanSpec's own reader spells them `attestation_public_key` / `proposal_public_key`.
+  `GenesisFile` accepts both; the generator's extra keys (`ATTESTATION_COMMITTEE_COUNT`,
+  `VALIDATOR_COUNT`, `ACTIVE_EPOCH`) are ignored.
+- **leanpoint probes `/v0/health`**, not `/lean/v0/health` (`convert-validator-config.py`);
+  the `verity-rpc` crate inside the `verity` binary serves both on `--api-port`. "Healthy" means
+  the process answered; it says nothing about sync.
+- **Bootnode ENRs are reduced to `/ip4/<ip>/udp/<quic port>/quic-v1/p2p/<peer id>`**, the peer id
+  derived from the record's secp256k1 key. Every lean client derives its libp2p identity from the
+  key that signs its record, which is what makes the `/p2p/` suffix safe to add.
+- `ATTESTATION_COMMITTEE_COUNT` is a leanSpec constant (1), so `--attestation-committee-count`
+  and `--aggregate-subnet-ids` are checked against it and refused otherwise, never applied.
+- `Dockerfile` builds the image lean-quickstart's docker mode and hive run
+  (`ghcr.io/nyxfoundation/verity`); it builds `--locked` for the reasons above.
+- **Running it locally** (what the 2026-09-11 verification did):
+  1. Clone lean-quickstart. Bump the images in `client-cmds/ethlambda-cmd.sh` and
+     `client-cmds/ream-cmd.sh` to `ethlambda:devnet5` / `ream:latest-devnet5` (see next bullet).
+  2. Add `client-cmds/verity-cmd.sh` (six touch points in `docs/adding-a-new-client.md` there). In
+     binary mode it runs `$scriptDir/../verity/target/release/verity`, i.e. a `verity` checkout beside
+     the lean-quickstart checkout; set `VERITY_BINARY=/path/to/verity` to run any other build.
+  3. Add a `verity_0` entry to `local-devnet/genesis/validator-config.yaml`. `privkey` is required
+     (32-byte hex, e.g. `openssl rand -hex 32`); ports must not collide with the entries already in
+     that file — the upstream file uses quic 9001–9010, metrics 8081–8090, api 5051–5060/8086/8087,
+     so `9011` / `8091` / `5061` are free. Trim the file to the nodes you actually run: every entry
+     is a validator, and finality needs two thirds of them online.
+  4. `NETWORK_DIR=local-devnet ./spin-node.sh --node all --generateGenesis --skip-leanpoint --skip-nemo`.
+  5. Verify: `curl http://127.0.0.1:<apiPort>/lean/v0/fork_choice` on every node and compare
+     `finalized.slot` / `finalized.root` (JSON); they must match and advance. `/lean/v0/checkpoints/justified`
+     is the same for justification, and `/metrics` on the metrics port exposes
+     `lean_latest_finalized_slot`. Verity's log prints `imported slot=… finalized=…` per block.
+- **The latest devnet generation is devnet5** (leanSpec #717 "Aggregated block proof", the
+  `SignedBlock { block, proof: MultiMessageAggregate }` shape Verity transcribes). lean-quickstart's
+  `client-cmds/*.sh` still pin devnet4 images (`ethlambda:devnet4`, `ream:latest-devnet4`), whose
+  `SignedBlock` carries per-attestation proofs plus an XMSS proposer signature: Verity discards their
+  blocks as `undecodable` and they discard Verity's. Run it against `ethlambda:devnet5` and
+  `ream:latest-devnet5` (both published), which is how the 2026-09-11 three-node run reached
+  agreement on head and justification.
+
 ## Documentation site (`docs/`)
 
 The docs are an [mdBook](https://rust-lang.github.io/mdBook/). All commands run from the `docs/` directory.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backend"
 version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanVM?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
@@ -2168,6 +2216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2244,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3374,10 +3429,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -4227,6 +4294,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5111,6 +5192,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5974,6 +6066,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "verity-metrics"
+version = "0.0.0"
+dependencies = [
+ "prometheus",
+]
+
+[[package]]
 name = "verity-node"
 version = "0.0.0"
 dependencies = [
@@ -5993,7 +6092,9 @@ dependencies = [
  "verity-chain",
  "verity-crypto",
  "verity-db",
+ "verity-metrics",
  "verity-p2p",
+ "verity-rpc",
  "verity-types",
  "verity-validator",
 ]
@@ -6014,6 +6115,24 @@ dependencies = [
  "sha2",
  "snap",
  "tokio",
+ "verity-types",
+]
+
+[[package]]
+name = "verity-rpc"
+version = "0.0.0"
+dependencies = [
+ "axum",
+ "hex",
+ "libssz",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "verity-chain",
+ "verity-db",
+ "verity-metrics",
  "verity-types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "enr"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
+dependencies = [
+ "alloy-rlp",
+ "base64",
+ "bytes",
+ "hex",
+ "k256",
+ "log",
+ "rand 0.8.8",
+ "sha3 0.10.9",
+ "zeroize",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5960,6 +5977,7 @@ dependencies = [
 name = "verity-node"
 version = "0.0.0"
 dependencies = [
+ "enr",
  "hex",
  "libssz",
  "rand 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,14 @@ libp2p = { version = "0.56", default-features = false, features = [
     "secp256k1",
 ] }
 
+# Decodes the ENR records lean-quickstart hands every node in `nodes.yaml`. Verity runs no
+# discovery — the peer set is known at configuration time — so this is a reader for a static
+# bootnode list, not a discovery dependency: RLP decoding, the secp256k1 signature check, and
+# the `ip` / `quic` fields, nothing else. `k256` is the identity scheme (`v4`) every lean
+# client signs its record with; `k256`, `alloy-rlp` and `sha3` were already in the lockfile
+# through leanSig, so this adds no new source tree.
+enr = { version = "0.13", default-features = false, features = ["k256"] }
+
 # The async runtime for the I/O Edge. The feature set is what the node actually uses — `rt`
 # and `rt-multi-thread` to spawn the swarm, chain, verification and duty tasks, `sync` for the
 # channels between them, `macros` for `select!`, `time` for request timeouts and the slot

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,17 @@ tokio = { version = "1", default-features = false, features = [
     "macros",
     "time",
     "signal",
+    "net",
 ] }
+
+# --- HTTP surface -------------------------------------------------------------------------
+# `axum` serves the cross-client REST API (`/lean/v0/*`) and the Prometheus scrape endpoint.
+# Only what a handful of GET/POST routes need: HTTP/1, JSON bodies, the tokio server. `net` on
+# tokio above is for the listener the server binds.
+axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
+# The leanMetrics contract is Prometheus text exposition; this is the registry and encoder.
+# Default features pull in protobuf exposition, which nothing scrapes.
+prometheus = { version = "0.14", default-features = false }
 futures = "0.3"
 
 # Snappy, in both of its formats. leanSpec uses the raw block format for gossip payloads and
@@ -217,6 +227,8 @@ verity-crypto = { path = "crates/verity-crypto", version = "0.0.0" }
 verity-db = { path = "crates/verity-db", version = "0.0.0" }
 verity-p2p = { path = "crates/verity-p2p", version = "0.0.0" }
 verity-validator = { path = "crates/verity-validator", version = "0.0.0" }
+verity-metrics = { path = "crates/verity-metrics", version = "0.0.0" }
+verity-rpc = { path = "crates/verity-rpc", version = "0.0.0" }
 verity-node = { path = "crates/verity-node", version = "0.0.0" }
 
 # --- Test-only -----------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7
+#
+# The image lean-quickstart runs Verity from (`client-cmds/verity-cmd.sh`, docker mode) and
+# the one hive drives. Two stages: a Rust builder, and a minimal runtime that carries the
+# binary alone.
+#
+# The build is `--locked` on purpose: two git dependencies (leanSig, Plonky3) are pinned only
+# in Cargo.lock, and a build allowed to re-resolve would silently follow their branches
+# (see CLAUDE.md). RocksDB's bindings need clang at build time; nothing at runtime does.
+
+FROM rust:1.97-bookworm AS builder
+WORKDIR /verity
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends clang libclang-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY rust-toolchain.toml Cargo.toml Cargo.lock ./
+COPY crates ./crates
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/verity/target \
+    cargo build --release --locked --bin verity \
+    && cp target/release/verity /usr/local/bin/verity
+
+FROM debian:bookworm-slim AS runtime
+
+LABEL org.opencontainers.image.source="https://github.com/NyxFoundation/verity"
+LABEL org.opencontainers.image.description="Verity, the formally verified lean consensus client"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# ca-certificates: checkpoint sync fetches over HTTPS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bin/verity /usr/local/bin/verity
+COPY LICENSE /verity/LICENSE
+
+# 9001/udp - libp2p QUIC
+# 5052     - REST API (/lean/v0/*)
+# 5054     - Prometheus metrics (/metrics)
+# lean-quickstart runs the container with --network host and passes the actual ports.
+EXPOSE 9001/udp 5052 5054
+ENTRYPOINT ["/usr/local/bin/verity"]

--- a/_typos.toml
+++ b/_typos.toml
@@ -10,6 +10,11 @@ extend-exclude = [
     "docs/mermaid-init.js",
 ]
 
+[default]
+# ENR records are base64url and land in tests as real-world samples; any 2-4 letter run inside
+# one is noise to a spell-checker, not a word.
+extend-ignore-re = ["enr:-[A-Za-z0-9_-]+"]
+
 [default.extend-words]
 # "ser" — serialization abbreviation (mermaid node IDs, serde ser/de), not a typo of "set".
 ser = "ser"

--- a/crates/verity-chain/src/view.rs
+++ b/crates/verity-chain/src/view.rs
@@ -34,6 +34,7 @@ use verity_types::{
 use crate::error::RejectionReason;
 use crate::fork_choice::duties::{attestation_data, attestation_target};
 use crate::fork_choice::store::{AttestationSignatureEntry, Store};
+use crate::fork_choice::weights::block_weights;
 
 /// An immutable view of the chain, as of one completed import.
 ///
@@ -106,6 +107,50 @@ impl ChainView {
     #[must_use]
     pub fn block(&self, root: Bytes32) -> Option<&Block> {
         self.store.blocks.get(&root)
+    }
+
+    /// Every block the snapshot holds: the unfinalized tree and the anchor.
+    pub fn blocks(&self) -> impl Iterator<Item = (&Bytes32, &Block)> {
+        self.store.blocks.iter()
+    }
+
+    /// Each known block's fork-choice weight: the stake of the latest votes at or below it.
+    ///
+    /// Counts only the votes currently driving the head, exactly as `update_head` sees them;
+    /// attestations seen but not yet accepted carry no weight here either.
+    #[must_use]
+    pub fn block_weights(&self) -> HashMap<Bytes32, u64> {
+        block_weights(&self.store)
+    }
+
+    /// How many per-validator signatures the aggregator has collected, over every vote.
+    #[must_use]
+    pub fn attestation_signature_count(&self) -> usize {
+        self.store
+            .attestation_signatures
+            .values()
+            .map(HashSet::len)
+            .sum()
+    }
+
+    /// How many proofs were gathered this slot and do not count yet.
+    #[must_use]
+    pub fn new_aggregated_payload_count(&self) -> usize {
+        self.store
+            .latest_new_aggregated_payloads
+            .values()
+            .map(HashSet::len)
+            .sum()
+    }
+
+    /// How many proofs count toward fork-choice weight.
+    #[must_use]
+    pub fn known_aggregated_payload_count(&self) -> usize {
+        self.store
+            .latest_known_aggregated_payloads
+            .values()
+            .map(HashSet::len)
+            .sum()
     }
 
     /// The highest slot of any block in view, canonical or not.

--- a/crates/verity-metrics/Cargo.toml
+++ b/crates/verity-metrics/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "verity-metrics"
+description = "The leanMetrics contract: the Prometheus metrics every lean client exposes under the same names, types, labels and buckets, so that one dashboard serves them all."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+
+# A leaf crate on purpose. It knows the contract — the registered strings — and nothing about
+# the chain, so any crate can hold a handle and record into it without a dependency cycle.
+[dependencies]
+prometheus.workspace = true
+
+[lints]
+workspace = true

--- a/crates/verity-metrics/src/lib.rs
+++ b/crates/verity-metrics/src/lib.rs
@@ -1,0 +1,359 @@
+//! The leanMetrics contract, as a registry.
+//!
+//! [leanMetrics](https://github.com/leanEthereum/leanMetrics) fixes what every lean client
+//! exposes: the metric name strings, their Prometheus types, their label names and enum
+//! values, and their histogram buckets — so that one Grafana dashboard reads every client.
+//! Transcribed from `metrics.md` at commit `69f97227`. What is governed is the registered
+//! string, type, labels and buckets; the Rust identifiers below are free, and are named for
+//! what they measure rather than for the string.
+//!
+//! # What is implemented
+//!
+//! The gauges and counters a node can sample from its chain view and its peer set: node
+//! info, the fork-choice and state-transition slots, the sync status, the validator and
+//! aggregator facts, the peer count, and the committee layout. The histograms — timings of
+//! signing, verification, block building, state transition — are not registered yet: each
+//! needs a probe at the point of work, and an unregistered histogram is a gap a dashboard
+//! shows as "no data", where a wrongly placed probe would show a wrong number.
+//!
+//! # Where the samples come from
+//!
+//! This crate registers and renders; it does not observe. leanMetrics names a "sample
+//! collection event" for each metric, and the crate that owns that event records into the
+//! handle it holds. Gauges marked "on scrape" are refreshed by the scrape endpoint itself,
+//! from the chain view current at that moment.
+
+use std::fmt;
+
+use prometheus::{Encoder, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder};
+
+/// A registry that could not be built.
+///
+/// Only a name collision produces one, and the fixed names below make that impossible; it is
+/// a type rather than a panic so that the contract's construction stays visible to callers.
+#[derive(Debug)]
+pub struct MetricsError(String);
+
+impl fmt::Display for MetricsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "cannot build the metric registry: {}", self.0)
+    }
+}
+
+impl std::error::Error for MetricsError {}
+
+impl From<prometheus::Error> for MetricsError {
+    fn from(error: prometheus::Error) -> Self {
+        Self(error.to_string())
+    }
+}
+
+/// The concrete gauge and counter types, for a caller that names one in a signature.
+pub mod prometheus_gauge {
+    pub use prometheus::{IntCounter, IntGauge};
+}
+
+/// The Prometheus text exposition media type, as leanSpec serves it.
+pub const TEXT_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+/// The `status` label of `lean_node_sync_status`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncStatus {
+    /// Not syncing and not synced: the node has not met the network yet.
+    Idle,
+    /// Behind the network and fetching.
+    Syncing,
+    /// Caught up.
+    Synced,
+}
+
+impl SyncStatus {
+    const ALL: [Self; 3] = [Self::Idle, Self::Syncing, Self::Synced];
+
+    /// The label value leanMetrics fixes for this status.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Syncing => "syncing",
+            Self::Synced => "synced",
+        }
+    }
+}
+
+/// Every registered metric, and the registry that renders them.
+///
+/// One per process, shared by handle. Fields are the metric families; recording into one
+/// is a plain Prometheus operation on it.
+#[derive(Debug)]
+pub struct Metrics {
+    registry: Registry,
+
+    /// `lean_node_info`, labelled `name`, `version`. Always 1.
+    pub node_info: IntGaugeVec,
+    /// `lean_node_start_time_seconds`: the Unix time the node started.
+    pub node_start_time_seconds: IntGauge,
+
+    /// `lean_head_slot`: the slot of the fork-choice head.
+    pub head_slot: IntGauge,
+    /// `lean_current_slot`: the slot the clock sits in.
+    pub current_slot: IntGauge,
+    /// `lean_safe_target_slot`: the slot of the safe target.
+    pub safe_target_slot: IntGauge,
+    /// `lean_gossip_signatures`: per-validator signatures held in the store.
+    pub gossip_signatures: IntGauge,
+    /// `lean_latest_new_aggregated_payloads`: proofs gathered this slot, not yet counted.
+    pub latest_new_aggregated_payloads: IntGauge,
+    /// `lean_latest_known_aggregated_payloads`: proofs counting toward weight.
+    pub latest_known_aggregated_payloads: IntGauge,
+    /// `lean_node_sync_status`, labelled `status`. Exactly one label value is 1.
+    pub node_sync_status: IntGaugeVec,
+
+    /// `lean_latest_justified_slot`.
+    pub latest_justified_slot: IntGauge,
+    /// `lean_latest_finalized_slot`.
+    pub latest_finalized_slot: IntGauge,
+    /// `lean_justified_slot`.
+    pub justified_slot: IntGauge,
+    /// `lean_finalized_slot`.
+    pub finalized_slot: IntGauge,
+    /// `lean_finalizations_total`, labelled `result` (`success`, `error`).
+    pub finalizations_total: IntCounterVec,
+
+    /// `lean_validators_count`: validators this node runs.
+    pub validators_count: IntGauge,
+    /// `lean_is_aggregator`: 1 when this node aggregates.
+    pub is_aggregator: IntGauge,
+
+    /// `lean_connected_peers`, labelled `client` (`<name>_<N>` or `unknown`).
+    pub connected_peers: IntGaugeVec,
+    /// `lean_attestation_committee_subnet`: the subnet this node's votes go on.
+    pub attestation_committee_subnet: IntGauge,
+    /// `lean_attestation_committee_count`: `ATTESTATION_COMMITTEE_COUNT`.
+    pub attestation_committee_count: IntGauge,
+}
+
+impl Metrics {
+    /// Registers every metric on a fresh registry.
+    ///
+    /// # Errors
+    ///
+    /// [`MetricsError`] only if two metrics collide, which the fixed names below make
+    /// impossible; it is propagated rather than unwrapped so the contract stays visible.
+    pub fn new() -> Result<Self, MetricsError> {
+        let registry = Registry::new();
+        let metrics = Self {
+            node_info: gauge_vec(
+                &registry,
+                "lean_node_info",
+                "Node information (always 1)",
+                &["name", "version"],
+            )?,
+            node_start_time_seconds: gauge(
+                &registry,
+                "lean_node_start_time_seconds",
+                "Start timestamp",
+            )?,
+            head_slot: gauge(&registry, "lean_head_slot", "Latest slot of the lean chain")?,
+            current_slot: gauge(
+                &registry,
+                "lean_current_slot",
+                "Current slot of the lean chain",
+            )?,
+            safe_target_slot: gauge(&registry, "lean_safe_target_slot", "Safe target slot")?,
+            gossip_signatures: gauge(
+                &registry,
+                "lean_gossip_signatures",
+                "Number of gossip signatures in fork-choice store",
+            )?,
+            latest_new_aggregated_payloads: gauge(
+                &registry,
+                "lean_latest_new_aggregated_payloads",
+                "Number of new aggregated payload items",
+            )?,
+            latest_known_aggregated_payloads: gauge(
+                &registry,
+                "lean_latest_known_aggregated_payloads",
+                "Number of known aggregated payload items",
+            )?,
+            node_sync_status: gauge_vec(
+                &registry,
+                "lean_node_sync_status",
+                "Node sync status",
+                &["status"],
+            )?,
+            latest_justified_slot: gauge(
+                &registry,
+                "lean_latest_justified_slot",
+                "Latest justified slot",
+            )?,
+            latest_finalized_slot: gauge(
+                &registry,
+                "lean_latest_finalized_slot",
+                "Latest finalized slot",
+            )?,
+            justified_slot: gauge(&registry, "lean_justified_slot", "Current justified slot")?,
+            finalized_slot: gauge(&registry, "lean_finalized_slot", "Current finalized slot")?,
+            finalizations_total: counter_vec(
+                &registry,
+                "lean_finalizations_total",
+                "Total number of finalization attempts",
+                &["result"],
+            )?,
+            validators_count: gauge(
+                &registry,
+                "lean_validators_count",
+                "Number of validators managed by a node",
+            )?,
+            is_aggregator: gauge(
+                &registry,
+                "lean_is_aggregator",
+                "Validator's is_aggregator status. True=1, False=0",
+            )?,
+            connected_peers: gauge_vec(
+                &registry,
+                "lean_connected_peers",
+                "Number of connected peers",
+                &["client"],
+            )?,
+            attestation_committee_subnet: gauge(
+                &registry,
+                "lean_attestation_committee_subnet",
+                "Node's attestation committee subnet",
+            )?,
+            attestation_committee_count: gauge(
+                &registry,
+                "lean_attestation_committee_count",
+                "Number of attestation committees (ATTESTATION_COMMITTEE_COUNT)",
+            )?,
+            registry,
+        };
+        Ok(metrics)
+    }
+
+    /// Records the node's identity and start time, once.
+    pub fn record_start(&self, name: &str, version: &str, start_time_seconds: i64) {
+        self.node_info.with_label_values(&[name, version]).set(1);
+        self.node_start_time_seconds.set(start_time_seconds);
+    }
+
+    /// Sets the sync status: the named label to 1, every other to 0.
+    ///
+    /// All three series are always present, so a dashboard's `max by (status)` reads the
+    /// same shape from every client whether or not a status has ever been active.
+    pub fn set_sync_status(&self, status: SyncStatus) {
+        for candidate in SyncStatus::ALL {
+            let value = i64::from(candidate == status);
+            self.node_sync_status
+                .with_label_values(&[candidate.label()])
+                .set(value);
+        }
+    }
+
+    /// Renders every metric in Prometheus text exposition format.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let mut buffer = Vec::new();
+        // The text encoder writes into a `Vec`, which cannot fail; a metric family that
+        // cannot be encoded is a bug in this crate, not a runtime condition to handle.
+        if let Err(error) = TextEncoder::new().encode(&self.registry.gather(), &mut buffer) {
+            return format!("# rendering failed: {error}\n");
+        }
+        String::from_utf8(buffer).unwrap_or_else(|_| "# rendering produced non-UTF-8\n".into())
+    }
+}
+
+fn gauge(registry: &Registry, name: &str, help: &str) -> Result<IntGauge, prometheus::Error> {
+    let gauge = IntGauge::with_opts(Opts::new(name, help))?;
+    registry.register(Box::new(gauge.clone()))?;
+    Ok(gauge)
+}
+
+fn gauge_vec(
+    registry: &Registry,
+    name: &str,
+    help: &str,
+    labels: &[&str],
+) -> Result<IntGaugeVec, prometheus::Error> {
+    let gauge = IntGaugeVec::new(Opts::new(name, help), labels)?;
+    registry.register(Box::new(gauge.clone()))?;
+    Ok(gauge)
+}
+
+fn counter_vec(
+    registry: &Registry,
+    name: &str,
+    help: &str,
+    labels: &[&str],
+) -> Result<IntCounterVec, prometheus::Error> {
+    let counter = IntCounterVec::new(Opts::new(name, help), labels)?;
+    registry.register(Box::new(counter.clone()))?;
+    Ok(counter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_register_every_contract_name_exactly_once() {
+        let metrics = Metrics::new().expect("fresh registry");
+        metrics.record_start("verity", "0.0.0", 1);
+        metrics.set_sync_status(SyncStatus::Synced);
+        metrics
+            .finalizations_total
+            .with_label_values(&["success"])
+            .inc();
+        metrics
+            .connected_peers
+            .with_label_values(&["unknown"])
+            .set(3);
+        let text = metrics.render();
+
+        for name in [
+            "lean_node_info{name=\"verity\",version=\"0.0.0\"} 1",
+            "lean_node_start_time_seconds 1",
+            "lean_head_slot 0",
+            "lean_current_slot 0",
+            "lean_safe_target_slot 0",
+            "lean_gossip_signatures 0",
+            "lean_latest_new_aggregated_payloads 0",
+            "lean_latest_known_aggregated_payloads 0",
+            "lean_node_sync_status{status=\"idle\"} 0",
+            "lean_node_sync_status{status=\"syncing\"} 0",
+            "lean_node_sync_status{status=\"synced\"} 1",
+            "lean_latest_justified_slot 0",
+            "lean_latest_finalized_slot 0",
+            "lean_justified_slot 0",
+            "lean_finalized_slot 0",
+            "lean_finalizations_total{result=\"success\"} 1",
+            "lean_validators_count 0",
+            "lean_is_aggregator 0",
+            "lean_connected_peers{client=\"unknown\"} 3",
+            "lean_attestation_committee_subnet 0",
+            "lean_attestation_committee_count 0",
+        ] {
+            assert!(text.contains(name), "missing `{name}` in:\n{text}");
+        }
+    }
+
+    #[test]
+    fn should_move_the_sync_status_to_exactly_one_label() {
+        let metrics = Metrics::new().expect("fresh registry");
+        metrics.set_sync_status(SyncStatus::Syncing);
+        metrics.set_sync_status(SyncStatus::Idle);
+        let text = metrics.render();
+        assert!(text.contains("lean_node_sync_status{status=\"idle\"} 1"));
+        assert!(text.contains("lean_node_sync_status{status=\"syncing\"} 0"));
+        assert!(text.contains("lean_node_sync_status{status=\"synced\"} 0"));
+    }
+
+    #[test]
+    fn should_declare_a_second_registry_independently() {
+        // Two nodes in one test process must not share a registry.
+        let a = Metrics::new().expect("first");
+        let b = Metrics::new().expect("second");
+        a.head_slot.set(7);
+        assert!(b.render().contains("lean_head_slot 0"));
+    }
+}

--- a/crates/verity-node/Cargo.toml
+++ b/crates/verity-node/Cargo.toml
@@ -12,11 +12,12 @@ publish = false
 # The wiring crate. Everything below it is a component with one job; this is where the
 # components are joined, which is why it is the only crate that depends on all of them.
 #
-# `serde_norway` and `hex` read the cross-client genesis and validator-assignment files;
-# `libssz` decodes gossip payloads, which arrive as raw bytes by design. `reqwest` and `rand`
-# belong to the sync service alone: the checkpoint-sync fetch and score-weighted peer
-# selection respectively (`docs/design/sync.md`).
+# `serde_norway` and `hex` read the cross-client genesis and validator-assignment files, and
+# `enr` the bootnode records beside them; `libssz` decodes gossip payloads, which arrive as raw
+# bytes by design. `reqwest` and `rand` belong to the sync service alone: the checkpoint-sync
+# fetch and score-weighted peer selection respectively (`docs/design/sync.md`).
 [dependencies]
+enr.workspace = true
 hex.workspace = true
 libssz.workspace = true
 rand.workspace = true

--- a/crates/verity-node/Cargo.toml
+++ b/crates/verity-node/Cargo.toml
@@ -30,14 +30,19 @@ tracing.workspace = true
 verity-chain.workspace = true
 verity-crypto.workspace = true
 verity-db.workspace = true
+verity-metrics.workspace = true
 verity-p2p.workspace = true
+verity-rpc.workspace = true
 verity-types.workspace = true
 verity-validator.workspace = true
 
-# `serde_json` reads the leanSpec fixture files; consensus values never travel as JSON.
+# `serde_json` reads the leanSpec fixture files and the API's JSON bodies; consensus values
+# never travel as JSON. `reqwest` drives the HTTP surface over a real socket in the tests.
 # `tracing-subscriber` is what makes `RUST_LOG` work in these harnesses: a library installs no
 # subscriber, so without it an end-to-end test that misbehaves is silent.
 [dev-dependencies]
+libssz.workspace = true
+reqwest.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/verity-node/src/bootstrap.rs
+++ b/crates/verity-node/src/bootstrap.rs
@@ -1,0 +1,342 @@
+//! The peer-facing inputs a lean node is started from: who to dial, and who to be.
+//!
+//! Transcribed from leanSpec `src/lean_spec/cli/bootstrap.py` and
+//! `src/lean_spec/node/networking/enr/enr.py`, read at commit `0b7d33ec`.
+//!
+//! # Bootnodes
+//!
+//! lean-quickstart writes every node's ENR into `nodes.yaml` so that no client has to run a
+//! discovery protocol; the file is a YAML list of strings. leanSpec's `--bootnode` accepts
+//! either an ENR (`enr:` followed by unpadded base64url) or a bare multiaddr, and so does
+//! [`parse_bootnode`], for both the file and the command line.
+//!
+//! An ENR is reduced to the one address the lean transport can use, `/ip4/<ip>/udp/<port>/quic-v1`,
+//! with the `quic` field preferred and `udp` the fallback, exactly as leanSpec's
+//! `ENR.multiaddr()` does. Verity appends `/p2p/<peer id>`, which leanSpec does not: the peer
+//! id is derived from the record's own secp256k1 key, so a dial that reaches a different
+//! identity at that address fails instead of admitting a stranger as the bootnode. Every lean
+//! client derives its libp2p identity from the same key that signs its record, which is what
+//! makes the two agree.
+//!
+//! A record whose signature does not verify is refused. The list is static and hand-written,
+//! so the check catches a copy-paste error rather than an attack — but a record that fails it
+//! is not the record the operator meant, and dialling it would only hide that.
+//!
+//! # Node key
+//!
+//! `<node>.key` is the node's secp256k1 secret, 32 bytes of hex on one line, `0x` optional.
+//! lean-quickstart writes it from the `privkey` field of `validator-config.yaml`, and the ENR
+//! in `nodes.yaml` is signed with the same key, so loading it is what makes this node's
+//! identity match the one every peer was told to expect.
+
+use std::fs;
+use std::path::Path;
+use std::str::FromStr;
+
+use verity_p2p::identity::{self, Keypair};
+use verity_p2p::{Multiaddr, PeerId};
+use verity_types::config::ATTESTATION_COMMITTEE_COUNT;
+
+use crate::error::ConfigError;
+
+/// The ENR key under which a lean node advertises its QUIC port.
+const QUIC_KEY: &str = "quic";
+
+/// A signed node record under the `v4` identity scheme, the only one lean clients use.
+type Record = enr::Enr<enr::k256::ecdsa::SigningKey>;
+
+/// Reads a bootnode list: a YAML sequence of ENR strings or multiaddrs.
+///
+/// # Errors
+///
+/// [`ConfigError::Unreadable`] when the file cannot be read, [`ConfigError::Malformed`] when
+/// it is not a sequence of strings, and [`ConfigError::MalformedBootnode`] for the first
+/// entry that is neither a valid ENR nor a multiaddr.
+pub fn read_bootnodes(path: &Path) -> Result<Vec<Multiaddr>, ConfigError> {
+    let text = fs::read_to_string(path).map_err(|error| ConfigError::Unreadable {
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })?;
+    let entries: Vec<String> =
+        serde_norway::from_str(&text).map_err(|error| ConfigError::Malformed {
+            path: path.to_path_buf(),
+            reason: error.to_string(),
+        })?;
+
+    entries
+        .iter()
+        .map(|entry| {
+            parse_bootnode(entry).map_err(|reason| ConfigError::MalformedBootnode {
+                source: path.display().to_string(),
+                entry: entry.clone(),
+                reason,
+            })
+        })
+        .collect()
+}
+
+/// Turns one bootnode string into a dialable address.
+///
+/// An `enr:` string is decoded, verified, and reduced to its QUIC multiaddr with the peer id
+/// appended. Anything else must parse as a multiaddr and is passed through untouched.
+///
+/// # Errors
+///
+/// A rendered reason when the entry is neither.
+pub fn parse_bootnode(entry: &str) -> Result<Multiaddr, String> {
+    let entry = entry.trim();
+    if entry.starts_with("enr:") {
+        return multiaddr_of_enr(entry);
+    }
+    Multiaddr::from_str(entry).map_err(|error| format!("not a multiaddr: {error}"))
+}
+
+fn multiaddr_of_enr(text: &str) -> Result<Multiaddr, String> {
+    let record = Record::from_str(text).map_err(|error| format!("invalid ENR: {error}"))?;
+    if !record.verify() {
+        return Err("ENR signature does not verify".to_string());
+    }
+
+    let ip = record
+        .ip4()
+        .ok_or_else(|| "ENR carries no IPv4 address".to_string())?;
+    let port = quic_port(&record)?
+        .or_else(|| record.udp4())
+        .ok_or_else(|| "ENR carries neither a quic nor a udp port".to_string())?;
+    let peer_id = peer_id_of(&record)?;
+
+    let address = format!("/ip4/{ip}/udp/{port}/quic-v1/p2p/{peer_id}");
+    Multiaddr::from_str(&address).map_err(|error| format!("cannot build multiaddr: {error}"))
+}
+
+/// The `quic` field, when present. Absent is `Ok(None)`; present but not a port is an error.
+fn quic_port(record: &Record) -> Result<Option<u16>, String> {
+    record
+        .get_decodable::<u16>(QUIC_KEY)
+        .transpose()
+        .map_err(|error| format!("ENR quic field is not a port: {error:?}"))
+}
+
+fn peer_id_of(record: &Record) -> Result<PeerId, String> {
+    use enr::EnrPublicKey as _;
+
+    let compressed = record.public_key().encode();
+    let public = identity::secp256k1::PublicKey::try_from_bytes(compressed.as_ref())
+        .map_err(|error| format!("ENR public key is not a libp2p identity: {error}"))?;
+    Ok(identity::PublicKey::from(public).to_peer_id())
+}
+
+/// Reads the node's secp256k1 secret and turns it into its libp2p identity.
+///
+/// # Errors
+///
+/// [`ConfigError::Unreadable`] when the file cannot be read and
+/// [`ConfigError::MalformedNodeKey`] when its contents are not a 32-byte secp256k1 secret.
+pub fn read_node_key(path: &Path) -> Result<Keypair, ConfigError> {
+    let text = fs::read_to_string(path).map_err(|error| ConfigError::Unreadable {
+        path: path.to_path_buf(),
+        reason: error.to_string(),
+    })?;
+    keypair_from_hex(&text).map_err(|reason| ConfigError::MalformedNodeKey {
+        path: path.to_path_buf(),
+        reason,
+    })
+}
+
+fn keypair_from_hex(text: &str) -> Result<Keypair, String> {
+    let trimmed = text.trim();
+    let trimmed = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+    let mut bytes = hex::decode(trimmed).map_err(|error| format!("not hex: {error}"))?;
+    if bytes.len() != 32 {
+        return Err(format!("expected 32 bytes, found {}", bytes.len()));
+    }
+    let secret = identity::secp256k1::SecretKey::try_from_bytes(&mut bytes)
+        .map_err(|error| format!("not a secp256k1 secret: {error}"))?;
+    Ok(Keypair::from(identity::secp256k1::Keypair::from(secret)))
+}
+
+/// Refuses a committee count the chain constants do not implement.
+///
+/// leanSpec fixes `ATTESTATION_COMMITTEE_COUNT` as a constant of the fork, and Verity
+/// transcribes it as one; the flag exists so that a lean-quickstart deployment configured for
+/// another value fails at startup, with the reason, rather than joining a network whose
+/// subnet layout it disagrees with.
+///
+/// # Errors
+///
+/// [`ConfigError::UnsupportedSetting`] when `count` is not the constant.
+pub fn check_committee_count(count: u64) -> Result<(), ConfigError> {
+    if count == ATTESTATION_COMMITTEE_COUNT {
+        return Ok(());
+    }
+    Err(ConfigError::UnsupportedSetting {
+        setting: "attestation committee count",
+        reason: format!("this build implements {ATTESTATION_COMMITTEE_COUNT}, not {count}"),
+    })
+}
+
+/// Refuses an aggregation subnet the chain constants do not define.
+///
+/// # Errors
+///
+/// [`ConfigError::UnsupportedSetting`] when any id is at or above the committee count.
+pub fn check_aggregate_subnets(subnets: &[u64]) -> Result<(), ConfigError> {
+    match subnets
+        .iter()
+        .find(|id| **id >= ATTESTATION_COMMITTEE_COUNT)
+    {
+        None => Ok(()),
+        Some(id) => Err(ConfigError::UnsupportedSetting {
+            setting: "aggregate subnet ids",
+            reason: format!(
+                "subnet {id} does not exist with {ATTESTATION_COMMITTEE_COUNT} committee(s)"
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    /// The first record of the `nodes.yaml` sample in lean-quickstart's README: 127.0.0.1,
+    /// quic 9000, signed by a secp256k1 key.
+    const README_ENR: &str = "enr:-IW4QMn2QUYENcnsEpITZLph3YZee8Y3B92INUje_riQUOFQQ5Zm5kASi7E_IuQoGCWgcmCYrH920Q52kH7tQcWcPhEBgmlkgnY0gmlwhH8AAAGEcXVpY4IjKIlzZWNwMjU2azGhAhMMnGF1rmIPQ9tWgqfkNmvsG-aIyc9EJU5JFo3Tegys";
+
+    const SECRET_HEX: &str = "bdf953adc161873ba026330c56450453f582e3c4ee6cb713644794bcfdd85fe5";
+
+    fn signing_key() -> enr::k256::ecdsa::SigningKey {
+        let bytes = hex::decode(SECRET_HEX).expect("hex");
+        enr::k256::ecdsa::SigningKey::from_slice(&bytes).expect("a secp256k1 secret")
+    }
+
+    fn write(contents: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().expect("a temporary file");
+        file.write_all(contents.as_bytes()).expect("write");
+        file.flush().expect("flush");
+        file
+    }
+
+    #[test]
+    fn should_reduce_the_readme_enr_to_its_quic_address() {
+        let address = parse_bootnode(README_ENR).expect("the README record parses");
+        let text = address.to_string();
+        assert!(
+            text.starts_with("/ip4/127.0.0.1/udp/9000/quic-v1/p2p/"),
+            "unexpected address {text}"
+        );
+    }
+
+    #[test]
+    fn should_derive_the_same_peer_id_the_node_key_produces() {
+        let key = signing_key();
+        let record = Record::builder()
+            .ip4(Ipv4Addr::LOCALHOST)
+            .add_value(QUIC_KEY, &9001u16)
+            .build(&key)
+            .expect("a signed record");
+
+        let address = parse_bootnode(&record.to_base64()).expect("parses");
+        let keypair = keypair_from_hex(SECRET_HEX).expect("the same secret");
+        let expected = format!(
+            "/ip4/127.0.0.1/udp/9001/quic-v1/p2p/{}",
+            keypair.public().to_peer_id()
+        );
+        assert_eq!(address.to_string(), expected);
+    }
+
+    #[test]
+    fn should_fall_back_to_the_udp_port_when_quic_is_absent() {
+        let record = Record::builder()
+            .ip4(Ipv4Addr::new(10, 0, 0, 7))
+            .udp4(9100)
+            .build(&signing_key())
+            .expect("a signed record");
+
+        let address = parse_bootnode(&record.to_base64()).expect("parses");
+        assert!(
+            address
+                .to_string()
+                .starts_with("/ip4/10.0.0.7/udp/9100/quic-v1/p2p/")
+        );
+    }
+
+    #[test]
+    fn should_refuse_an_enr_without_an_address() {
+        let record = Record::builder()
+            .udp4(9100)
+            .build(&signing_key())
+            .expect("a signed record");
+
+        let error = parse_bootnode(&record.to_base64()).expect_err("no ip");
+        assert!(error.contains("IPv4"), "{error}");
+    }
+
+    #[test]
+    fn should_refuse_a_tampered_enr() {
+        // Flip a character inside the signed content; the signature no longer covers it.
+        let mut tampered = README_ENR.to_string();
+        let tail = tampered.len() - 8;
+        tampered.replace_range(tail..tail + 1, "A");
+        assert!(parse_bootnode(&tampered).is_err());
+    }
+
+    #[test]
+    fn should_pass_a_bare_multiaddr_through() {
+        let address = parse_bootnode(" /ip4/10.0.0.1/udp/9000/quic-v1 ").expect("parses");
+        assert_eq!(address.to_string(), "/ip4/10.0.0.1/udp/9000/quic-v1");
+    }
+
+    #[test]
+    fn should_refuse_anything_that_is_neither() {
+        assert!(parse_bootnode("localhost:9000").is_err());
+    }
+
+    #[test]
+    fn should_read_a_nodes_yaml_list_and_name_the_bad_entry() {
+        let file = write(&format!(
+            "- {README_ENR}\n- /ip4/10.0.0.1/udp/9000/quic-v1\n"
+        ));
+        let addresses = read_bootnodes(file.path()).expect("both entries parse");
+        assert_eq!(addresses.len(), 2);
+
+        let bad = write("- not-an-address\n");
+        match read_bootnodes(bad.path()) {
+            Err(ConfigError::MalformedBootnode { entry, .. }) => {
+                assert_eq!(entry, "not-an-address");
+            }
+            other => panic!("expected MalformedBootnode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_read_a_node_key_with_or_without_a_prefix() {
+        let bare = write(&format!("{SECRET_HEX}\n"));
+        let prefixed = write(&format!("0x{SECRET_HEX}"));
+        let a = read_node_key(bare.path()).expect("bare hex loads");
+        let b = read_node_key(prefixed.path()).expect("prefixed hex loads");
+        assert_eq!(a.public().to_peer_id(), b.public().to_peer_id());
+    }
+
+    #[test]
+    fn should_refuse_a_node_key_of_the_wrong_length() {
+        let short = write("abcd");
+        match read_node_key(short.path()) {
+            Err(ConfigError::MalformedNodeKey { reason, .. }) => {
+                assert!(reason.contains("32 bytes"), "{reason}");
+            }
+            other => panic!("expected MalformedNodeKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_accept_only_the_transcribed_committee_count() {
+        assert!(check_committee_count(ATTESTATION_COMMITTEE_COUNT).is_ok());
+        assert!(check_committee_count(ATTESTATION_COMMITTEE_COUNT + 1).is_err());
+        assert!(check_aggregate_subnets(&[0]).is_ok());
+        assert!(check_aggregate_subnets(&[0, ATTESTATION_COMMITTEE_COUNT]).is_err());
+    }
+}

--- a/crates/verity-node/src/chain.rs
+++ b/crates/verity-node/src/chain.rs
@@ -24,6 +24,7 @@
 //! anything added later.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::{mpsc, watch};
 
@@ -51,6 +52,9 @@ pub struct Aggregator {
     pub prover: Prover,
     /// Where a finished round's aggregates re-enter — channel ②, like any other duty product.
     pub products: mpsc::Sender<LocalProduct>,
+    /// Whether the role is on. Shared with the admin API, which flips it at runtime; read
+    /// once per round, so a flip lands on the next interval 2 rather than mid-round.
+    pub enabled: Arc<AtomicBool>,
 }
 
 /// The task that owns `Store` and the repository, and the only thing that writes either.
@@ -218,6 +222,9 @@ impl<B: StorageBackend> ChainTask<B> {
         let Some(aggregator) = &self.aggregator else {
             return;
         };
+        if !aggregator.enabled.load(Ordering::Relaxed) {
+            return;
+        }
 
         let view = Arc::new(ChainView::of(&self.store));
         let prover = aggregator.prover.clone();

--- a/crates/verity-node/src/config.rs
+++ b/crates/verity-node/src/config.rs
@@ -18,6 +18,11 @@
 //!       proposal_public_key: 0x51c8...
 //!   ```
 //!
+//!   The generator lean-quickstart runs (`generate-genesis.sh`) writes the same two keys as
+//!   `attestation_pubkey` / `proposal_pubkey`, bare hex, and adds `ATTESTATION_COMMITTEE_COUNT`,
+//!   `VALIDATOR_COUNT` and `ACTIVE_EPOCH` beside them. One format with two live writers, so
+//!   both spellings are accepted; the extra keys are informational and ignored.
+//!
 //! - **The assignment file** (`validators.yaml`, beside the keys) maps each node's identifier
 //!   to the validator indices it runs. A node whose identifier is absent runs none, which is
 //!   a legitimate configuration — it follows the chain without signing.
@@ -64,8 +69,10 @@ pub struct GenesisFile {
 #[derive(Debug, Clone, Deserialize)]
 pub struct GenesisValidator {
     /// XMSS public key for signing attestations, hex, `0x` prefix optional.
+    #[serde(alias = "attestation_pubkey")]
     pub attestation_public_key: String,
     /// XMSS public key the proposer signs the block root with.
+    #[serde(alias = "proposal_pubkey")]
     pub proposal_public_key: String,
 }
 
@@ -204,6 +211,21 @@ mod tests {
         let validators = genesis.to_validators().expect("one validator");
 
         assert_eq!(validators[0].attestation_public_key, [0x11u8; 52]);
+    }
+
+    #[test]
+    fn should_read_the_generator_spelling_and_ignore_its_extra_keys() {
+        let file = write(&format!(
+            "GENESIS_TIME: 1763712794\nATTESTATION_COMMITTEE_COUNT: 1\nACTIVE_EPOCH: 10\nVALIDATOR_COUNT: 1\nGENESIS_VALIDATORS:\n  - attestation_pubkey: \"{}\"\n    proposal_pubkey: \"{}\"\n",
+            "11".repeat(52),
+            "22".repeat(52)
+        ));
+        let genesis = GenesisFile::read(file.path()).expect("the generator's file");
+        let validators = genesis.to_validators().expect("one validator");
+
+        assert_eq!(genesis.genesis_time, 1_763_712_794);
+        assert_eq!(validators[0].attestation_public_key, [0x11u8; 52]);
+        assert_eq!(validators[0].proposal_public_key, [0x22u8; 52]);
     }
 
     #[test]

--- a/crates/verity-node/src/error.rs
+++ b/crates/verity-node/src/error.rs
@@ -10,7 +10,9 @@ use std::path::PathBuf;
 
 use verity_chain::RejectionReason;
 use verity_db::StorageError;
+use verity_metrics::MetricsError;
 use verity_p2p::BuildError;
+use verity_rpc::BindError;
 use verity_types::Slot;
 use verity_validator::DutyError;
 
@@ -144,6 +146,13 @@ pub enum NodeError {
         /// The slot of the anchor that was fetched.
         slot: Slot,
     },
+    /// The metric registry could not be built.
+    Metrics(MetricsError),
+    /// An HTTP listener could not be bound.
+    ///
+    /// Fatal rather than skipped: a node started with `--api-port` is a node something else
+    /// will probe, and a silent absence would be diagnosed there, much later.
+    Http(BindError),
 }
 
 impl fmt::Display for NodeError {
@@ -170,7 +179,21 @@ impl fmt::Display for NodeError {
                  --checkpoint-sync-url",
                 slot.0
             ),
+            Self::Metrics(error) => write!(f, "{error}"),
+            Self::Http(error) => write!(f, "http: {error}"),
         }
+    }
+}
+
+impl From<MetricsError> for NodeError {
+    fn from(error: MetricsError) -> Self {
+        Self::Metrics(error)
+    }
+}
+
+impl From<BindError> for NodeError {
+    fn from(error: BindError) -> Self {
+        Self::Http(error)
     }
 }
 

--- a/crates/verity-node/src/error.rs
+++ b/crates/verity-node/src/error.rs
@@ -45,6 +45,29 @@ pub enum ConfigError {
         /// How many the file names.
         count: usize,
     },
+    /// A bootnode entry is neither a signed ENR nor a multiaddr.
+    MalformedBootnode {
+        /// Where the entry came from: the file, or the flag.
+        source: String,
+        /// The entry as written.
+        entry: String,
+        /// What was wrong with it.
+        reason: String,
+    },
+    /// The node key file does not hold a secp256k1 secret.
+    MalformedNodeKey {
+        /// The file that was read.
+        path: PathBuf,
+        /// What was wrong with its contents.
+        reason: String,
+    },
+    /// A setting the deployment asked for that this build does not implement.
+    UnsupportedSetting {
+        /// The setting, named for the operator.
+        setting: &'static str,
+        /// Why it is refused.
+        reason: String,
+    },
 }
 
 impl fmt::Display for ConfigError {
@@ -55,6 +78,17 @@ impl fmt::Display for ConfigError {
             }
             Self::Malformed { path, reason } => {
                 write!(f, "malformed {}: {reason}", path.display())
+            }
+            Self::MalformedBootnode {
+                source,
+                entry,
+                reason,
+            } => write!(f, "bad bootnode {entry:?} in {source}: {reason}"),
+            Self::MalformedNodeKey { path, reason } => {
+                write!(f, "node key {} is unusable: {reason}", path.display())
+            }
+            Self::UnsupportedSetting { setting, reason } => {
+                write!(f, "unsupported {setting}: {reason}")
             }
             Self::MalformedKey { index, role } => write!(
                 f,

--- a/crates/verity-node/src/lib.rs
+++ b/crates/verity-node/src/lib.rs
@@ -50,17 +50,25 @@ pub mod store_open;
 pub mod sync;
 pub mod verification;
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
 use verity_chain::{ChainView, SlotClock, generate_genesis};
 
-use verity_db::RocksBackend;
+use verity_db::{Repository, RocksBackend, StorageReader};
+use verity_metrics::Metrics;
 use verity_p2p::{NetworkConfig, PeerId, identity::Keypair};
+use verity_rpc::{
+    ApiContext, BoundListener, HttpServer, SignedBlockSource, api_router, metrics_router,
+};
 use verity_types::ValidatorIndex;
+use verity_types::config::ATTESTATION_COMMITTEE_COUNT;
 use verity_validator::{DutyService, Keyring, Prover};
 
 use crate::chain::{Aggregator, ChainTask};
@@ -145,6 +153,12 @@ pub struct NodeConfig {
     /// Present means a checkpoint start, and that path has no fallbacks: a fetch or
     /// verification failure stops the node (`docs/design/sync.md`, Decision 1).
     pub checkpoint_sync_url: Option<String>,
+    /// Where the REST API (`/lean/v0/*`) listens. Absent means it is not served.
+    pub api_address: Option<SocketAddr>,
+    /// Where the Prometheus scrape endpoint listens. Absent means it is not served.
+    pub metrics_address: Option<SocketAddr>,
+    /// The client version `lean_node_info` reports.
+    pub version: String,
 }
 
 /// A running node, and the handles that stop it.
@@ -160,6 +174,10 @@ pub struct Node {
     stage_counters: Arc<StageCounters>,
     bridge_counters: Arc<BridgeCounters>,
     sync_counters: Arc<SyncCounters>,
+    metrics: Arc<Metrics>,
+    aggregator: Arc<AtomicBool>,
+    api: Option<HttpServer>,
+    metrics_server: Option<HttpServer>,
 }
 
 impl Node {
@@ -184,6 +202,11 @@ impl Node {
         // the node without having written an anchor of any kind.
         let checkpoint = fetch_checkpoint(&config, &genesis_state).await?;
 
+        // Bound here, served later. A port already in use — the commonest misconfiguration on
+        // a shared host — stops the node before it has opened the database or spawned a task.
+        let api_listener = bind_optional(config.api_address).await?;
+        let metrics_listener = bind_optional(config.metrics_address).await?;
+
         // The store carries one validator index, which is only ever used to attribute the
         // node's own votes; the keyring below is what actually decides which duties run.
         let backend = RocksBackend::open(&config.data_directory)?;
@@ -199,6 +222,8 @@ impl Node {
         let served = Arc::new(store_open::open_reader(reader, &genesis_state)?);
 
         let keyring = load_keys(&config)?;
+        let metrics = Arc::new(Metrics::new()?);
+        record_start(&metrics, &config, &keyring);
         let prover = Prover::new();
         if !keyring.is_empty() {
             // Paid once, here, rather than by the first duty of the node's life.
@@ -214,17 +239,21 @@ impl Node {
         let (block_requests, block_request_stream) = mpsc::channel(BLOCK_REQUEST_CAPACITY);
         let (peer_events, peer_event_stream) = mpsc::channel(PEER_EVENT_CAPACITY);
 
-        let aggregator = config.is_aggregator.then(|| Aggregator {
+        // Always wired, gated by the role flag: the admin API can turn aggregation on at
+        // runtime, and a round that has nowhere to send its output cannot be added later.
+        let aggregator_role = Arc::new(AtomicBool::new(config.is_aggregator));
+        let aggregator = Aggregator {
             prover: prover.clone(),
             products: products.clone(),
-        });
+            enabled: Arc::clone(&aggregator_role),
+        };
         let (chain, view) = ChainTask::new(
             store,
             repository,
             ticks.clone(),
             local_stream,
             verified_stream,
-            aggregator,
+            Some(aggregator),
         );
 
         let (handle, events) = verity_p2p::spawn(network_config(&config))?;
@@ -247,6 +276,7 @@ impl Node {
                 handle.clone(),
                 view.clone(),
                 Arc::clone(&bridge_counters),
+                Arc::clone(&metrics),
             )
             .run(),
         );
@@ -265,6 +295,7 @@ impl Node {
         // Order matters only in one place: the chain task is spawned last so that every
         // sender into it already exists, and it therefore never sees an empty inbox that
         // looks like shutdown.
+        let signed_block = signed_block_source(Arc::clone(&served));
         let draining = vec![
             tokio::spawn(DutyService::new(keyring, prover, products, view.clone(), ticks).run()),
             tokio::spawn(ProductRelay::new(product_stream, local, handle.clone()).run()),
@@ -293,6 +324,17 @@ impl Node {
             tokio::spawn(chain.run()),
         ];
 
+        let context = Arc::new(ApiContext {
+            view: view.clone(),
+            synced: synced.clone(),
+            signed_block,
+            aggregator: Arc::clone(&aggregator_role),
+            metrics: Arc::clone(&metrics),
+        });
+        let api = api_listener.map(|listener| listener.serve(api_router(Arc::clone(&context))));
+        let metrics_server =
+            metrics_listener.map(|listener| listener.serve(metrics_router(context)));
+
         tracing::info!(%peer_id, "node started");
 
         Ok(Self {
@@ -307,7 +349,35 @@ impl Node {
             stage_counters,
             bridge_counters,
             sync_counters,
+            metrics,
+            aggregator: aggregator_role,
+            api,
+            metrics_server,
         })
+    }
+
+    /// Where the REST API is listening, when it is served.
+    #[must_use]
+    pub fn api_address(&self) -> Option<SocketAddr> {
+        self.api.as_ref().map(HttpServer::local_addr)
+    }
+
+    /// Where the scrape endpoint is listening, when it is served.
+    #[must_use]
+    pub fn metrics_address(&self) -> Option<SocketAddr> {
+        self.metrics_server.as_ref().map(HttpServer::local_addr)
+    }
+
+    /// The process's metric registry.
+    #[must_use]
+    pub fn metrics(&self) -> &Metrics {
+        &self.metrics
+    }
+
+    /// Whether the aggregation round is on right now.
+    #[must_use]
+    pub fn is_aggregator(&self) -> bool {
+        self.aggregator.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// The snapshot channel every reader answers from.
@@ -376,6 +446,14 @@ impl Node {
     /// Everything else drains: the duty loop's products are followed all the way into the
     /// store, and the chain task persists what it was given before it exits.
     pub async fn shutdown(mut self) {
+        // The HTTP surface first: nothing it serves should be read from a node that is
+        // stopping, and its shutdown lets an in-flight response finish.
+        if let Some(server) = self.api.take() {
+            server.shutdown().await;
+        }
+        if let Some(server) = self.metrics_server.take() {
+            server.shutdown().await;
+        }
         self.ticker.abort();
         self.bridge.abort();
         // The last handle: dropping it closes the swarm's command channel, which is how the
@@ -414,6 +492,56 @@ fn load_keys(config: &NodeConfig) -> Result<Keyring, NodeError> {
         }
         _ => Ok(Keyring::empty()),
     }
+}
+
+/// Binds an HTTP listener when an address was configured.
+async fn bind_optional(address: Option<SocketAddr>) -> Result<Option<BoundListener>, NodeError> {
+    match address {
+        Some(address) => Ok(Some(verity_rpc::bind(address).await?)),
+        None => Ok(None),
+    }
+}
+
+/// Records the "on node start" metrics: identity, start time, and the static facts.
+fn record_start(metrics: &Metrics, config: &NodeConfig, keyring: &Keyring) {
+    let start_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |elapsed| gauge_value(elapsed.as_secs()));
+    metrics.record_start("verity", &config.version, start_time);
+    metrics
+        .validators_count
+        .set(gauge_value(keyring.validators().count() as u64));
+    metrics.is_aggregator.set(i64::from(config.is_aggregator));
+    metrics
+        .attestation_committee_subnet
+        .set(gauge_value(ATTESTATION_SUBNET.0));
+    metrics
+        .attestation_committee_count
+        .set(gauge_value(ATTESTATION_COMMITTEE_COUNT));
+}
+
+/// A count as a gauge value; nothing counted here approaches `i64::MAX`.
+fn gauge_value(count: u64) -> i64 {
+    i64::try_from(count).unwrap_or(i64::MAX)
+}
+
+/// The finalized-block read the HTTP API performs, over the responder's database handle.
+///
+/// A storage error is reported as "not available" and logged: the route cannot repair the
+/// database, and the responder's next range read will surface the same damage as a
+/// `SERVER_ERROR` where it matters.
+fn signed_block_source<B: StorageReader + Send + Sync + 'static>(
+    repository: Arc<Repository<B>>,
+) -> SignedBlockSource {
+    Arc::new(
+        move |root| match sync::responder::signed_block(&repository, root) {
+            Ok(block) => block,
+            Err(error) => {
+                tracing::warn!(%error, "cannot read the finalized block for the API");
+                None
+            }
+        },
+    )
 }
 
 /// The network service's configuration, derived from the node's.

--- a/crates/verity-node/src/lib.rs
+++ b/crates/verity-node/src/lib.rs
@@ -40,6 +40,7 @@
 //! inputs run out. Duty products are drained to the end: they are the one thing in the
 //! pipeline no peer can give back.
 
+pub mod bootstrap;
 pub mod chain;
 pub mod clock;
 pub mod config;
@@ -72,12 +73,18 @@ use crate::sync::responder::BlockResponder;
 use crate::sync::{SyncCounters, SyncService};
 use crate::verification::{StageCounters, VerificationStage};
 
+pub use bootstrap::{
+    check_aggregate_subnets, check_committee_count, parse_bootnode, read_bootnodes, read_node_key,
+};
 pub use config::{ASSIGNMENT_FILE_NAME, GenesisFile, assigned_validators};
 pub use error::ConfigError;
 
 // Re-exported so the binary can name addresses and identities without a second dependency on
 // the networking crate; the libp2p version is pinned once, in the workspace manifest.
 pub use verity_p2p::{Multiaddr, identity};
+// Re-exported for the same reason: the binary defaults its topic segment to the fork's digest
+// and does not otherwise depend on the types crate.
+pub use verity_types::config::GOSSIP_DIGEST;
 
 /// Capacity of the duty-product channel (②).
 ///

--- a/crates/verity-node/src/network.rs
+++ b/crates/verity-node/src/network.rs
@@ -16,6 +16,7 @@ use libssz::SszEncode;
 use tokio::sync::{mpsc, watch};
 
 use verity_chain::ChainView;
+use verity_metrics::{Metrics, prometheus_gauge};
 use verity_p2p::{ErrorCode, GossipKind, NetworkEvent, NetworkHandle, Request, Response, Status};
 use verity_types::SubnetId;
 use verity_validator::LocalProduct;
@@ -28,6 +29,9 @@ use crate::verification::GossipPayload;
 /// leanSpec fixes `ATTESTATION_COMMITTEE_COUNT = 1`, so there is exactly one attestation
 /// subnet and every validator uses it. This becomes a computation the day that constant moves.
 pub const ATTESTATION_SUBNET: SubnetId = SubnetId(0);
+
+/// The `client` label of `lean_connected_peers` for a peer whose client is not announced.
+const PEER_CLIENT_UNKNOWN: &str = "unknown";
 
 /// Gossip the bridge could not hand downstream.
 #[derive(Debug, Default)]
@@ -70,6 +74,7 @@ pub struct NetworkBridge {
     handle: NetworkHandle,
     view: watch::Receiver<Arc<ChainView>>,
     counters: Arc<BridgeCounters>,
+    metrics: Arc<Metrics>,
 }
 
 impl NetworkBridge {
@@ -81,6 +86,7 @@ impl NetworkBridge {
         handle: NetworkHandle,
         view: watch::Receiver<Arc<ChainView>>,
         counters: Arc<BridgeCounters>,
+        metrics: Arc<Metrics>,
     ) -> Self {
         Self {
             events,
@@ -91,7 +97,16 @@ impl NetworkBridge {
             handle,
             view,
             counters,
+            metrics,
         }
+    }
+
+    /// `lean_connected_peers`. leanMetrics labels the gauge by the peer's client, which the
+    /// lean transport does not announce, so every peer is `unknown`.
+    fn connected_peers(&self) -> prometheus_gauge::IntGauge {
+        self.metrics
+            .connected_peers
+            .with_label_values(&[PEER_CLIENT_UNKNOWN])
     }
 
     /// Runs until the network task stops.
@@ -119,12 +134,14 @@ impl NetworkBridge {
                 }
                 NetworkEvent::PeerConnected(peer) => {
                     tracing::info!(%peer, "peer connected");
+                    self.connected_peers().inc();
                     if self.peers.send(PeerEvent::Connected(peer)).await.is_err() {
                         break;
                     }
                 }
                 NetworkEvent::PeerDisconnected(peer) => {
                     tracing::info!(%peer, "peer disconnected");
+                    self.connected_peers().dec();
                     if self
                         .peers
                         .send(PeerEvent::Disconnected(peer))

--- a/crates/verity-node/src/sync/responder.rs
+++ b/crates/verity-node/src/sync/responder.rs
@@ -227,6 +227,25 @@ fn stored_signed_block<B: StorageReader>(
     }))
 }
 
+/// One stored block with its proof, for the HTTP API's finalized-block route.
+///
+/// The same read the range responder does per block, keyed by root alone: the header is
+/// looked up first to learn the slot the proof is filed under. `None` means the root is not
+/// stored, or names the anchor — which was adopted from configuration and has no proof.
+///
+/// # Errors
+///
+/// [`StorageError`] when a block above the anchor is missing a part, which is damage.
+pub fn signed_block<B: StorageReader>(
+    repository: &Repository<B>,
+    root: Bytes32,
+) -> Result<Option<SignedBlock>, StorageError> {
+    let Some(header) = repository.block_header(root)? else {
+        return Ok(None);
+    };
+    stored_signed_block(repository, header.slot, root, anchor_slot(repository)?)
+}
+
 /// The first slot this node holds proof-bearing history for.
 fn anchor_slot<B: StorageReader>(repository: &Repository<B>) -> Result<Slot, StorageError> {
     Ok(repository.served_from_slot()?.unwrap_or(Slot(0)))

--- a/crates/verity-node/tests/catch_up.rs
+++ b/crates/verity-node/tests/catch_up.rs
@@ -95,6 +95,9 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
         // nothing to do with what this test claims. `single_node.rs` covers that path.
         is_aggregator: false,
         checkpoint_sync_url: None,
+        api_address: None,
+        metrics_address: None,
+        version: String::new(),
     })
     .await
     .expect("the producer starts");
@@ -151,6 +154,9 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
         key_directory: None,
         is_aggregator: false,
         checkpoint_sync_url: None,
+        api_address: None,
+        metrics_address: None,
+        version: String::new(),
     })
     .await
     .expect("the server starts on the producer's database");
@@ -175,6 +181,9 @@ async fn should_catch_up_to_a_running_node_when_started_after_it() {
         key_directory: None,
         is_aggregator: false,
         checkpoint_sync_url: None,
+        api_address: None,
+        metrics_address: None,
+        version: String::new(),
     })
     .await
     .expect("the follower starts");

--- a/crates/verity-node/tests/http_api.rs
+++ b/crates/verity-node/tests/http_api.rs
@@ -1,0 +1,240 @@
+//! The HTTP surface, driven over real sockets the way its consumers drive it: leanpoint's
+//! health probe, Prometheus' scrape, and a peer's checkpoint fetch.
+//!
+//! A follower node at genesis is enough: every route answers from the snapshot, and the
+//! snapshot at genesis is fully known — one block, one state, both checkpoints on it. No keys
+//! are needed, so this runs in the fast gate.
+
+mod common;
+
+use std::net::SocketAddr;
+
+use libssz::SszDecode;
+use verity_node::{GenesisFile, Node, NodeConfig, identity::Keypair};
+use verity_types::State;
+
+/// A genesis file with one validator whose keys are never used: this node follows.
+fn genesis_file(root: &std::path::Path) -> std::path::PathBuf {
+    let path = root.join("config.yaml");
+    std::fs::write(
+        &path,
+        format!(
+            "GENESIS_TIME: {}\nGENESIS_VALIDATORS:\n  - attestation_pubkey: \"{}\"\n    proposal_pubkey: \"{}\"\n",
+            common::now_seconds(),
+            "11".repeat(52),
+            "22".repeat(52)
+        ),
+    )
+    .expect("the genesis file");
+    path
+}
+
+async fn start_follower(root: &std::path::Path) -> Node {
+    Node::start(NodeConfig {
+        genesis: GenesisFile::read(&genesis_file(root)).expect("the genesis file"),
+        data_directory: root.join("db"),
+        listen: "/ip4/127.0.0.1/udp/0/quic-v1"
+            .parse()
+            .expect("a listen address"),
+        bootnodes: Vec::new(),
+        network_name: "12345678".to_string(),
+        keypair: Keypair::generate_secp256k1(),
+        validator_indices: Vec::new(),
+        key_directory: None,
+        is_aggregator: false,
+        checkpoint_sync_url: None,
+        api_address: Some(loopback()),
+        metrics_address: Some(loopback()),
+        version: "test".to_string(),
+    })
+    .await
+    .expect("the node starts")
+}
+
+/// reqwest is built with `rustls-no-provider`, so a client cannot be built until a provider
+/// is installed — the node does this itself before a checkpoint fetch, and a test that never
+/// fetches one has to do it here.
+fn http_client() -> reqwest::Client {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    reqwest::Client::new()
+}
+
+fn loopback() -> SocketAddr {
+    "127.0.0.1:0".parse().expect("a socket address")
+}
+
+fn url(address: SocketAddr, path: &str) -> String {
+    format!("http://{address}{path}")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_answer_every_cross_client_route_from_the_genesis_snapshot() {
+    common::init_logging();
+    let root = tempfile::tempdir().expect("a temporary directory");
+    let node = start_follower(root.path()).await;
+    let api = node.api_address().expect("the API is served");
+    let client = http_client();
+    let view = node.view().borrow().clone();
+
+    // Health, on both spellings.
+    for path in ["/lean/v0/health", "/v0/health"] {
+        let response = client.get(url(api, path)).send().await.expect("health");
+        assert_eq!(response.status(), 200, "{path}");
+        assert_eq!(
+            response.headers()["content-type"],
+            "application/json",
+            "{path}"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(&response.text().await.expect("text")).expect("json");
+        assert_eq!(body["status"], "healthy");
+        assert_eq!(body["service"], "lean-rpc-api");
+    }
+
+    // The justified checkpoint is the genesis anchor.
+    let anchor = view.latest_finalized();
+    let body = client
+        .get(url(api, "/lean/v0/checkpoints/justified"))
+        .send()
+        .await
+        .expect("justified")
+        .text()
+        .await
+        .expect("text");
+    let body: serde_json::Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(body["slot"], 0);
+    assert_eq!(body["root"], format!("0x{}", common::hex(&anchor.root)));
+
+    // The fork-choice tree is the anchor alone.
+    let body = client
+        .get(url(api, "/lean/v0/fork_choice"))
+        .send()
+        .await
+        .expect("fork choice")
+        .text()
+        .await
+        .expect("text");
+    let body: serde_json::Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(body["nodes"].as_array().map(Vec::len), Some(1));
+    assert_eq!(body["nodes"][0]["slot"], 0);
+    assert_eq!(body["nodes"][0]["weight"], 0);
+    assert_eq!(body["head"], body["nodes"][0]["root"]);
+    assert_eq!(body["validator_count"], 1);
+    assert_eq!(body["finalized"]["slot"], 0);
+
+    // The finalized state is the genesis state, byte for byte.
+    let response = client
+        .get(url(api, "/lean/v0/states/finalized"))
+        .send()
+        .await
+        .expect("state");
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.headers()["content-type"],
+        "application/octet-stream"
+    );
+    let state = State::from_ssz_bytes(&response.bytes().await.expect("bytes")).expect("a state");
+    assert_eq!(Some(&state), view.state(anchor.root));
+
+    // The anchor was adopted from configuration and carries no proof, so there is no signed
+    // block to serve — which leanSpec reports as 404, not as an empty proof.
+    let response = client
+        .get(url(api, "/lean/v0/blocks/finalized"))
+        .send()
+        .await
+        .expect("block");
+    assert_eq!(response.status(), 404);
+
+    node.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_expose_the_lean_metrics_on_both_ports() {
+    common::init_logging();
+    let root = tempfile::tempdir().expect("a temporary directory");
+    let node = start_follower(root.path()).await;
+    let client = http_client();
+
+    for address in [
+        node.api_address().expect("api"),
+        node.metrics_address().expect("metrics"),
+    ] {
+        let response = client
+            .get(url(address, "/metrics"))
+            .send()
+            .await
+            .expect("scrape");
+        assert_eq!(response.status(), 200);
+        assert!(
+            response.headers()["content-type"]
+                .to_str()
+                .expect("ascii")
+                .starts_with("text/plain; version=0.0.4")
+        );
+        let text = response.text().await.expect("text");
+        for line in [
+            "lean_node_info{name=\"verity\",version=\"test\"} 1",
+            "lean_head_slot 0",
+            "lean_latest_finalized_slot 0",
+            "lean_validators_count 0",
+            "lean_is_aggregator 0",
+            "lean_attestation_committee_count 1",
+            "lean_node_sync_status{status=\"syncing\"} 1",
+            "lean_current_slot",
+        ] {
+            assert!(
+                text.contains(line),
+                "missing `{line}` on {address}:\n{text}"
+            );
+        }
+    }
+
+    node.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_toggle_the_aggregator_role_through_the_admin_route() {
+    common::init_logging();
+    let root = tempfile::tempdir().expect("a temporary directory");
+    let node = start_follower(root.path()).await;
+    let api = node.api_address().expect("api");
+    let client = http_client();
+    let admin = url(api, "/lean/v0/admin/aggregator");
+
+    let body = client
+        .get(&admin)
+        .send()
+        .await
+        .expect("status")
+        .text()
+        .await
+        .expect("text");
+    let body: serde_json::Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(body["is_aggregator"], false);
+
+    let body = client
+        .post(&admin)
+        .body("{\"enabled\": true}")
+        .send()
+        .await
+        .expect("toggle")
+        .text()
+        .await
+        .expect("text");
+    let body: serde_json::Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(body["is_aggregator"], true);
+    assert_eq!(body["previous"], false);
+    assert!(
+        node.is_aggregator(),
+        "the chain task's flag follows the route"
+    );
+
+    // Integers are not booleans, and neither is a missing field or a broken body.
+    for body in ["{\"enabled\": 1}", "{}", "not json"] {
+        let response = client.post(&admin).body(body).send().await.expect("post");
+        assert_eq!(response.status(), 400, "{body}");
+    }
+    assert!(node.is_aggregator(), "a refused request changes nothing");
+
+    node.shutdown().await;
+}

--- a/crates/verity-node/tests/single_node.rs
+++ b/crates/verity-node/tests/single_node.rs
@@ -70,6 +70,9 @@ async fn should_advance_the_head_past_genesis_when_a_node_runs_its_own_validator
         key_directory: Some(key_base.join("hash-sig-keys")),
         is_aggregator: true,
         checkpoint_sync_url: None,
+        api_address: None,
+        metrics_address: None,
+        version: String::new(),
     })
     .await
     .expect("the node starts");

--- a/crates/verity-rpc/Cargo.toml
+++ b/crates/verity-rpc/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "verity-rpc"
+description = "The HTTP surface: the cross-client REST API under /lean/v0 and the Prometheus scrape endpoint."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+
+# An I/O Edge crate. It answers from the chain view like every other reader, encodes with the
+# same SSZ the wire uses, and never reaches past the snapshot into the chain task.
+[dependencies]
+axum.workspace = true
+hex.workspace = true
+libssz.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+verity-chain.workspace = true
+verity-metrics.workspace = true
+verity-types.workspace = true
+
+# The tests drive a bound server over real HTTP, as leanpoint and a checkpoint-syncing peer
+# would, rather than calling handlers in-process.
+[dev-dependencies]
+reqwest.workspace = true
+verity-db.workspace = true
+
+[lints]
+workspace = true

--- a/crates/verity-rpc/src/json.rs
+++ b/crates/verity-rpc/src/json.rs
@@ -1,0 +1,127 @@
+//! The JSON bodies of the REST API, keyed exactly as leanSpec's `responses.py` keys them.
+//!
+//! Field names are snake_case and never aliased; roots are `0x`-prefixed lowercase hex,
+//! slots and indices are plain integers, and an absent count is `null` rather than zero —
+//! zero would read as "no validators" where the truth is "no state to count them in".
+
+use serde::Serialize;
+use verity_types::{Bytes32, Checkpoint};
+
+/// A 32-byte root on the wire: `0x` followed by 64 lowercase hex digits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Hex32(pub Bytes32);
+
+impl Serialize for Hex32 {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&format!("0x{}", hex::encode(self.0)))
+    }
+}
+
+/// `GET /lean/v0/health`.
+#[derive(Debug, Serialize)]
+pub struct HealthBody {
+    /// Always `healthy`: the process answered.
+    pub status: &'static str,
+    /// The service identifier leanSpec fixes.
+    pub service: &'static str,
+}
+
+/// A checkpoint on the wire: its slot and block root.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct CheckpointBody {
+    /// The checkpoint's slot.
+    pub slot: u64,
+    /// The checkpoint's block root.
+    pub root: Hex32,
+}
+
+impl From<Checkpoint> for CheckpointBody {
+    fn from(checkpoint: Checkpoint) -> Self {
+        Self {
+            slot: checkpoint.slot.0,
+            root: Hex32(checkpoint.root),
+        }
+    }
+}
+
+/// One block in the fork-choice tree.
+#[derive(Debug, Serialize)]
+pub struct ForkChoiceNode {
+    /// The block's root.
+    pub root: Hex32,
+    /// The block's slot.
+    pub slot: u64,
+    /// The parent's root.
+    pub parent_root: Hex32,
+    /// Who proposed it.
+    pub proposer_index: u64,
+    /// The stake of the latest votes at or below it.
+    pub weight: u64,
+}
+
+/// `GET /lean/v0/fork_choice`: a snapshot of the tree from the finalized slot up.
+#[derive(Debug, Serialize)]
+pub struct ForkChoiceBody {
+    /// Every block at or above the finalized slot.
+    pub nodes: Vec<ForkChoiceNode>,
+    /// The head root.
+    pub head: Hex32,
+    /// The latest justified checkpoint.
+    pub justified: CheckpointBody,
+    /// The latest finalized checkpoint.
+    pub finalized: CheckpointBody,
+    /// The safe target root.
+    pub safe_target: Hex32,
+    /// The head state's registry size, or `null` when the head state is not in view.
+    pub validator_count: Option<usize>,
+}
+
+/// `GET /lean/v0/admin/aggregator`.
+#[derive(Debug, Serialize)]
+pub struct AggregatorStatusBody {
+    /// Whether the node runs the aggregation round.
+    pub is_aggregator: bool,
+}
+
+/// `POST /lean/v0/admin/aggregator`: the new role and the one it replaced.
+#[derive(Debug, Serialize)]
+pub struct AggregatorToggleBody {
+    /// The role now in effect.
+    pub is_aggregator: bool,
+    /// The role before this request.
+    pub previous: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use verity_types::Slot;
+
+    use super::*;
+
+    #[test]
+    fn should_render_roots_as_prefixed_lowercase_hex() {
+        let body = CheckpointBody::from(Checkpoint {
+            root: [0xab; 32],
+            slot: Slot(7),
+        });
+        let text = serde_json::to_string(&body).expect("serializes");
+        assert_eq!(
+            text,
+            "{\"slot\":7,\"root\":\"0xabababababababababababababababababababababababababababababababab\"}"
+        );
+    }
+
+    #[test]
+    fn should_render_an_absent_validator_count_as_null() {
+        let body = ForkChoiceBody {
+            nodes: Vec::new(),
+            head: Hex32([0; 32]),
+            justified: CheckpointBody::from(Checkpoint::default()),
+            finalized: CheckpointBody::from(Checkpoint::default()),
+            safe_target: Hex32([0; 32]),
+            validator_count: None,
+        };
+        let text = serde_json::to_string(&body).expect("serializes");
+        assert!(text.ends_with("\"validator_count\":null}"), "{text}");
+    }
+}

--- a/crates/verity-rpc/src/lib.rs
+++ b/crates/verity-rpc/src/lib.rs
@@ -1,0 +1,193 @@
+//! The node's HTTP surface: the cross-client REST API and the Prometheus scrape endpoint.
+//!
+//! Transcribed from leanSpec `src/lean_spec/node/api/{server,handlers,responses,context}.py`
+//! at commit `0b7d33ec`. The routes, the JSON field names and the response media types are
+//! the wire contract every lean client shares; a checkpoint-syncing peer fetches
+//! `/lean/v0/states/finalized` from any of them, and leanpoint probes any of them for health.
+//!
+//! # What the handlers read
+//!
+//! Every answer comes from the [`ChainView`] current when the request arrives — the same
+//! snapshot channel validator duties and the verification stage answer from
+//! (`docs/design/concurrency.md`). There is no query into the chain task and nothing here
+//! can block it. The one thing the view does not hold, the finalized block's proof, comes
+//! from a [`SignedBlockSource`] the node wires from its read-only database handle.
+//!
+//! # Two listeners, one router shape
+//!
+//! lean-quickstart gives every node an API port and a metrics port. [`api_router`] serves
+//! both the REST API and `/metrics`, as leanSpec's single server does; [`metrics_router`]
+//! serves `/metrics` and the health probe alone, for the port Prometheus is pointed at.
+//!
+//! # Bind first, serve later
+//!
+//! [`bind`] takes the port and [`BoundListener::serve`] starts answering on it, as two steps:
+//! a node binds before it opens its database so that a port in use fails it with nothing
+//! started, and serves once the snapshot channel the handlers read from exists.
+//!
+//! # The admin route is unauthenticated
+//!
+//! As in leanSpec: `/lean/v0/admin/aggregator` toggles the aggregator role at runtime and
+//! trusts whoever can reach the port. A deployment restricts it at the network layer.
+
+use std::fmt;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use axum::Router;
+use tokio::net::TcpListener;
+use tokio::sync::{oneshot, watch};
+use tokio::task::JoinHandle;
+
+use verity_chain::ChainView;
+use verity_metrics::Metrics;
+use verity_types::{Bytes32, SignedBlock};
+
+pub mod json;
+mod routes;
+mod sample;
+
+pub use routes::{api_router, metrics_router};
+
+/// Resolves a block root to its signed block, proof included, or to nothing.
+///
+/// The view holds blocks without their proofs — a proof is verified once and stored, never
+/// read again on the consensus path — so serving a finalized `SignedBlock` is a database
+/// read the node wires in. Returning `None` means "not available", which the route reports
+/// as 404 exactly as leanSpec does for a root its source cannot produce.
+pub type SignedBlockSource = Arc<dyn Fn(Bytes32) -> Option<SignedBlock> + Send + Sync>;
+
+/// What the handlers need, resolved once when the node wires the server.
+pub struct ApiContext {
+    /// The snapshot channel every reader answers from.
+    pub view: watch::Receiver<Arc<ChainView>>,
+    /// Whether the node considers itself caught up.
+    pub synced: watch::Receiver<bool>,
+    /// Where a finalized block's proof comes from.
+    pub signed_block: SignedBlockSource,
+    /// The aggregator role, shared with the chain task so the admin route can flip it.
+    pub aggregator: Arc<AtomicBool>,
+    /// The process's metric registry.
+    pub metrics: Arc<Metrics>,
+}
+
+/// A listener that could not be bound.
+#[derive(Debug)]
+pub struct BindError {
+    /// The address that was requested.
+    pub address: SocketAddr,
+    /// The operating system's reason, rendered.
+    pub reason: String,
+}
+
+impl fmt::Display for BindError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "cannot bind {}: {}", self.address, self.reason)
+    }
+}
+
+impl std::error::Error for BindError {}
+
+/// A bound listener that is not serving yet.
+#[derive(Debug)]
+pub struct BoundListener {
+    listener: TcpListener,
+    local_addr: SocketAddr,
+}
+
+impl BoundListener {
+    /// The address the listener actually bound. With port 0 requested, this is where the
+    /// chosen port appears.
+    #[must_use]
+    pub const fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Starts serving `router` on this listener, until [`HttpServer::shutdown`].
+    #[must_use = "the server stops when its handle is dropped"]
+    pub fn serve(self, router: Router) -> HttpServer {
+        let local_addr = self.local_addr;
+        let (stop, stopped) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let served = axum::serve(self.listener, router)
+                .with_graceful_shutdown(async move {
+                    let _ = stopped.await;
+                })
+                .await;
+            if let Err(error) = served {
+                tracing::error!(%local_addr, %error, "http server stopped with an error");
+            }
+        });
+        tracing::info!(%local_addr, "http server listening");
+
+        HttpServer {
+            local_addr,
+            stop: Some(stop),
+            task,
+        }
+    }
+}
+
+/// A running HTTP server, and the handle that stops it.
+pub struct HttpServer {
+    local_addr: SocketAddr,
+    stop: Option<oneshot::Sender<()>>,
+    task: JoinHandle<()>,
+}
+
+impl HttpServer {
+    /// The address the server is listening on.
+    #[must_use]
+    pub const fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Stops accepting, lets in-flight requests finish, and waits for the task to end.
+    pub async fn shutdown(mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+        let _ = (&mut self.task).await;
+    }
+}
+
+impl Drop for HttpServer {
+    fn drop(&mut self) {
+        // A server dropped without `shutdown` must not keep serving from a task nobody
+        // holds; aborting is the only handle left at that point.
+        self.task.abort();
+    }
+}
+
+/// Binds `address` without serving anything on it yet.
+///
+/// # Errors
+///
+/// [`BindError`] when the listener cannot be bound — the port is taken, or the address is
+/// not local. Nothing is spawned on failure.
+pub async fn bind(address: SocketAddr) -> Result<BoundListener, BindError> {
+    let listener = TcpListener::bind(address)
+        .await
+        .map_err(|error| BindError {
+            address,
+            reason: error.to_string(),
+        })?;
+    let local_addr = listener.local_addr().map_err(|error| BindError {
+        address,
+        reason: error.to_string(),
+    })?;
+    Ok(BoundListener {
+        listener,
+        local_addr,
+    })
+}
+
+/// Binds `address` and serves `router` on it: [`bind`] and [`BoundListener::serve`] in one.
+///
+/// # Errors
+///
+/// [`BindError`] as for [`bind`].
+pub async fn serve(address: SocketAddr, router: Router) -> Result<HttpServer, BindError> {
+    Ok(bind(address).await?.serve(router))
+}

--- a/crates/verity-rpc/src/routes.rs
+++ b/crates/verity-rpc/src/routes.rs
@@ -1,0 +1,194 @@
+//! The routes, and the handler behind each.
+//!
+//! Every handler takes the shared [`ApiContext`], reads the view current at that moment,
+//! and answers. The two SSZ routes encode a full state or block, which is CPU-heavy; leanSpec
+//! moves that off its event loop, and so does this — onto the blocking pool, holding only a
+//! clone of the snapshot's `Arc`.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use axum::Router;
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Json, Response};
+use axum::routing::get;
+use libssz::SszEncode;
+use serde::Serialize;
+use verity_metrics::TEXT_CONTENT_TYPE;
+
+use crate::ApiContext;
+use crate::json::{
+    AggregatorStatusBody, AggregatorToggleBody, CheckpointBody, ForkChoiceBody, ForkChoiceNode,
+    HealthBody, Hex32,
+};
+use crate::sample::on_scrape;
+
+type Shared = Arc<ApiContext>;
+
+/// The status leanSpec's health probe always reports.
+const STATUS_HEALTHY: &str = "healthy";
+/// The service identifier leanSpec's health probe always reports.
+const SERVICE_NAME: &str = "lean-rpc-api";
+/// The media type of the SSZ routes.
+const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
+
+/// The REST API and the scrape endpoint together, for the API port.
+///
+/// `/v0/health` is served beside `/lean/v0/health` because leanpoint, as lean-quickstart
+/// configures it (`convert-validator-config.py`), probes the shorter path.
+pub fn api_router(context: Shared) -> Router {
+    Router::new()
+        .route("/lean/v0/health", get(health))
+        .route("/v0/health", get(health))
+        .route("/lean/v0/states/finalized", get(finalized_state))
+        .route("/lean/v0/blocks/finalized", get(finalized_block))
+        .route("/lean/v0/checkpoints/justified", get(justified_checkpoint))
+        .route("/lean/v0/fork_choice", get(fork_choice))
+        .route("/metrics", get(metrics))
+        .route(
+            "/lean/v0/admin/aggregator",
+            get(aggregator_status).post(aggregator_toggle),
+        )
+        .with_state(context)
+}
+
+/// The scrape endpoint and the health probe alone, for the metrics port.
+pub fn metrics_router(context: Shared) -> Router {
+    Router::new()
+        .route("/metrics", get(metrics))
+        .route("/lean/v0/health", get(health))
+        .with_state(context)
+}
+
+async fn health() -> Response {
+    json(HealthBody {
+        status: STATUS_HEALTHY,
+        service: SERVICE_NAME,
+    })
+}
+
+async fn metrics(State(context): State<Shared>) -> Response {
+    on_scrape(&context);
+    let mut response = context.metrics.render().into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(TEXT_CONTENT_TYPE),
+    );
+    response
+}
+
+async fn justified_checkpoint(State(context): State<Shared>) -> Response {
+    let view = context.view.borrow().clone();
+    json(CheckpointBody::from(view.latest_justified()))
+}
+
+async fn fork_choice(State(context): State<Shared>) -> Response {
+    let view = context.view.borrow().clone();
+    let finalized = view.latest_finalized();
+    let weights = view.block_weights();
+
+    let nodes = view
+        .blocks()
+        .filter(|(_, block)| block.slot.0 >= finalized.slot.0)
+        .map(|(root, block)| ForkChoiceNode {
+            root: Hex32(*root),
+            slot: block.slot.0,
+            parent_root: Hex32(block.parent_root),
+            proposer_index: block.proposer_index.0,
+            weight: weights.get(root).copied().unwrap_or(0),
+        })
+        .collect();
+
+    json(ForkChoiceBody {
+        nodes,
+        head: Hex32(view.head()),
+        justified: CheckpointBody::from(view.latest_justified()),
+        finalized: CheckpointBody::from(finalized),
+        safe_target: Hex32(view.safe_target()),
+        validator_count: view.head_state().map(|state| state.validators.len()),
+    })
+}
+
+async fn finalized_state(State(context): State<Shared>) -> Response {
+    let view = context.view.borrow().clone();
+    let encoded = tokio::task::spawn_blocking(move || {
+        let root = view.latest_finalized().root;
+        view.state(root).map(SszEncode::to_ssz)
+    })
+    .await;
+
+    match encoded {
+        Ok(Some(bytes)) => ssz(bytes),
+        Ok(None) => problem(StatusCode::NOT_FOUND, "Finalized state not available"),
+        Err(_) => problem(StatusCode::INTERNAL_SERVER_ERROR, "Encoding failed"),
+    }
+}
+
+async fn finalized_block(State(context): State<Shared>) -> Response {
+    let root = context.view.borrow().latest_finalized().root;
+    let source = Arc::clone(&context.signed_block);
+    let encoded =
+        tokio::task::spawn_blocking(move || source(root).map(|block| block.to_ssz())).await;
+
+    match encoded {
+        Ok(Some(bytes)) => ssz(bytes),
+        Ok(None) => problem(
+            StatusCode::NOT_FOUND,
+            "Finalized signed block not available",
+        ),
+        Err(_) => problem(StatusCode::INTERNAL_SERVER_ERROR, "Encoding failed"),
+    }
+}
+
+async fn aggregator_status(State(context): State<Shared>) -> Response {
+    json(AggregatorStatusBody {
+        is_aggregator: context.aggregator.load(Ordering::Relaxed),
+    })
+}
+
+/// Sets the role from `{"enabled": <bool>}` and reports the value it replaced.
+///
+/// The body is parsed by hand so that `0` and `1`, which a lenient decoder would accept as
+/// booleans, are refused as leanSpec refuses them.
+async fn aggregator_toggle(State(context): State<Shared>, body: Bytes) -> Response {
+    let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return problem(StatusCode::BAD_REQUEST, "Invalid JSON body");
+    };
+    let Some(enabled) = request.get("enabled") else {
+        return problem(StatusCode::BAD_REQUEST, "Missing 'enabled' field in body");
+    };
+    let Some(enabled) = enabled.as_bool() else {
+        return problem(StatusCode::BAD_REQUEST, "'enabled' must be a boolean");
+    };
+
+    let previous = context.aggregator.swap(enabled, Ordering::Relaxed);
+    if previous != enabled {
+        tracing::info!(
+            "aggregator role {} via admin API",
+            if enabled { "activated" } else { "deactivated" }
+        );
+    }
+    json(AggregatorToggleBody {
+        is_aggregator: enabled,
+        previous,
+    })
+}
+
+fn json<T: Serialize>(body: T) -> Response {
+    Json(body).into_response()
+}
+
+fn ssz(bytes: Vec<u8>) -> Response {
+    let mut response = bytes.into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(SSZ_CONTENT_TYPE),
+    );
+    response
+}
+
+fn problem(status: StatusCode, reason: &'static str) -> Response {
+    (status, reason).into_response()
+}

--- a/crates/verity-rpc/src/sample.rs
+++ b/crates/verity-rpc/src/sample.rs
@@ -1,0 +1,59 @@
+//! The metrics whose leanMetrics collection event is "on scrape", or that the view already
+//! answers for: refreshed from the current snapshot each time `/metrics` is read.
+//!
+//! Reading the snapshot at scrape time is what keeps the chain task out of the metrics path
+//! entirely — it publishes views; it does not know a scrape happened.
+
+use verity_chain::ChainView;
+use verity_metrics::{Metrics, SyncStatus};
+
+use crate::ApiContext;
+
+/// Refreshes every view-derived gauge from the snapshot current now.
+pub fn on_scrape(context: &ApiContext) {
+    let view = context.view.borrow().clone();
+    let synced = *context.synced.borrow();
+    sample_view(&context.metrics, &view);
+    context.metrics.set_sync_status(if synced {
+        SyncStatus::Synced
+    } else {
+        SyncStatus::Syncing
+    });
+}
+
+fn sample_view(metrics: &Metrics, view: &ChainView) {
+    let justified = view.latest_justified().slot.0;
+    let finalized = view.latest_finalized().slot.0;
+    let safe_target_slot = view
+        .block(view.safe_target())
+        .map_or(0, |block| block.slot.0);
+
+    metrics
+        .head_slot
+        .set(gauge_value(view.head_checkpoint().slot.0));
+    metrics.current_slot.set(gauge_value(view.slot().0));
+    metrics.safe_target_slot.set(gauge_value(safe_target_slot));
+    metrics.latest_justified_slot.set(gauge_value(justified));
+    metrics.justified_slot.set(gauge_value(justified));
+    metrics.latest_finalized_slot.set(gauge_value(finalized));
+    metrics.finalized_slot.set(gauge_value(finalized));
+    metrics
+        .gossip_signatures
+        .set(count_value(view.attestation_signature_count()));
+    metrics
+        .latest_new_aggregated_payloads
+        .set(count_value(view.new_aggregated_payload_count()));
+    metrics
+        .latest_known_aggregated_payloads
+        .set(count_value(view.known_aggregated_payload_count()));
+}
+
+/// A slot as a gauge value. Slots never approach `i64::MAX`; saturating keeps the cast
+/// honest without a panic path.
+fn gauge_value(slot: u64) -> i64 {
+    i64::try_from(slot).unwrap_or(i64::MAX)
+}
+
+fn count_value(count: usize) -> i64 {
+    i64::try_from(count).unwrap_or(i64::MAX)
+}

--- a/crates/verity-types/src/config.rs
+++ b/crates/verity-types/src/config.rs
@@ -47,3 +47,10 @@ pub const JUSTIFICATION_VALIDATORS_LIMIT: usize = HISTORICAL_ROOTS_LIMIT * VALID
 
 /// Maximum length in bytes of a serialized aggregation proof.
 pub const BYTE_LIST_512_KIB_LIMIT: usize = 512 * 1024;
+
+/// The network segment of every gossip topic, `/leanconsensus/<digest>/<name>/ssz_snappy`.
+///
+/// leanSpec names it `GOSSIP_DIGEST` in `spec/forks/lstar/spec.py`, and every lean client on a
+/// devnet spells it the same way. A node with a different value subscribes to topics nobody
+/// publishes on and hears nothing, so this is a constant of the fork, not an operator choice.
+pub const GOSSIP_DIGEST: &str = "12345678";

--- a/crates/verity/src/main.rs
+++ b/crates/verity/src/main.rs
@@ -2,12 +2,19 @@
 //!
 //! # The command line is the cross-client one
 //!
-//! The flags mirror leanSpec's node so that a Verity process can be dropped into a
-//! lean-quickstart devnet in place of any other client: the same `--genesis` file, the same
-//! `--validator-keys` layout, the same `--node-id` lookup. Two flags are Verity's own —
+//! The flags are the set lean-quickstart drives every client with (`docs/adding-a-new-client.md`
+//! there), so that a Verity process can be dropped into a devnet in place of any other client:
+//! the same `config.yaml` behind `--genesis`, the same `nodes.yaml` behind `--bootnodes`, the
+//! same `<node>.key` behind `--node-key`, the same `validators.yaml` and `hash-sig-keys/`
+//! layout behind `--validator-keys`, the same `--node-id` lookup. Two flags are Verity's own:
 //! `--data-dir`, because Verity persists what the reference node keeps in memory, and
-//! `--network-name`, because the topic segment is a caller string with no computation behind
-//! it yet.
+//! `--network-name`, which defaults to the fork's gossip digest and exists only so that a
+//! private network can partition itself off.
+//!
+//! Two flags are accepted for the deployment's sake and then checked rather than used:
+//! `--attestation-committee-count` and `--aggregate-subnet-ids`. leanSpec fixes the committee
+//! count as a constant of the fork, and this build transcribes it; a deployment asking for
+//! another value is refused at startup, with the reason, rather than joined.
 //!
 //! Sync has exactly one flag, `--checkpoint-sync-url`, and that is deliberate: every other
 //! number the sync service uses is a constant in the code, because `docs/design/sync.md` puts
@@ -19,15 +26,16 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use verity_node::{
-    ASSIGNMENT_FILE_NAME, GenesisFile, Multiaddr, Node, NodeConfig, assigned_validators,
-    config::KEY_SUBDIRECTORY, identity::Keypair,
+    ASSIGNMENT_FILE_NAME, ConfigError, GOSSIP_DIGEST, GenesisFile, Multiaddr, Node, NodeConfig,
+    assigned_validators, check_aggregate_subnets, check_committee_count, config::KEY_SUBDIRECTORY,
+    identity::Keypair, parse_bootnode, read_bootnodes, read_node_key,
 };
 
 /// A lean consensus node.
 #[derive(Debug, Parser)]
 #[command(name = "verity", version, about = "The Verity lean consensus client")]
 struct Args {
-    /// Path to the genesis YAML file.
+    /// Path to the genesis file (`config.yaml`).
     #[arg(long, value_name = "PATH")]
     genesis: PathBuf,
 
@@ -39,17 +47,31 @@ struct Args {
     #[arg(
         long,
         value_name = "MULTIADDR",
-        default_value = "/ip4/0.0.0.0/udp/9001/quic-v1"
+        default_value = "/ip4/0.0.0.0/udp/9001/quic-v1",
+        conflicts_with = "listen_port"
     )]
     listen: Multiaddr,
 
-    /// Peer to dial at startup. Repeatable.
-    #[arg(long = "bootnode", value_name = "MULTIADDR")]
-    bootnodes: Vec<Multiaddr>,
+    /// UDP port to listen on for inbound QUIC connections, on every interface.
+    #[arg(long, value_name = "PORT")]
+    listen_port: Option<u16>,
+
+    /// Peer to dial at startup, as a multiaddr or an ENR. Repeatable.
+    #[arg(long = "bootnode", value_name = "MULTIADDR|ENR")]
+    bootnode: Vec<String>,
+
+    /// File listing peers to dial at startup (`nodes.yaml`): a YAML list of ENRs or multiaddrs.
+    #[arg(long, value_name = "PATH")]
+    bootnodes: Option<PathBuf>,
 
     /// The network segment of every gossip topic. Peers that disagree exchange no gossip.
-    #[arg(long, value_name = "NAME", default_value = "00000000")]
+    #[arg(long, value_name = "NAME", default_value = GOSSIP_DIGEST)]
     network_name: String,
+
+    /// File holding this node's secp256k1 secret as hex (`<node>.key`). Omit for a fresh
+    /// identity each run.
+    #[arg(long, value_name = "PATH")]
+    node_key: Option<PathBuf>,
 
     /// Directory holding `validators.yaml` and `hash-sig-keys/`. Omit to follow without signing.
     #[arg(long, value_name = "DIR")]
@@ -62,6 +84,20 @@ struct Args {
     /// Run the interval-2 aggregation round.
     #[arg(long)]
     is_aggregator: bool,
+
+    /// Subnets to aggregate for, comma-separated. Accepted for deployment compatibility and
+    /// checked against the fork's committee count.
+    #[arg(
+        long,
+        value_name = "IDS",
+        value_delimiter = ',',
+        requires = "is_aggregator"
+    )]
+    aggregate_subnet_ids: Vec<u64>,
+
+    /// The deployment's attestation committee count. Checked against the fork's constant.
+    #[arg(long, value_name = "N")]
+    attestation_committee_count: Option<u64>,
 
     /// Base URL of a node to fetch the finalized anchor from, instead of replaying from
     /// genesis. A fetch or verification failure stops the node; there is no fallback.
@@ -91,6 +127,11 @@ async fn main() -> ExitCode {
 async fn run(args: Args) -> Result<(), verity_node::error::NodeError> {
     let genesis = GenesisFile::read(&args.genesis)?;
 
+    if let Some(count) = args.attestation_committee_count {
+        check_committee_count(count)?;
+    }
+    check_aggregate_subnets(&args.aggregate_subnet_ids)?;
+
     // The keys directory decides whether this node signs at all: with no directory there is
     // no assignment to read and no key to load, which is a follower.
     let (validator_indices, key_directory) = match &args.validator_keys {
@@ -101,15 +142,24 @@ async fn run(args: Args) -> Result<(), verity_node::error::NodeError> {
         None => (Vec::new(), None),
     };
 
+    // A configured key is what lets peers dial this node by the identity in `nodes.yaml`.
+    // Without one, a fresh identity per run is fine: nothing upstream depends on this node
+    // keeping the same peer id across restarts when it is only ever the dialler.
+    let keypair = match &args.node_key {
+        Some(path) => read_node_key(path)?,
+        None => Keypair::generate_secp256k1(),
+    };
+
+    let listen = listen_address(&args);
+    let bootnodes = bootnodes(&args)?;
+
     let node = Node::start(NodeConfig {
         genesis,
         data_directory: args.data_dir,
-        listen: args.listen,
-        bootnodes: args.bootnodes,
+        listen,
+        bootnodes,
         network_name: args.network_name,
-        // A fresh identity per run. Peers are reached by dialling configured addresses, so
-        // nothing upstream depends on this node keeping the same peer id across restarts.
-        keypair: Keypair::generate_secp256k1(),
+        keypair,
         validator_indices,
         key_directory,
         is_aggregator: args.is_aggregator,
@@ -124,6 +174,34 @@ async fn run(args: Args) -> Result<(), verity_node::error::NodeError> {
     tracing::info!("interrupted; shutting down");
     node.shutdown().await;
     Ok(())
+}
+
+/// The bind address: the port flag when given, the full multiaddr otherwise.
+fn listen_address(args: &Args) -> Multiaddr {
+    match args.listen_port {
+        Some(port) => format!("/ip4/0.0.0.0/udp/{port}/quic-v1")
+            .parse()
+            .expect("a port number always forms a valid multiaddr"),
+        None => args.listen.clone(),
+    }
+}
+
+/// Every peer to dial at startup: the file's entries first, then the flag's.
+fn bootnodes(args: &Args) -> Result<Vec<Multiaddr>, ConfigError> {
+    let mut addresses = match &args.bootnodes {
+        Some(path) => read_bootnodes(path)?,
+        None => Vec::new(),
+    };
+    for entry in &args.bootnode {
+        addresses.push(
+            parse_bootnode(entry).map_err(|reason| ConfigError::MalformedBootnode {
+                source: "--bootnode".to_string(),
+                entry: entry.clone(),
+                reason,
+            })?,
+        );
+    }
+    Ok(addresses)
 }
 
 /// Installs the subscriber. A library never does this — it takes the choice from whoever

--- a/crates/verity/src/main.rs
+++ b/crates/verity/src/main.rs
@@ -21,6 +21,7 @@
 //! the thresholds outside the design's commitments. An operator can choose where the node
 //! starts; the rate at which it catches up is not a choice the wire format leaves open.
 
+use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -104,6 +105,18 @@ struct Args {
     #[arg(long, value_name = "URL")]
     checkpoint_sync_url: Option<String>,
 
+    /// Address the REST API and the metrics endpoint bind to.
+    #[arg(long, value_name = "IP", default_value = "0.0.0.0")]
+    http_address: IpAddr,
+
+    /// Port of the REST API (`/lean/v0/*`). Omit to serve none.
+    #[arg(long, value_name = "PORT")]
+    api_port: Option<u16>,
+
+    /// Port of the Prometheus scrape endpoint (`/metrics`). Omit to serve none.
+    #[arg(long, value_name = "PORT")]
+    metrics_port: Option<u16>,
+
     /// Log at DEBUG instead of INFO.
     #[arg(short, long)]
     verbose: bool,
@@ -164,6 +177,13 @@ async fn run(args: Args) -> Result<(), verity_node::error::NodeError> {
         key_directory,
         is_aggregator: args.is_aggregator,
         checkpoint_sync_url: args.checkpoint_sync_url,
+        api_address: args
+            .api_port
+            .map(|port| SocketAddr::new(args.http_address, port)),
+        metrics_address: args
+            .metrics_port
+            .map(|port| SocketAddr::new(args.http_address, port)),
+        version: env!("CARGO_PKG_VERSION").to_string(),
     })
     .await?;
 

--- a/crates/verity/src/main.rs
+++ b/crates/verity/src/main.rs
@@ -57,11 +57,13 @@ struct Args {
     #[arg(long, value_name = "PORT")]
     listen_port: Option<u16>,
 
-    /// Peer to dial at startup, as a multiaddr or an ENR. Repeatable.
+    /// Peer to dial at startup, as a multiaddr or an ENR. Repeatable, and may be combined
+    /// with --bootnodes: the file's entries are dialled first, then these.
     #[arg(long = "bootnode", value_name = "MULTIADDR|ENR")]
     bootnode: Vec<String>,
 
-    /// File listing peers to dial at startup (`nodes.yaml`): a YAML list of ENRs or multiaddrs.
+    /// File listing peers to dial at startup: lean-quickstart's `nodes.yaml`, a YAML list of
+    /// ENRs or multiaddrs.
     #[arg(long, value_name = "PATH")]
     bootnodes: Option<PathBuf>,
 
@@ -74,11 +76,14 @@ struct Args {
     #[arg(long, value_name = "PATH")]
     node_key: Option<PathBuf>,
 
-    /// Directory holding `validators.yaml` and `hash-sig-keys/`. Omit to follow without signing.
+    /// The genesis directory lean-quickstart generated, shared by every node: it holds
+    /// `validators.yaml` (node id -> validator indices) and `hash-sig-keys/`. Omit to follow
+    /// without signing.
     #[arg(long, value_name = "DIR")]
     validator_keys: Option<PathBuf>,
 
     /// This node's identifier, looked up in `validators.yaml` to find its validator indices.
+    /// An identifier the file does not name runs no validators and follows the chain.
     #[arg(long, value_name = "ID", default_value = "verity_0")]
     node_id: String,
 
@@ -86,8 +91,8 @@ struct Args {
     #[arg(long)]
     is_aggregator: bool,
 
-    /// Subnets to aggregate for, comma-separated. Accepted for deployment compatibility and
-    /// checked against the fork's committee count.
+    /// Subnets to aggregate for, comma-separated. Accepted for deployment compatibility; a
+    /// subnet the fork's committee count does not define stops the node at startup.
     #[arg(
         long,
         value_name = "IDS",
@@ -96,7 +101,8 @@ struct Args {
     )]
     aggregate_subnet_ids: Vec<u64>,
 
-    /// The deployment's attestation committee count. Checked against the fork's constant.
+    /// The deployment's attestation committee count. A value other than the fork's constant
+    /// stops the node at startup rather than joining a network it disagrees with.
     #[arg(long, value_name = "N")]
     attestation_committee_count: Option<u64>,
 
@@ -109,11 +115,14 @@ struct Args {
     #[arg(long, value_name = "IP", default_value = "0.0.0.0")]
     http_address: IpAddr,
 
-    /// Port of the REST API (`/lean/v0/*`). Omit to serve none.
+    /// Port of the REST API: `/lean/v0/*` (health, finalized state and block, justified
+    /// checkpoint, fork_choice, admin), `/v0/health` for leanpoint, and `/metrics`. Omit to
+    /// serve none.
     #[arg(long, value_name = "PORT")]
     api_port: Option<u16>,
 
-    /// Port of the Prometheus scrape endpoint (`/metrics`). Omit to serve none.
+    /// Port of the Prometheus scrape endpoint (`/metrics`, plus `/lean/v0/health`). Omit to
+    /// serve none.
     #[arg(long, value_name = "PORT")]
     metrics_port: Option<u16>,
 

--- a/docs/src/reference/architecture.md
+++ b/docs/src/reference/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Verity Architecture
-last_updated: 2026-09-07
+last_updated: 2026-09-11
 tags:
   - architecture
   - verification-boundary
@@ -143,7 +143,8 @@ This layout is the **target** shape. The kickoff decision of 2026-07-22 was to s
 single `verity-consensus` crate and split only when a second crate earned its existence; that
 split has since happened, crate by crate, and the workspace now holds `verity-types`,
 `verity-chain`, `verity-crypto`, `verity-db`, `verity-p2p`, `verity-validator`, `verity-node`,
-and the `verity` binary. What is still ahead is named as such below.
+`verity-rpc`, `verity-metrics`, and the `verity` binary. What is still ahead is named as such
+below.
 
 The Rust runtime is a Cargo workspace. Crates map onto the zones, and **calls and dependencies flow
 inward, from higher-effect / lower-assurance toward lower-effect / higher-assurance — Verified Core never calls
@@ -205,8 +206,13 @@ upstream Lean library name per Rust's `-sys` convention.
   into `StorageReader` (point and range reads) and `StorageBackend` (those plus `write`), so a
   reader sharing the writer's open database is a handle with no `write` on it rather than one
   trusted not to call it. See [Storage engine and retention](#storage-engine-and-retention).
-- `verity-rpc` — HTTP API surface.
-- `verity-metrics` — implementation of the leanMetrics contract.
+- `verity-rpc` — the HTTP surface: the cross-client REST API (`/lean/v0/*` — health, the
+  finalized state and block as SSZ for checkpoint-syncing peers, the justified checkpoint and
+  fork-choice tree as JSON, the aggregator admin toggle) and the Prometheus scrape endpoint.
+  Every route answers from the `ChainView` snapshot; nothing here can reach the chain task.
+- `verity-metrics` — the [leanMetrics](https://github.com/leanEthereum/leanMetrics) registry:
+  the metric names, types and labels every lean client exposes identically, so one dashboard
+  serves them all. A leaf crate; the crate that owns each collection event records into it.
 
 Layer mapping: **Verified Core** = Verity Consensus (the compiled export subset of formal-leanSpec, not a Cargo crate); **Runtime Shell** = `verity-consensus-sys`,
 `verity-types`, `verity-chain`, `verity-crypto`, `verity-db`; **I/O Edge** = `verity-p2p`,


### PR DESCRIPTION
## Summary

Makes a Verity process a drop-in node for a [lean-quickstart](https://github.com/blockblaz/lean-quickstart) multi-client devnet, and verifies it against the latest devnet generation: in a local three-node run (`verity_0` + `ethlambda:devnet5` + `ream:latest-devnet5`, lean-quickstart `0c229a6b`) all three nodes agreed on head, justified and finalized checkpoints (finalized 42 → 49 with identical roots) and ream imported 14 blocks Verity proposed.

Four gaps stood between the previous `develop` and that run. None was visible from the code; each came from reading the tooling.

1. **Gossip topic segment.** Verity defaulted `--network-name` to `00000000`; every lean client uses leanSpec's `GOSSIP_DIGEST`, `12345678`. Now a transcribed constant and the default.
2. **Genesis key spelling.** lean-quickstart's generator writes `attestation_pubkey` / `proposal_pubkey`; leanSpec's own reader (and Verity) read `attestation_public_key`. Both are accepted.
3. **Bootnodes and identity.** The devnet hands every client an ENR list (`nodes.yaml`) and a `<node>.key`; Verity took only multiaddrs and minted a fresh identity per run. `verity_node::bootstrap` reads both (transcribed from leanSpec `cli/bootstrap.py` and `networking/enr`), with the `enr` crate on `k256` only.
4. **No HTTP surface.** leanpoint probes health, Prometheus scrapes metrics, and peers checkpoint-sync from `/lean/v0/states/finalized`; Verity served none of it. Two new I/O Edge crates: `verity-rpc` (axum; routes transcribed from leanSpec `node/api` at `0b7d33ec`, plus the `/v0/health` path leanpoint actually probes) and `verity-metrics` (the leanMetrics `69f97227` registry, gauges and counters, names/types/labels exact; histograms wait for probes at the point of work).

Also: `--listen-port`, `--attestation-committee-count` and `--aggregate-subnet-ids` (checked against the fork's constant, refused otherwise), `--http-address` / `--api-port` / `--metrics-port`, a runtime aggregator toggle through the admin route, `lean_connected_peers` from the network bridge, a `Dockerfile` (`--locked`), and the devnet facts recorded in `CLAUDE.md` and `docs/src/reference/architecture.md`.

## A finding worth knowing before the next run

lean-quickstart's `client-cmds/*.sh` still pin **devnet4** images. Their `SignedBlock` carries per-attestation proofs and an XMSS proposer signature; leanSpec `main` (#717, devnet5) — which Verity transcribes — carries one `MultiMessageAggregate`. Against devnet4 images Verity discards every block as `undecodable` and is discarded in turn. `ethlambda:devnet5` and `ream:latest-devnet5` are published and are what the run above used.

## Follow-ups observed in the run (not addressed here)

- `duty not performed … SOURCE_AFTER_TARGET` at slots 16 and 64, right after justification jumped: the attestation data derivation picks a source ahead of the target for one interval.
- `block proof could not be built slot=39 … aggregated public keys is empty`: one proposal with six attestations produced nothing to fold.
- The validator duty gate closed often (`head_lag ≥ 5`) because block imports arrive in bursts behind proof verification; Verity missed several of its proposal slots between 9 and 42.

## Validation

- `cargo fmt --all --check`, `cargo clippy --locked --workspace --all-targets -- -D warnings`, `cargo test --locked --workspace`, `cargo deny --locked check` — all green.
- New tests: `verity_node::bootstrap` (ENR / node key, including the README's real ENR sample), the generator's genesis spelling, `verity-node/tests/http_api.rs` (every route over a real socket, both listeners, the admin toggle), `verity-metrics` registry.
- `docker build .` produces a runnable image.
- Three-node devnet run as described above; the lean-quickstart integration (six touch points from `docs/adding-a-new-client.md`) is prepared on a local branch for an upstream PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
